### PR TITLE
fixup(Guild): add safetyAlertsChannelID into toJSON() list

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1316,6 +1316,7 @@ class Guild extends Base {
             "publicUpdatesChannelID",
             "roles",
             "rulesChannelID",
+            "safetyAlertsChannelID",
             "splash",
             "stickers",
             "systemChannelFlags",


### PR DESCRIPTION
I always seem to forget to add it there.