### PR TITLE
refactor(interactions): clean up properties

### DIFF
--- a/lib/structures/AutocompleteInteraction.js
+++ b/lib/structures/AutocompleteInteraction.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const Interaction = require("./Interaction");
-const Permission = require("./Permission");
 const {InteractionResponseTypes} = require("../Constants");
 
 /**

--- a/lib/structures/AutocompleteInteraction.js
+++ b/lib/structures/AutocompleteInteraction.js
@@ -26,34 +26,6 @@ class AutocompleteInteraction extends Interaction {
     constructor(data, client) {
         super(data, client);
         this.#client = client;
-
-        this.channel = this.#client.getChannel(data.channel_id) || {
-            id: data.channel_id
-        };
-
-        this.data = data.data;
-
-        if(data.guild_id !== undefined) {
-            this.guildID = data.guild_id;
-        }
-
-        if(data.member !== undefined) {
-            if(this.channel.guild) {
-                data.member.id = data.member.user.id;
-                this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else {
-                const guild = this.#client.guilds.get(data.guild_id);
-                this.member = guild.members.update(data.member, guild);
-            }
-        }
-
-        if(data.user !== undefined) {
-            this.user = this.#client.users.update(data.user, client);
-        }
-
-        if(data.app_permissions !== undefined) {
-            this.appPermissions = new Permission(data.app_permissions);
-        }
     }
 
     /**

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -8,7 +8,6 @@ const Channel = require("./Channel");
 const Message = require("./Message");
 const Attachment = require("./Attachment");
 const Collection = require("../util/Collection");
-const Permission = require("./Permission");
 
 const {InteractionResponseTypes} = require("../Constants");
 

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -40,12 +40,6 @@ class CommandInteraction extends Interaction {
         super(data, client);
         this.#client = client;
 
-        this.channel = this.#client.getChannel(data.channel_id) || {
-            id: data.channel_id
-        };
-
-        this.data = JSON.parse(JSON.stringify(data.data));
-
         if(data.data.resolved !== undefined) {
             //Users
             if(data.data.resolved.users !== undefined) {
@@ -102,28 +96,6 @@ class CommandInteraction extends Interaction {
                 });
                 this.data.resolved.attachments = attachmentsmap;
             }
-        }
-
-        if(data.guild_id !== undefined) {
-            this.guildID = data.guild_id;
-        }
-
-        if(data.member !== undefined) {
-            if(this.channel.guild) {
-                data.member.id = data.member.user.id;
-                this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else {
-                const guild = this.#client.guilds.get(data.guild_id);
-                this.member = guild.members.update(data.member, guild);
-            }
-        }
-
-        if(data.user !== undefined) {
-            this.user = this.#client.users.update(data.user, client);
-        }
-
-        if(data.app_permissions !== undefined) {
-            this.appPermissions = new Permission(data.app_permissions);
         }
     }
 

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -36,12 +36,6 @@ class ComponentInteraction extends Interaction {
         super(data, client);
         this.#client = client;
 
-        this.channel = this.#client.getChannel(data.channel_id) || {
-            id: data.channel_id
-        };
-
-        this.data = JSON.parse(JSON.stringify(data.data));
-
         if(data.data.resolved !== undefined) {
             //Users
             if(data.data.resolved.users !== undefined) {
@@ -84,30 +78,8 @@ class ComponentInteraction extends Interaction {
             }
         }
 
-        if(data.guild_id !== undefined) {
-            this.guildID = data.guild_id;
-        }
-
-        if(data.member !== undefined) {
-            if(this.channel.guild) {
-                data.member.id = data.member.user.id;
-                this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else {
-                const guild = this.#client.guilds.get(data.guild_id);
-                this.member = guild.members.update(data.member, guild);
-            }
-        }
-
         if(data.message !== undefined) {
             this.message = new Message(data.message, this.#client);
-        }
-
-        if(data.user !== undefined) {
-            this.user = this.#client.users.update(data.user, client);
-        }
-
-        if(data.app_permissions !== undefined) {
-            this.appPermissions = new Permission(data.app_permissions);
         }
     }
 

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -7,7 +7,6 @@ const Role = require("./Role");
 const Channel = require("./Channel");
 const Message = require("./Message");
 const Collection = require("../util/Collection");
-const Permission = require("./Permission");
 
 const {InteractionResponseTypes} = require("../Constants");
 

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -20,31 +20,6 @@ class ModalSubmitInteraction extends Interaction {
     constructor(data, client) {
         super(data, client);
         this.#client = client;
-
-        this.channel = this.#client.getChannel(data.channel_id) || {
-            id: data.channel_id
-        };
-
-        this.data = data.data;
-
-        if(data.guild_id !== undefined) {
-            this.guildID = data.guild_id;
-        }
-
-        if(data.member !== undefined) {
-            if(this.channel.guild) {
-                data.member.id = data.member.user.id;
-                this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else {
-                const guild = this.#client.guilds.get(data.guild_id);
-                this.member = guild.members.update(data.member, guild);
-            }
-        }
-
-        if(data.user !== undefined) {
-            this.user = this.#client.users.update(data.user, client);
-        }
-
     }
 
     /**


### PR DESCRIPTION
Removes segments of code from derived interaction classes that execute the same code as the base Interaction class, effectively making the fields being set twice (once in the Interaction class and then in the derived class