### PR TITLE
fix(VoiceConnection): Use 74 bytes for UDP discovery

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -262,7 +262,7 @@ class VoiceConnection extends EventEmitter {
                             this.disconnect(err);
                         }
                     });
-                    const udpMessage = Buffer.allocUnsafe(70);
+                    const udpMessage = Buffer.allocUnsafe(74);
                     udpMessage.writeUInt16BE(0x1, 0);
                     udpMessage.writeUInt16BE(70, 2);
                     udpMessage.writeUInt32BE(this.ssrc, 4);


### PR DESCRIPTION
Discord now requires 74 bytes for UDP discovery. Note that not receiving a UDP message causes the connection promise to hang.

Related: https://github.com/DV8FromTheWorld/JDA/pull/2413