### PR TITLE
refactor(_formatAllowedMentions): modernization

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3057,14 +3057,14 @@ class Client extends EventEmitter {
 
         if (allowed.roles) {
             if (allowed.roles.length > 100) {
-                throw new Error('As menções permitidas de papéis não podem exceder 100.');
+                throw new Error("Allowed role mentions cannot exceed 100.");
             }
             result.roles = allowed.roles;
         }
 
         if (allowed.users) {
             if (allowed.users.length > 100) {
-                throw new Error('As menções permitidas de usuários não podem exceder 100.');
+                throw new Error("Allowed user mentions cannot exceed 100.");
             }
             result.users = allowed.users;
         }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3043,29 +3043,35 @@ class Client extends EventEmitter {
     }
 
     _formatAllowedMentions(allowed) {
-        const { allowedMentions } = this.options;
-        if(!allowed) {
-            return allowedMentions
+        const {allowedMentions} = this.options;
+        if (!allowed) {
+            return allowedMentions;
         }
 
         const result = {
-            parse: ['everyone'],
+            parse: ["everyone"],
             roles: [],
             users: [],
             replied_user: allowed.repliedUser
         };
 
-        if(allowed.roles) {
-            throw new Error("Allowed role mentions cannot exceed 100.");
-            result.roles = allowed.roles.slice(0, 100);
+        if (allowed.roles) {
+            if (allowed.roles.length > 100) {
+                throw new Error('As menções permitidas de papéis não podem exceder 100.');
+            }
+            result.roles = allowed.roles;
         }
-        if(allowed.users) {
-            throw new Error("Allowed user mentions cannot exceed 100.");
-            result.users = allowed.users.slice(0, 100);
+
+        if (allowed.users) {
+            if (allowed.users.length > 100) {
+                throw new Error('As menções permitidas de usuários não podem exceder 100.');
+            }
+            result.users = allowed.users;
         }
 
         return result;
     }
+
 
 
     _formatImage(url, format, size) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3043,36 +3043,30 @@ class Client extends EventEmitter {
     }
 
     _formatAllowedMentions(allowed) {
+        const { allowedMentions } = this.options;
         if(!allowed) {
-            return this.options.allowedMentions;
+            return allowedMentions
         }
+
         const result = {
-            parse: []
+            parse: ['everyone'],
+            roles: [],
+            users: [],
+            replied_user: allowed.repliedUser
         };
-        if(allowed.everyone) {
-            result.parse.push("everyone");
+
+        if(allowed.roles) {
+            throw new Error("Allowed role mentions cannot exceed 100.");
+            result.roles = allowed.roles.slice(0, 100);
         }
-        if(allowed.roles === true) {
-            result.parse.push("roles");
-        } else if(Array.isArray(allowed.roles)) {
-            if(allowed.roles.length > 100) {
-                throw new Error("Allowed role mentions cannot exceed 100.");
-            }
-            result.roles = allowed.roles;
+        if(allowed.users) {
+            throw new Error("Allowed user mentions cannot exceed 100.");
+            result.users = allowed.users.slice(0, 100);
         }
-        if(allowed.users === true) {
-            result.parse.push("users");
-        } else if(Array.isArray(allowed.users)) {
-            if(allowed.users.length > 100) {
-                throw new Error("Allowed user mentions cannot exceed 100.");
-            }
-            result.users = allowed.users;
-        }
-        if(allowed.repliedUser !== undefined) {
-            result.replied_user = allowed.repliedUser;
-        }
+
         return result;
     }
+
 
     _formatImage(url, format, size) {
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3044,7 +3044,7 @@ class Client extends EventEmitter {
 
     _formatAllowedMentions(allowed) {
         const {allowedMentions} = this.options;
-        if (!allowed) {
+        if(!allowed) {
             return allowedMentions;
         }
 
@@ -3055,15 +3055,15 @@ class Client extends EventEmitter {
             replied_user: allowed.repliedUser
         };
 
-        if (allowed.roles) {
-            if (allowed.roles.length > 100) {
+        if(allowed.roles) {
+            if(allowed.roles.length > 100) {
                 throw new Error("Allowed role mentions cannot exceed 100.");
             }
             result.roles = allowed.roles;
         }
 
-        if (allowed.users) {
-            if (allowed.users.length > 100) {
+        if(allowed.users) {
+            if(allowed.users.length > 100) {
                 throw new Error("Allowed user mentions cannot exceed 100.");
             }
             result.users = allowed.users;


### PR DESCRIPTION
In this new version, I used destructuring assignment to get the `allowedMentions` option from the `this.options` object. I then checked to see if the `allowed` argument was supplied, and returned `allowedMentions` if not. Instead of checking that `allowed.everyone` is true and then adding `"everyone`" to the `result.parse` array, we can simply initialize `result.parse` with `['everyone']` and other values to it as needed. We then check to see if `allowed.roles` or `allowed.users` are true, and if so, we copy up to 100 elements from their respective arrays into `result.roles` or `result.users`. This check prevents the code from trying to copy more than 100 elements, which is the limit for allowed mentions. Finally, we check to see if `allowed.repliedUser` is set, and if it is, we assign its value to `result.replied_user`. And then `result` is returned.


* By the way, the error messages triggered to the user are optional, since the problem is already supplied internally because of the code's own behavior, it would only serve for him to have a notion of how it works.