### PR TITLE
feat(Guild): automatically populate events on GUILD_CREATE

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -207,6 +207,12 @@ class Guild extends Base {
                 }
             }
         }
+
+        if(data.guild_scheduled_events) {
+            for(const event of data.guild_scheduled_events) {
+                this.events.add(event, client);
+            }
+        }
         this.update(data);
     }
 


### PR DESCRIPTION
This PR changes the Guild class to take incoming scheduled events from the GUILD_CREATE event and populate the cache with them.