### PR TITLE
fixup(Client): oops :( make _processAttachments return the expected structure

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3136,7 +3136,7 @@ class Client extends EventEmitter {
 
     _processAttachments(attachments) {
         if(!attachments) {
-            return [];
+            return {};
         }
         const files = [];
         const resultAttachments = [];
@@ -3158,7 +3158,10 @@ class Client extends EventEmitter {
             }
         });
 
-        return {files, resultAttachments};
+        return {
+            files: files.length ? files : undefined,
+            attachments: resultAttachments
+        };
     }
 
     toString() {


### PR DESCRIPTION
Also do not pass empty file arrays (triggers data being sent over as multipart data)