### PR TITLE
chore: normalize `embeds`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1372,8 +1372,6 @@ declare namespace Dysnomia {
     attachments?: AdvancedMessageContentAttachment[];
     components?: ActionRow[];
     content?: string;
-    /** @deprecated */
-    embed?: EmbedOptions;
     embeds?: EmbedOptions[];
     /** @deprecated */
     files?: T extends "isMessageEdit" ? (FileContent | FileContent[]) : never;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -707,7 +707,6 @@ class Client extends EventEmitter {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] Message flags. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
@@ -1914,7 +1913,6 @@ class Client extends EventEmitter {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [options.content] A content string
-    * @arg {Object} [options.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [options.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} options.file[].file A buffer containing file data
@@ -1929,12 +1927,6 @@ class Client extends EventEmitter {
         }
         if(options.allowedMentions) {
             options.allowed_mentions = this._formatAllowedMentions(options.allowedMentions);
-        }
-        if(options.embed) {
-            if(!options.embeds) {
-                options.embeds = [];
-            }
-            options.embeds.push(options.embed);
         }
         if(options.file) {
             emitDeprecation("EDIT_WEBHOOK_MESSAGE_FILE");
@@ -2010,7 +2002,6 @@ class Client extends EventEmitter {
     * @arg {String} [options.avatarURL] A URL for a custom avatar, defaults to webhook default avatar if not specified
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [options.content] A content string
-    * @arg {Object} [options.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [options.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data
@@ -2030,12 +2021,6 @@ class Client extends EventEmitter {
         }
         if(options.threadID) {
             qs += "&thread_id=" + options.threadID;
-        }
-        if(options.embed) {
-            if(!options.embeds) {
-                options.embeds = [];
-            }
-            options.embeds.push(options.embed);
         }
 
         if(options.file) {

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -149,7 +149,6 @@ class CommandInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -190,7 +189,6 @@ class CommandInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -319,7 +317,6 @@ class CommandInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -360,7 +357,6 @@ class CommandInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -131,7 +131,6 @@ class ComponentInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -172,7 +171,6 @@ class ComponentInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -316,7 +314,6 @@ class ComponentInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -357,7 +354,6 @@ class ComponentInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -400,7 +396,6 @@ class ComponentInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Boolean} [content.tts] Set the message TTS flag

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -496,7 +496,6 @@ class Message extends Base {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [content.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} content.file[].file A buffer containing file data
@@ -527,7 +526,6 @@ class Message extends Base {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [options.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [options.content] A content string
-    * @arg {Object} [options.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [options.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -67,7 +67,6 @@ class ModalSubmitInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [options.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] 64 for Ephemeral
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -108,7 +107,6 @@ class ModalSubmitInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Boolean} [content.flags] 64 for Ephemeral
     * @arg {Boolean} [content.tts] Set the message TTS flag
@@ -238,7 +236,6 @@ class ModalSubmitInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -279,7 +276,6 @@ class ModalSubmitInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -321,7 +317,6 @@ class ModalSubmitInteraction extends Interaction {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Boolean} [content.flags] 64 for Ephemeral
     * @arg {Boolean} [content.tts] Set the message TTS flag

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -90,7 +90,6 @@ class PrivateChannel extends Channel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [content.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} content.file[].file A buffer containing file data

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -195,7 +195,6 @@ class TextChannel extends GuildChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [content.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} content.file[].file A buffer containing file data

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -89,7 +89,6 @@ class ThreadChannel extends GuildChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -142,7 +141,6 @@ class ThreadChannel extends GuildChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object | Array<Object>} [content.file] [DEPRECATED] A file object (or an Array of them)
     * @arg {Buffer} content.file[].file A buffer containing file data


### PR DESCRIPTION
Settled down on using the `embeds` array instead of `embed` – `embed` will no longer be accepted.