### PR TITLE
fix(Interaction): return default Interaction class on unknown interaction types (v0.1.x)

### DIFF
--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -96,6 +96,7 @@ class Interaction extends Base {
         }
 
         client.emit("warn", new Error(`Unknown interaction type: ${data.type}\n${JSON.stringify(data, null, 2)}`));
+        return new Interaction(data, client);
     }
 
     toJSON(props = []) {


### PR DESCRIPTION
Backports #42 to v0.1.x