### PR TITLE
feat: support onboarding updates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2160,7 +2160,7 @@ declare namespace Dysnomia {
     OnboardingModes: {
       ONBOARDING_DEFAULT:  0;
       ONBOARDING_ADVANCED: 1;
-    }
+    };
     OnboardingPromptTypes: {
       MULTIPLE_CHOICE: 0;
       DROPDOWN:        1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,6 +105,7 @@ declare namespace Dysnomia {
   type GuildScheduledEventPrivacyLevel = Constants["GuildScheduledEventPrivacyLevel"][keyof Constants["GuildScheduledEventPrivacyLevel"]];
   type GuildScheduledEventStatus = Constants["GuildScheduledEventStatus"][keyof Constants["GuildScheduledEventStatus"]];
   type NSFWLevel = Constants["GuildNSFWLevels"][keyof Constants["GuildNSFWLevels"]];
+  type OnboardingModes = Constants["OnboardingModes"][keyof Constants["OnboardingModes"]];
   type OnboardingPromptTypes = Constants["OnboardingPromptTypes"][keyof Constants["OnboardingPromptTypes"]];
   type PossiblyUncachedGuild = Guild | Uncached;
   type PossiblyUncachedGuildScheduledEvent = GuildScheduledEvent | Uncached;
@@ -929,6 +930,9 @@ declare namespace Dysnomia {
     level: MFALevel;
     reason?: string;
   }
+  interface EditGuildOnboardingOptions extends Partial<Omit<GuildOnboarding, "guild_id">> {
+    reason?: string;
+  }
   interface GetGuildAuditLogOptions {
     actionType?: number;
     after?: string;
@@ -982,6 +986,7 @@ declare namespace Dysnomia {
     enabled: boolean;
     default_channel_ids: string[];
     guild_id: string;
+    mode: OnboardingModes;
     prompts: GuildOnboardingPrompt[];
   }
   interface GuildOnboardingPrompt {
@@ -2152,6 +2157,10 @@ declare namespace Dysnomia {
       INVITED: 1;
       ACCEPTED: 2;
     };
+    OnboardingModes: {
+      ONBOARDING_DEFAULT:  0;
+      ONBOARDING_ADVANCED: 1;
+    }
     OnboardingPromptTypes: {
       MULTIPLE_CHOICE: 0;
       DROPDOWN:        1;
@@ -2609,6 +2618,7 @@ declare namespace Dysnomia {
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
     editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
     editGuildMFALevel(guildID: string, options: EditGuildMFALevelOptions): Promise<MFALevel>;
+    editGuildOnboarding(guildID: string, options: EditGuildOnboardingOptions): Promise<GuildOnboarding>;
     editGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, eventID: string, event: GuildScheduledEventEditOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     editGuildSticker(guildID: string, stickerID: string, options?: EditStickerOptions, reason?: string): Promise<Sticker>;
     editGuildTemplate(guildID: string, code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;
@@ -2940,6 +2950,7 @@ declare namespace Dysnomia {
     editIntegration(integrationID: string, options: IntegrationOptions): Promise<void>;
     editMember(memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
     editMFALevel(options: EditGuildMFALevelOptions): Promise<MFALevel>;
+    editOnboarding(options: EditGuildOnboardingOptions): Promise<GuildOnboarding>;
     editRole(roleID: string, options: RoleOptions): Promise<Role>;
     editScheduledEvent<T extends GuildScheduledEventEntityTypes>(eventID: string, event: GuildScheduledEventEditOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     editSticker(stickerID: string, options?: EditStickerOptions, reason?: string): Promise<Sticker>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1505,6 +1505,17 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Edits the onboarding flow of a guild, shown to new members
+     * @param {String} guildID The ID of the guild
+     * @param {Object} options The [guild onboarding](https://discord.com/developers/docs/resources/guild#guild-onboarding-object) object
+     * @param {String} [options.reason] The reason to be displayed in audit logs
+     * @returns {Promise<Object>} Resolves with the [guild onboarding object](https://discord.com/developers/docs/resources/guild#guild-onboarding-object)
+     */
+    editGuildOnboarding(guildID, options) {
+        return this.requestHandler.request("PUT", Endpoints.GUILD_ONBOARDING(guildID), true, options);
+    }
+
+    /**
     * Edit a guild scheduled event
     * @arg {String} guildID The guild ID where the event will be edited
     * @arg {String} eventID The guild scheduled event ID to be edited

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -444,6 +444,11 @@ module.exports.MembershipState = {
     ACCEPTED: 2
 };
 
+module.exports.OnboardingModes = {
+    ONBOARDING_DEFAULT:  0,
+    ONBOARDING_ADVANCED: 1
+};
+
 module.exports.OnboardingPromptTypes = {
     MULTIPLE_CHOICE: 0,
     DROPDOWN:        1

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -762,6 +762,16 @@ class Guild extends Base {
     }
 
     /**
+     * Edits the onboarding flow of this guild, shown to new members
+     * @param {Object} options The [guild onboarding](https://discord.com/developers/docs/resources/guild#guild-onboarding-object) object
+     * @param {String} [options.reason] The reason to be displayed in audit logs
+     * @returns {Promise<Object>} Resolves with the [guild onboarding object](https://discord.com/developers/docs/resources/guild#guild-onboarding-object)
+     */
+    editOnboarding(options) {
+        return this.#client.editGuildOnboarding.call(this.#client, this.id, options);
+    }
+
+    /**
     * Edit the guild role
     * @arg {String} roleID The ID of the role
     * @arg {Object} options The properties to edit


### PR DESCRIPTION
Adds onboarding `mode` field into the TS definitions along with appropriate constants and adds an `editGuildOnboarding(guildID, options)` method for updating the onboarding object

Ref: https://github.com/discord/discord-api-docs/pull/6101