### PR TITLE
fixup(Guild): add safetyAlertsChannelID into toJSON() list (v0.1.x)

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1374,6 +1374,7 @@ class Guild extends Base {
             "publicUpdatesChannelID",
             "roles",
             "rulesChannelID",
+            "safetyAlertsChannelID",
             "splash",
             "stickers",
             "systemChannelFlags",


### PR DESCRIPTION
Same as #73, except for v0.1.x