### PR TITLE
feat: add new message types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2166,6 +2166,8 @@ declare namespace Dysnomia {
       CONTEXT_MENU_COMMAND:                         23;
       AUTO_MODERATION_ACTION:                       24;
       ROLE_SUBSCRIPTION_PURCHASE:                   25;
+      INTERACTION_PREMIUM_UPSELL:                   26;
+      GUILD_APPLICATION_PREMIUM_SUBSCRIPTION:       32;
     };
     MembershipState: {
       INVITED: 1;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -443,7 +443,9 @@ module.exports.MessageTypes = {
     GUILD_INVITE_REMINDER:                        22,
     CONTEXT_MENU_COMMAND:                         23,
     AUTO_MODERATION_ACTION:                       24,
-    ROLE_SUBSCRIPTION_PURCHASE:                   25
+    ROLE_SUBSCRIPTION_PURCHASE:                   25,
+    INTERACTION_PREMIUM_UPSELL:                   26,
+    GUILD_APPLICATION_PREMIUM_SUBSCRIPTION:       32
 };
 
 module.exports.MembershipState = {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -226,6 +226,15 @@ class Message extends Base {
             case MessageTypes.AUTO_MODERATION_ACTION: {
                 break;
             }
+            case MessageTypes.ROLE_SUBSCRIPTION_PURCHASE: {
+                break;
+            }
+            case MessageTypes.INTERACTION_PREMIUM_UPSELL: {
+                break;
+            }
+            case MessageTypes.GUILD_APPLICATION_PREMIUM_SUBSCRIPTION: {
+                break;
+            }
             default: {
                 this._client.emit("warn", `Unhandled MESSAGE_CREATE type: ${JSON.stringify(data, null, 2)}`);
                 break;


### PR DESCRIPTION
currently won't apply any transformations to message content, as I don't know how the messages look like.

ref: https://github.com/discord/discord-api-docs/commit/e9711be4a294ca0d39c7e769d9c19c8883b8286b
ref: https://github.com/discord/discord-api-docs/commit/83f6c85d808c0ba37f5268d7b5ea79fbc0859d58