### PR TITLE
fix(Client): do not send the file buffer twice

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3238,6 +3238,7 @@ class Client extends EventEmitter {
 
                 resultAttachments.push({
                     ...attachment,
+                    file: undefined,
                     id: idx
                 });
             }


### PR DESCRIPTION
Changes the internal attachment processing logic to not send the appropriate file buffer twice, resulting in large file uploads failing.