### PR TITLE
fix(PrivateThreadChannel): properly propagate updates

### DIFF
--- a/lib/structures/PrivateThreadChannel.js
+++ b/lib/structures/PrivateThreadChannel.js
@@ -19,6 +19,7 @@ class PrivateThreadChannel extends ThreadChannel {
     }
 
     update(data) {
+        super.update(data);
         if(data.thread_metadata !== undefined) {
             this.threadMetadata = {
                 archiveTimestamp: Date.parse(data.thread_metadata.archive_timestamp),


### PR DESCRIPTION
Corrects private thread updates not being correctly propagated down the prototype chain.