### PR TITLE
fix(ShardManager): add requestTimeout default

### DIFF
--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -32,6 +32,7 @@ class ShardManager extends Collection {
             maxConcurrency:       1,
             maxShards:            1,
             seedVoiceConnections: false,
+            requestTimeout:       15000,
             reconnectDelay:       ((lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000)
         }, options);
 


### PR DESCRIPTION
This prevented things like `requestGuildMembers` from working by default.