### PR TITLE
fix(ForumChannel): check against null values

### DIFF
--- a/lib/structures/ForumChannel.js
+++ b/lib/structures/ForumChannel.js
@@ -50,19 +50,19 @@ class ForumChannel extends GuildChannel {
         if(data.default_forum_layout !== undefined) {
             this.defaultForumLayout = data.default_forum_layout;
         }
-        if(data.default_reaction_emoji !== undefined) {
+        if(data.default_reaction_emoji !== undefined && data.default_reaction_emoji !== null) {
             this.defaultReactionEmoji = {
                 emojiID: data.default_reaction_emoji.emoji_id,
                 emojiName: data.default_reaction_emoji.emoji_name
             };
         }
-        if(data.default_sort_order !== undefined) {
+        if(data.default_sort_order !== undefined && data.default_sort_order !== null) {
             this.defaultSortOrder = data.default_sort_order;
         }
         if(data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
-        if(data.topic !== undefined) {
+        if(data.topic !== undefined && data.topic !== null) {
             this.topic = data.topic;
         }
         if(data.permission_overwrites) {


### PR DESCRIPTION
Newly-created forum channels without a `default_reaction_emoji` would error with a `TypeError: Cannot read properties of null (reading 'emoji_id')`. This makes sure other properties are null-checked before assigning.