### PR TITLE
refactor(DiscordRESTError): readability and performance enhancements

### DIFF
--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -50,24 +50,24 @@ class DiscordRESTError extends Error {
         return `${this.constructor.name} [${this.code}]`;
     }
 
-    flattenErrors(errors, keyPrefix = '') {
+    flattenErrors(errors, keyPrefix = "") {
         return Object.entries(errors).reduce((messages, [fieldName, value]) => {
-          if (fieldName === 'message' || fieldName === 'code') {
-            return messages;
-          }
+            if (fieldName === "message" || fieldName === "code") {
+                return messages;
+            }
 
-          const prefix = keyPrefix + fieldName + ': ';
-          if (Array.isArray(value)) {
-            return messages.concat(value.map(str => prefix + str));
-          }
+            const prefix = keyPrefix + fieldName + ": ";
+            if(Array.isArray(value)) {
+                return messages.concat(value.map((str) => prefix + str));
+            }
 
-          if (value._errors) {
-            return messages.concat(value._errors.map(obj => prefix + obj.message));
-          }
+            if(value._errors) {
+                return messages.concat(value._errors.map((obj) => prefix + obj.message));
+            }
 
-          return messages.concat(this.flattenErrors(value, prefix));
+            return messages.concat(this.flattenErrors(value, prefix));
         }, []);
-      }
+    }
 }
 
 module.exports = DiscordRESTError;

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -52,7 +52,7 @@ class DiscordRESTError extends Error {
 
     flattenErrors(errors, keyPrefix = "") {
         return Object.entries(errors).reduce((messages, [fieldName, value]) => {
-            if (fieldName === "message" || fieldName === "code") {
+            if(fieldName === "message" || fieldName === "code") {
                 return messages;
             }
 

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -50,22 +50,24 @@ class DiscordRESTError extends Error {
         return `${this.constructor.name} [${this.code}]`;
     }
 
-    flattenErrors(errors, keyPrefix = "") {
-        let messages = [];
-        for(const fieldName in errors) {
-            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
-                continue;
-            }
-            if(errors[fieldName]._errors) {
-                messages = messages.concat(errors[fieldName]._errors.map((obj) => `${keyPrefix + fieldName}: ${obj.message}`));
-            } else if(Array.isArray(errors[fieldName])) {
-                messages = messages.concat(errors[fieldName].map((str) => `${keyPrefix + fieldName}: ${str}`));
-            } else if(typeof errors[fieldName] === "object") {
-                messages = messages.concat(this.flattenErrors(errors[fieldName], keyPrefix + fieldName + "."));
-            }
-        }
-        return messages;
-    }
+    flattenErrors(errors, keyPrefix = '') {
+        return Object.entries(errors).reduce((messages, [fieldName, value]) => {
+          if (fieldName === 'message' || fieldName === 'code') {
+            return messages;
+          }
+
+          const prefix = keyPrefix + fieldName + ': ';
+          if (Array.isArray(value)) {
+            return messages.concat(value.map(str => prefix + str));
+          }
+
+          if (value._errors) {
+            return messages.concat(value._errors.map(obj => prefix + obj.message));
+          }
+
+          return messages.concat(this.flattenErrors(value, prefix));
+        }, []);
+      }
 }
 
 module.exports = DiscordRESTError;


### PR DESCRIPTION
Basically, I used `Object.entries` to iterate over the object's properties `errors` and transform them into an array of `[key, value]`. Then I used reduce to accumulate the error messages into an array, checking whether the current property is a nested object, an array, or an error directly. The `return` in each case returns the existing messages plus the new messages, always prefixing the name of the field in question.