### PR TITLE
(RFC) refactor: new linting rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,7 +18,7 @@ rules:
     - allowSingleLine: false
   comma-dangle:
     - 2
-    - never
+    - always-multiline
   comma-style:
     - 2
     - last

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -19,6 +19,9 @@ rules:
   comma-dangle:
     - 2
     - never
+  comma-style:
+    - 2
+    - last
   curly: 2
   eol-last:
     - 2

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,31 +23,25 @@ rules:
   eol-last:
     - 2
     - always
+  eqeqeq:
+    - 2
+    - always
+    - "null": ignore
   indent:
     - 2
     - 4
     - SwitchCase: 1
       ignoreComments: false
+  key-spacing:
+    - 2
   keyword-spacing:
     - 2
-    - after: true
-      overrides:
-        catch:
-          after: false
-        for:
-          after: false
-        if:
-          after: false
-        switch:
-          after: false
-        while:
-          after: false
   no-prototype-builtins: 0
   no-trailing-spaces: 2
   no-var: 2
   object-curly-spacing:
     - 2
-    - never
+    - always
   object-shorthand:
     - 2
     - consistent-as-needed
@@ -93,3 +87,5 @@ rules:
         custom-inspect-method:
         - name: "[util.inspect.custom]"
           type: method
+  strict:
+    - 2

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -84,6 +84,7 @@ rules:
         alphabetical-private-methods:
         - type: method
           sort: alphabetical
+          private: true
         custom-inspect-method:
         - name: "[util.inspect.custom]"
           type: method

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -57,6 +57,7 @@ rules:
     - 2
     - order:
       - "[alphabetical-properties]"
+      - "[alphabetical-private-properties]"
       - constructor
       - update
       - "[alphabetical-getters]"
@@ -84,6 +85,9 @@ rules:
         alphabetical-private-methods:
         - type: method
           sort: alphabetical
+          private: true
+        alphabetical-private-properties:
+        - type: property
           private: true
         custom-inspect-method:
         - name: "[util.inspect.custom]"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,7 +39,6 @@ rules:
     - 2
   keyword-spacing:
     - 2
-  no-prototype-builtins: 0
   no-trailing-spaces: 2
   no-var: 2
   object-curly-spacing:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -96,3 +96,9 @@ rules:
           type: method
   strict:
     - 2
+overrides:
+  - files: [ ./lib/Constants.js ]
+    rules:
+      key-spacing:
+        - 2
+        - align: value

--- a/examples/applicationCommands.js
+++ b/examples/applicationCommands.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 const Constants = Dysnomia.Constants;
@@ -5,8 +7,8 @@ const Constants = Dysnomia.Constants;
 // Replace TOKEN with your bot account's token
 const bot = new Dysnomia.Client("BOT TOKEN", {
     gateway: {
-        intents: [] //No intents are needed for interactions, but you still need to specify either an empty array or 0
-    }
+        intents: [], //No intents are needed for interactions, but you still need to specify either an empty array or 0
+    },
 });
 
 bot.on("ready", async () => { // When the bot is ready
@@ -14,7 +16,7 @@ bot.on("ready", async () => { // When the bot is ready
 
     const commands = await bot.getCommands();
 
-    if(!commands.length) {
+    if (!commands.length) {
         bot.createCommand({
             name: "test_chat_input",
             description: "Test command to show how to make commands",
@@ -27,48 +29,48 @@ bot.on("ready", async () => { // When the bot is ready
                     "choices": [ //The possible choices for the options
                         {
                             "name": "Dog",
-                            "value": "animal_dog"
+                            "value": "animal_dog",
                         },
                         {
                             "name": "Cat",
-                            "value": "animal_cat"
+                            "value": "animal_cat",
                         },
                         {
                             "name": "Penguin",
-                            "value": "animal_penguin"
-                        }
-                    ]
+                            "value": "animal_penguin",
+                        },
+                    ],
                 },
                 {
                     "name": "only_smol",
                     "description": "Whether to show only baby animals",
                     "type": Constants.ApplicationCommandOptionTypes.BOOLEAN,
-                    "required": false
-                }
+                    "required": false,
+                },
             ],
-            type: Constants.ApplicationCommandTypes.CHAT_INPUT //Not required for Chat input type, but recommended
+            type: Constants.ApplicationCommandTypes.CHAT_INPUT, //Not required for Chat input type, but recommended
         }); //Create a chat input command
 
         bot.createCommand({
             name: "Test User Menu",
-            type: Constants.ApplicationCommandTypes.USER
+            type: Constants.ApplicationCommandTypes.USER,
         }); //Create a user context menu
 
         bot.createCommand({
             name: "Test Message Menu",
-            type: Constants.ApplicationCommandTypes.MESSAGE
+            type: Constants.ApplicationCommandTypes.MESSAGE,
         }); //Create a message context menu
 
         bot.createCommand({
             name: "test_edit_command",
             description: "Test command to show off how to edit commands",
-            type: Constants.ApplicationCommandTypes.CHAT_INPUT //Not required for Chat input type, but recommended
+            type: Constants.ApplicationCommandTypes.CHAT_INPUT, //Not required for Chat input type, but recommended
         }); //Create a chat input command
 
         bot.createCommand({
             name: "test_delete_command",
             description: "Test command to show off how to delete commands",
-            type: Constants.ApplicationCommandTypes.CHAT_INPUT //Not required for Chat input type, but recommended
+            type: Constants.ApplicationCommandTypes.CHAT_INPUT, //Not required for Chat input type, but recommended
         }); //Create a chat input command
 
         //In practice, you should use bulkEditCommands if you need to create multiple commands
@@ -80,13 +82,13 @@ bot.on("error", (err) => {
 });
 
 bot.on("interactionCreate", (interaction) => {
-    if(interaction instanceof Dysnomia.CommandInteraction) {
-        switch(interaction.data.name) {
+    if (interaction instanceof Dysnomia.CommandInteraction) {
+        switch (interaction.data.name) {
             case "test_edit_command":
                 interaction.createMessage("interaction recieved");
                 return bot.editCommand(interaction.data.id, {
                     name: "edited_test_command",
-                    description: "Test command that was edited by running test_edit_command"
+                    description: "Test command that was edited by running test_edit_command",
                 });
             case "test_delete_command":
                 interaction.createMessage("interaction received");

--- a/examples/components.js
+++ b/examples/components.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 const Constants = Dysnomia.Constants;
@@ -5,8 +7,8 @@ const Constants = Dysnomia.Constants;
 // Replace TOKEN with your bot account's token
 const bot = new Dysnomia.Client("BOT TOKEN", {
     gateway: {
-        intents: ["guildMessages"]
-    }
+        intents: ["guildMessages"],
+    },
 });
 
 bot.on("ready", async () => { // When the bot is ready
@@ -18,7 +20,7 @@ bot.on("error", (err) => {
 });
 
 bot.on("messageCreate", (msg) => { // When a message is created
-    if(msg.content === "!button") { // If the message content is "!button"
+    if (msg.content === "!button") { // If the message content is "!button"
         bot.createMessage(msg.channel.id, {
             content: "Button Example",
             components: [
@@ -30,14 +32,14 @@ bot.on("messageCreate", (msg) => { // When a message is created
                             style: Constants.ButtonStyles.PRIMARY, // This is the style of the button https://discord.com/developers/docs/interactions/message-components#button-object-button-styles
                             custom_id: "click_one",
                             label: "Click me!",
-                            disabled: false // Whether or not the button is disabled, is false by default
-                        }
-                    ]
-                }
-            ]
+                            disabled: false, // Whether or not the button is disabled, is false by default
+                        },
+                    ],
+                },
+            ],
         });
         // Send a message in the same channel with a Button
-    } else if(msg.content === "!select") { // Otherwise, if the message is "!select"
+    } else if (msg.content === "!select") { // Otherwise, if the message is "!select"
         bot.createMessage(msg.channel.id, {
             content: "Select Menu Example",
             components: [
@@ -52,31 +54,31 @@ bot.on("messageCreate", (msg) => { // When a message is created
                                 {
                                     label: "Option 1",
                                     value: "option_1",
-                                    description: "[Insert description here]"
+                                    description: "[Insert description here]",
                                 },
                                 {
                                     label: "Option 2",
                                     value: "option_2",
-                                    description: "This is only here to show off picking one"
-                                }
+                                    description: "This is only here to show off picking one",
+                                },
                             ],
                             min_values: 1,
                             max_values: 1,
-                            disabled: false // Whether or not the select menu is disabled, is false by default
-                        }
-                    ]
-                }
-            ]
+                            disabled: false, // Whether or not the select menu is disabled, is false by default
+                        },
+                    ],
+                },
+            ],
         });
         // Send a message in the same channel with a Select Menu
     }
 });
 
 bot.on("interactionCreate", (interaction) => {
-    if(interaction instanceof Dysnomia.ComponentInteraction) {
+    if (interaction instanceof Dysnomia.ComponentInteraction) {
         return interaction.createMessage({
             content: "Interaction Received",
-            flags: 64
+            flags: 64,
         });
     }
 });

--- a/examples/embed.js
+++ b/examples/embed.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 // Replace TOKEN with your bot account's token
@@ -12,32 +14,32 @@ bot.on("error", (err) => {
 });
 
 bot.on("messageCreate", (msg) => { // When a message is created
-    if(msg.content === "!embed") { // If the message content is "!embed"
+    if (msg.content === "!embed") { // If the message content is "!embed"
         bot.createMessage(msg.channel.id, {
             embeds: [{
                 title: "I'm an embed!", // Title of the embed
                 description: "Here is some more info, with **awesome** formatting.\nPretty *neat*, huh?",
                 author: { // Author property
                     name: msg.author.username,
-                    icon_url: msg.author.avatarURL
+                    icon_url: msg.author.avatarURL,
                 },
                 color: 0x008000, // Color, either in hex (show), or a base-10 integer
                 fields: [ // Array of field objects
                     {
                         name: "Some extra info.", // Field title
                         value: "Some extra value.", // Field
-                        inline: true // Whether you want multiple fields in same line
+                        inline: true, // Whether you want multiple fields in same line
                     },
                     {
                         name: "Some more extra info.",
                         value: "Another extra value.",
-                        inline: true
-                    }
+                        inline: true,
+                    },
                 ],
                 footer: { // Footer text
-                    text: "Created with Dysnomia."
-                }
-            }]
+                    text: "Created with Dysnomia.",
+                },
+            }],
         });
     }
 });

--- a/examples/intent.js
+++ b/examples/intent.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 // Replace TOKEN with your bot account's token
@@ -5,9 +7,9 @@ const bot = new Dysnomia.Client("Bot TOKEN", {
     gateway: {
         intents: [
             "guilds",
-            "guildMessages"
-        ]
-    }
+            "guildMessages",
+        ],
+    },
 });
 
 bot.on("ready", () => { // When the bot is ready

--- a/examples/pingpong.js
+++ b/examples/pingpong.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 // Replace TOKEN with your bot account's token
@@ -12,10 +14,10 @@ bot.on("error", (err) => {
 });
 
 bot.on("messageCreate", (msg) => { // When a message is created
-    if(msg.content === "!ping") { // If the message content is "!ping"
+    if (msg.content === "!ping") { // If the message content is "!ping"
         bot.createMessage(msg.channel.id, "Pong!");
         // Send a message in the same channel with "Pong!"
-    } else if(msg.content === "!pong") { // Otherwise, if the message is "!pong"
+    } else if (msg.content === "!pong") { // Otherwise, if the message is "!pong"
         bot.createMessage(msg.channel.id, "Ping!");
         // Respond with "Ping!"
     }

--- a/examples/playFile.js
+++ b/examples/playFile.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 // Replace TOKEN with your bot account's token
@@ -14,16 +16,16 @@ bot.on("error", (err) => {
 });
 
 bot.on("messageCreate", (msg) => { // When a message is created
-    if(msg.content.startsWith(playCommand)) { // If the message content starts with "!play "
-        if(msg.content.length <= playCommand.length + 1) { // Check if a filename was specified
+    if (msg.content.startsWith(playCommand)) { // If the message content starts with "!play "
+        if (msg.content.length <= playCommand.length + 1) { // Check if a filename was specified
             bot.createMessage(msg.channel.id, "Please specify a filename.");
             return;
         }
-        if(!msg.channel.guild) { // Check if the message was sent in a guild
+        if (!msg.channel.guild) { // Check if the message was sent in a guild
             bot.createMessage(msg.channel.id, "This command can only be run in a server.");
             return;
         }
-        if(!msg.member.voiceState.channelID) { // Check if the user is in a voice channel
+        if (!msg.member.voiceState.channelID) { // Check if the user is in a voice channel
             bot.createMessage(msg.channel.id, "You are not in a voice channel.");
             return;
         }
@@ -32,7 +34,7 @@ bot.on("messageCreate", (msg) => { // When a message is created
             bot.createMessage(msg.channel.id, "Error joining voice channel: " + err.message); // Notify the user if there is an error
             console.log(err); // Log the error
         }).then((connection) => {
-            if(connection.playing) { // Stop playing if the connection is playing something
+            if (connection.playing) { // Stop playing if the connection is playing something
                 connection.stopPlaying();
             }
             connection.play(filename); // Play the file and notify the user

--- a/examples/sharding.js
+++ b/examples/sharding.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Dysnomia = require("@projectdysnomia/dysnomia");
 
 // Replace TOKEN with your bot account's token
@@ -7,8 +9,8 @@ const bot = new Dysnomia.Client("Bot TOKEN", {
         lastShardID: 15,
         maxShards: 16,
         getAllUsers: false,
-        intents: ["guilds", "guildMembers", "guildPresences"]
-    }
+        intents: ["guilds", "guildMembers", "guildPresences"],
+    },
 });
 
 bot.on("ready", () => { // When the bot is ready

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -31,13 +31,13 @@ const AutoModerationRule = require("./structures/AutoModerationRule");
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events");
 }
 let Erlpack;
 try {
     Erlpack = require("erlpack");
-} catch{ // eslint-disable no-empty
+} catch { // eslint-disable no-empty
 }
 
 const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
@@ -74,7 +74,7 @@ class Client extends EventEmitter {
         activities: null,
         afk: false,
         since: null,
-        status: "offline"
+        status: "offline",
     };
     privateChannelMap = {};
     privateChannels = new Collection(PrivateChannel);
@@ -135,7 +135,7 @@ class Client extends EventEmitter {
         this.options = Object.assign({
             allowedMentions: {
                 users: true,
-                roles: true
+                roles: true,
             },
             defaultImageFormat: "jpg",
             defaultImageSize: 128,
@@ -144,18 +144,18 @@ class Client extends EventEmitter {
             rest: {},
             restMode: false,
             ws: {},
-            gateway: {}
+            gateway: {},
         }, options);
         this.options.allowedMentions = this._formatAllowedMentions(this.options.allowedMentions);
-        if(!Constants.ImageFormats.includes(this.options.defaultImageFormat.toLowerCase())) {
+        if (!Constants.ImageFormats.includes(this.options.defaultImageFormat.toLowerCase())) {
             throw new TypeError(`Invalid default image format: ${this.options.defaultImageFormat}`);
         }
         const defaultImageSize = this.options.defaultImageSize;
-        if(defaultImageSize < Constants.ImageSizeBoundaries.MINIMUM || defaultImageSize > Constants.ImageSizeBoundaries.MAXIMUM || (defaultImageSize & (defaultImageSize - 1))) {
+        if (defaultImageSize < Constants.ImageSizeBoundaries.MINIMUM || defaultImageSize > Constants.ImageSizeBoundaries.MAXIMUM || (defaultImageSize & (defaultImageSize - 1))) {
             throw new TypeError(`Invalid default image size: ${defaultImageSize}`);
         }
         // Set HTTP Agent on Websockets if not already set
-        if(this.options.rest.agent && !this.options.ws?.agent) {
+        if (this.options.rest.agent && !this.options.ws?.agent) {
             this.options.ws ??= {};
             this.options.ws.agent = this.options.rest.agent;
         }
@@ -164,7 +164,7 @@ class Client extends EventEmitter {
             configurable: true,
             enumerable: false,
             writable: true,
-            value: token
+            value: token,
         });
 
         this.requestHandler = new RequestHandler(this, this.options.rest);
@@ -200,7 +200,7 @@ class Client extends EventEmitter {
             nick: options.nick,
             roles: options.roles,
             mute: options.mute,
-            deaf: options.deaf
+            deaf: options.deaf,
         });
     }
 
@@ -214,7 +214,7 @@ class Client extends EventEmitter {
     */
     addGuildMemberRole(guildID, memberID, roleID, reason) {
         return this.requestHandler.request("PUT", Endpoints.GUILD_MEMBER_ROLE(guildID, memberID, roleID), true, {
-            reason
+            reason,
         });
     }
 
@@ -226,7 +226,7 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     addMessageReaction(channelID, messageID, reaction) {
-        if(reaction === decodeURI(reaction)) {
+        if (reaction === decodeURI(reaction)) {
             reaction = encodeURIComponent(reaction);
         }
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_MESSAGE_REACTION_USER(channelID, messageID, reaction, "@me"), true);
@@ -243,7 +243,7 @@ class Client extends EventEmitter {
     banGuildMember(guildID, userID, options) {
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
             delete_message_seconds: options.deleteMessageSeconds || 0,
-            reason: options.reason
+            reason: options.reason,
         });
     }
 
@@ -264,11 +264,11 @@ class Client extends EventEmitter {
     * @returns {Promise<ApplicationCommand[]>}
     */
     bulkEditCommands(commands) {
-        for(const command of commands) {
-            if(command.name !== undefined && command.type === 1) {
+        for (const command of commands) {
+            if (command.name !== undefined && command.type === 1) {
                 command.name = command.name.toLowerCase();
             }
-            if(command.defaultMemberPermissions !== undefined) {
+            if (command.defaultMemberPermissions !== undefined) {
                 command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
             }
             command.default_member_permissions = command.defaultMemberPermissions;
@@ -286,11 +286,11 @@ class Client extends EventEmitter {
     * @returns {ApplicationCommand[]} Resolves with an array of commands objects
     */
     bulkEditGuildCommands(guildID, commands) {
-        for(const command of commands) {
-            if(command.name !== undefined && command.type === 1) {
+        for (const command of commands) {
+            if (command.name !== undefined && command.type === 1) {
                 command.name = command.name.toLowerCase();
             }
-            if(command.defaultMemberPermissions !== undefined) {
+            if (command.defaultMemberPermissions !== undefined) {
                 command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
             }
             command.default_member_permissions = command.defaultMemberPermissions;
@@ -309,7 +309,7 @@ class Client extends EventEmitter {
             guild_id: guildID || null,
             channel_id: null,
             self_mute: false,
-            self_deaf: false
+            self_deaf: false,
         });
         this.voiceConnections.leave(guildID);
     }
@@ -319,43 +319,43 @@ class Client extends EventEmitter {
     * @returns {Promise} Resolves when all shards are initialized
     */
     async connect() {
-        if(typeof this._token !== "string") {
+        if (typeof this._token !== "string") {
             throw new Error(`Invalid token "${this._token}"`);
         }
         try {
             const data = await (this.shards.options.maxShards === "auto" || (this.shards.options.shardConcurrency === "auto" && this.bot) ? this.getBotGateway() : this.getGateway());
-            if(!data.url || (this.shards.options.maxShards === "auto" && !data.shards)) {
+            if (!data.url || (this.shards.options.maxShards === "auto" && !data.shards)) {
                 throw new Error("Invalid response from gateway REST call");
             }
-            if(data.url.includes("?")) {
+            if (data.url.includes("?")) {
                 data.url = data.url.substring(0, data.url.indexOf("?"));
             }
-            if(!data.url.endsWith("/")) {
+            if (!data.url.endsWith("/")) {
                 data.url += "/";
             }
             this.gatewayURL = `${data.url}?v=${Constants.GATEWAY_VERSION}&encoding=${Erlpack ? "etf" : "json"}`;
 
-            if(this.shards.options.compress) {
+            if (this.shards.options.compress) {
                 this.gatewayURL += "&compress=zlib-stream";
             }
 
-            if(this.shards.options.maxShards === "auto") {
-                if(!data.shards) {
+            if (this.shards.options.maxShards === "auto") {
+                if (!data.shards) {
                     throw new Error("Failed to autoshard due to lack of data from Discord.");
                 }
                 this.shards.options.maxShards = data.shards;
                 this.shards.options.lastShardID ??= data.shards - 1;
             }
 
-            if(this.shards.options.shardConcurrency === "auto" && typeof data.session_start_limit?.max_concurrency === "number") {
+            if (this.shards.options.shardConcurrency === "auto" && typeof data.session_start_limit?.max_concurrency === "number") {
                 this.shards.options.maxConcurrency = data.session_start_limit.max_concurrency;
             }
 
-            for(let i = this.shards.options.firstShardID; i <= this.shards.options.lastShardID; ++i) {
+            for (let i = this.shards.options.firstShardID; i <= this.shards.options.lastShardID; ++i) {
                 this.shards.spawn(i);
             }
-        } catch(err) {
-            if(!this.shards.options.autoreconnect) {
+        } catch (err) {
+            if (!this.shards.options.autoreconnect) {
                 throw err;
             }
             const reconnectDelay = this.shards.options.reconnectDelay(this.lastReconnectDelay, this.reconnectAttempts);
@@ -391,7 +391,7 @@ class Client extends EventEmitter {
             name: options.name,
             reason: options.reason,
             trigger_metadata: options.triggerMetadata,
-            trigger_type: options.triggerType
+            trigger_type: options.triggerType,
         }).then((rule) => new AutoModerationRule(rule, this));
     }
 
@@ -427,13 +427,13 @@ class Client extends EventEmitter {
                 name: tag.name,
                 moderated: tag.moderated,
                 emoji_id: tag.emojiID,
-                emoji_name: tag.emojiName
+                emoji_name: tag.emojiName,
             })),
             bitrate: options.bitrate,
             default_auto_archive_duration: options.defaultAutoArchiveDuration,
             default_reaction_emoji: options.defaultReactionEmoji && {
                 emoji_id: options.defaultReactionEmoji.emojiID,
-                emoji_name: options.defaultReactionEmoji.emojiName
+                emoji_name: options.defaultReactionEmoji.emojiName,
             },
             default_sort_order: options.defaultSortOrder,
             nsfw: options.nsfw,
@@ -445,7 +445,7 @@ class Client extends EventEmitter {
             rtc_region: options.rtcRegion,
             topic: options.topic,
             user_limit: options.userLimit,
-            video_quality_mode: options.videoQualityMode
+            video_quality_mode: options.videoQualityMode,
         }).then((channel) => Channel.from(channel, this));
     }
 
@@ -472,7 +472,7 @@ class Client extends EventEmitter {
             target_user_id: options.targetUserID,
             temporary: options.temporary,
             unique: options.unique,
-            reason: reason
+            reason: reason,
         }).then((invite) => new Invite(invite, this));
     }
 
@@ -505,10 +505,10 @@ class Client extends EventEmitter {
     * @returns {Promise<ApplicationCommand>}
     */
     createCommand(command) {
-        if(command.name !== undefined && command.type === 1) {
+        if (command.name !== undefined && command.type === 1) {
             command.name = command.name.toLowerCase();
         }
-        if(command.defaultMemberPermissions !== undefined) {
+        if (command.defaultMemberPermissions !== undefined) {
             command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
@@ -535,7 +535,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Guild>}
     */
     createGuild(name, options) {
-        if(this.guilds.size > 9) {
+        if (this.guilds.size > 9) {
             throw new Error("This method can't be used when in 10 or more guilds.");
         }
 
@@ -550,7 +550,7 @@ class Client extends EventEmitter {
             afk_timeout: options.afkTimeout,
             roles: options.roles,
             channels: options.channels,
-            system_channel_flags: options.systemChannelFlags
+            system_channel_flags: options.systemChannelFlags,
         }).then((guild) => new Guild(guild, this));
     }
 
@@ -569,10 +569,10 @@ class Client extends EventEmitter {
     * @returns {Promise<ApplicationCommand>}
     */
     createGuildCommand(guildID, command) {
-        if(command.name !== undefined && command.type === 1) {
+        if (command.name !== undefined && command.type === 1) {
             command.name = command.name.toLowerCase();
         }
-        if(command.defaultMemberPermissions !== undefined) {
+        if (command.defaultMemberPermissions !== undefined) {
             command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
@@ -606,7 +606,7 @@ class Client extends EventEmitter {
     createGuildFromTemplate(code, name, icon) {
         return this.requestHandler.request("POST", Endpoints.GUILD_TEMPLATE(code), true, {
             name,
-            icon
+            icon,
         }).then((guild) => new Guild(guild, this));
     }
 
@@ -638,7 +638,7 @@ class Client extends EventEmitter {
             privacy_level: event.privacyLevel,
             scheduled_end_time: event.scheduledEndTime,
             scheduled_start_time: event.scheduledStartTime,
-            reason: reason
+            reason: reason,
         }).then((data) => new GuildScheduledEvent(data, this));
     }
 
@@ -660,10 +660,10 @@ class Client extends EventEmitter {
             description: options.description,
             name: options.name,
             tags: options.tags,
-            reason: reason
+            reason: reason,
         }, [{
             ...options.file,
-            fieldName: "file"
+            fieldName: "file",
         }]);
     }
 
@@ -677,7 +677,7 @@ class Client extends EventEmitter {
     createGuildTemplate(guildID, name, description) {
         return this.requestHandler.request("POST", Endpoints.GUILD_TEMPLATES(guildID), true, {
             name,
-            description
+            description,
         }).then((template) => new GuildTemplate(template, this));
     }
 
@@ -727,38 +727,38 @@ class Client extends EventEmitter {
     * @returns {Promise<Message>}
     */
     createMessage(channelID, content) {
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
             content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             content.sticker_ids = content.stickerIDs;
-            if(content.messageReference) {
+            if (content.messageReference) {
                 content.message_reference = content.messageReference;
-                if(content.messageReference.messageID !== undefined) {
+                if (content.messageReference.messageID !== undefined) {
                     content.message_reference.message_id = content.messageReference.messageID;
                     content.messageReference.messageID = undefined;
                 }
-                if(content.messageReference.channelID !== undefined) {
+                if (content.messageReference.channelID !== undefined) {
                     content.message_reference.channel_id = content.messageReference.channelID;
                     content.messageReference.channelID = undefined;
                 }
-                if(content.messageReference.guildID !== undefined) {
+                if (content.messageReference.guildID !== undefined) {
                     content.message_reference.guild_id = content.messageReference.guildID;
                     content.messageReference.guildID = undefined;
                 }
-                if(content.messageReference.failIfNotExists !== undefined) {
+                if (content.messageReference.failIfNotExists !== undefined) {
                     content.message_reference.fail_if_not_exists = content.messageReference.failIfNotExists;
                     content.messageReference.failIfNotExists = undefined;
                 }
             }
         }
 
-        const {files, attachments} = this._processAttachments(content.attachments);
+        const { files, attachments } = this._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.requestHandler.request("POST", Endpoints.CHANNEL_MESSAGES(channelID), true, content, files).then((message) => new Message(message, this));
@@ -779,7 +779,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Role>}
     */
     createRole(guildID, options, reason) {
-        if(options.permissions !== undefined) {
+        if (options.permissions !== undefined) {
             options.permissions = options.permissions instanceof Permission ? String(options.permissions.allow) : String(options.permissions);
         }
         return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, {
@@ -790,10 +790,10 @@ class Client extends EventEmitter {
             icon: options.icon,
             mentionable: options.mentionable,
             unicode_emoji: options.unicodeEmoji,
-            reason: reason
+            reason: reason,
         }).then((role) => {
             const guild = this.guilds.get(guildID);
-            if(guild) {
+            if (guild) {
                 return guild.roles.add(role, guild);
             } else {
                 return new Role(role);
@@ -815,7 +815,7 @@ class Client extends EventEmitter {
             channel_id: channelID,
             privacy_level: options.privacyLevel,
             send_start_notification: options.sendStartNotification,
-            topic: options.topic
+            topic: options.topic,
         }).then((instance) => new StageInstance(instance, this));
     }
 
@@ -845,16 +845,16 @@ class Client extends EventEmitter {
     * @returns {Promise<ThreadChannel>}
     */
     createThread(channelID, options) {
-        if(options.message) {
-            if(options.message.content !== undefined && typeof options.message.content !== "string") {
+        if (options.message) {
+            if (options.message.content !== undefined && typeof options.message.content !== "string") {
                 options.message.content = "" + options.message.content;
             }
             options.message.allowed_mentions = this._formatAllowedMentions(options.message.allowedMentions);
             options.message.sticker_ids = options.message.stickerIDs;
         }
 
-        const {files, attachments} = options.message ? this._processAttachments(options.message.attachments) : {};
-        if(options.message) {
+        const { files, attachments } = options.message ? this._processAttachments(options.message.attachments) : {};
+        if (options.message) {
             options.message.attachments = attachments;
         }
 
@@ -865,7 +865,7 @@ class Client extends EventEmitter {
             message: options.message,
             name: options.name,
             type: options.type,
-            rate_limit_per_user: options.rateLimitPerUser
+            rate_limit_per_user: options.rateLimitPerUser,
         }, files).then((channel) => Channel.from(channel, this));
     }
 
@@ -883,7 +883,7 @@ class Client extends EventEmitter {
         return this.requestHandler.request("POST", Endpoints.THREAD_WITH_MESSAGE(channelID, messageID), true, {
             name: options.name,
             auto_archive_duration: options.autoArchiveDuration,
-            rate_limit_per_user: options.rateLimitPerUser
+            rate_limit_per_user: options.rateLimitPerUser,
         }).then((channel) => Channel.from(channel, this));
     }
 
@@ -906,7 +906,7 @@ class Client extends EventEmitter {
      */
     deleteAutoModerationRule(guildID, ruleID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.AUTO_MODERATION_RULE(guildID, ruleID), true, {
-            reason
+            reason,
         });
     }
 
@@ -918,7 +918,7 @@ class Client extends EventEmitter {
     */
     deleteChannel(channelID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL(channelID), true, {
-            reason
+            reason,
         });
     }
 
@@ -931,7 +931,7 @@ class Client extends EventEmitter {
     */
     deleteChannelPermission(channelID, overwriteID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
-            reason
+            reason,
         });
     }
 
@@ -972,7 +972,7 @@ class Client extends EventEmitter {
     */
     deleteGuildEmoji(guildID, emojiID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_EMOJI(guildID, emojiID), true, {
-            reason
+            reason,
         });
     }
 
@@ -1005,7 +1005,7 @@ class Client extends EventEmitter {
     */
     deleteGuildSticker(guildID, stickerID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_STICKER(guildID, stickerID), true, {
-            reason
+            reason,
         });
     }
 
@@ -1027,7 +1027,7 @@ class Client extends EventEmitter {
     */
     deleteInvite(inviteID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.INVITE(inviteID), true, {
-            reason
+            reason,
         });
     }
 
@@ -1040,7 +1040,7 @@ class Client extends EventEmitter {
     */
     deleteMessage(channelID, messageID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, {
-            reason
+            reason,
         });
     }
 
@@ -1052,28 +1052,28 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     deleteMessages(channelID, messageIDs, reason) {
-        if(messageIDs.length === 0) {
+        if (messageIDs.length === 0) {
             return Promise.resolve();
         }
-        if(messageIDs.length === 1) {
+        if (messageIDs.length === 1) {
             return this.deleteMessage(channelID, messageIDs[0], reason);
         }
 
         const oldestAllowedSnowflake = (Date.now() - 1421280000000) * 4194304;
         const invalidMessage = messageIDs.find((messageID) => messageID < oldestAllowedSnowflake);
-        if(invalidMessage) {
+        if (invalidMessage) {
             return Promise.reject(new Error(`Message ${invalidMessage} is more than 2 weeks old.`));
         }
 
-        if(messageIDs.length > 100) {
+        if (messageIDs.length > 100) {
             return this.requestHandler.request("POST", Endpoints.CHANNEL_BULK_DELETE(channelID), true, {
                 messages: messageIDs.splice(0, 100),
-                reason: reason
+                reason: reason,
             }).then(() => this.deleteMessages(channelID, messageIDs, reason));
         }
         return this.requestHandler.request("POST", Endpoints.CHANNEL_BULK_DELETE(channelID), true, {
             messages: messageIDs,
-            reason: reason
+            reason: reason,
         });
     }
 
@@ -1086,7 +1086,7 @@ class Client extends EventEmitter {
     */
     deleteRole(guildID, roleID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_ROLE(guildID, roleID), true, {
-            reason
+            reason,
         });
     }
 
@@ -1108,7 +1108,7 @@ class Client extends EventEmitter {
     */
     deleteWebhook(webhookID, token, reason) {
         return this.requestHandler.request("DELETE", token ? Endpoints.WEBHOOK_TOKEN(webhookID, token) : Endpoints.WEBHOOK(webhookID), !token, {
-            reason
+            reason,
         });
     }
 
@@ -1172,7 +1172,7 @@ class Client extends EventEmitter {
             exempt_roles: options.exemptRoles,
             name: options.name,
             reason: options.reason,
-            trigger_metadata: options.triggerMetadata
+            trigger_metadata: options.triggerMetadata,
         }).then((rule) => new AutoModerationRule(rule, this));
     }
 
@@ -1215,7 +1215,7 @@ class Client extends EventEmitter {
                 name: tag.name,
                 moderated: tag.moderated,
                 emoji_id: tag.emojiID,
-                emoji_name: tag.emojiName
+                emoji_name: tag.emojiName,
             })),
             applied_tags: options.appliedTags,
             bitrate: options.bitrate,
@@ -1223,7 +1223,7 @@ class Client extends EventEmitter {
             default_forum_layout: options.defaultForumLayout,
             default_reaction_emoji: options.defaultReactionEmoji && {
                 emoji_id: options.defaultReactionEmoji.emojiID,
-                emoji_name: options.defaultReactionEmoji.emojiName
+                emoji_name: options.defaultReactionEmoji.emojiName,
             },
             default_sort_order: options.defaultSortOrder,
             default_thread_rate_limit_per_user: options.defaultThreadRateLimitPerUser,
@@ -1242,7 +1242,7 @@ class Client extends EventEmitter {
             user_limit: options.userLimit,
             video_quality_mode: options.videoQualityMode,
             permission_overwrites: options.permissionOverwrites,
-            reason: reason
+            reason: reason,
         }).then((channel) => Channel.from(channel, this));
     }
 
@@ -1257,14 +1257,14 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type, reason) {
-        if(typeof type === "string") { // backward compatibility
+        if (typeof type === "string") { // backward compatibility
             type = type === "member" ? 1 : 0;
         }
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
             allow,
             deny,
             type,
-            reason
+            reason,
         });
     }
 
@@ -1280,10 +1280,10 @@ class Client extends EventEmitter {
     editChannelPosition(channelID, position, options = {}) {
         let channels = this.guilds.get(this.channelGuildMap[channelID]).channels;
         const channel = channels.get(channelID);
-        if(!channel) {
+        if (!channel) {
             return Promise.reject(new Error(`Channel ${channelID} not found`));
         }
-        if(channel.position === position) {
+        if (channel.position === position) {
             return Promise.resolve();
         }
         const min = Math.min(position, channel.position);
@@ -1294,7 +1294,7 @@ class Client extends EventEmitter {
                 && chan.position <= max
                 && chan.id !== channelID;
         }).sort((a, b) => a.position - b.position);
-        if(position > channel.position) {
+        if (position > channel.position) {
             channels.push(channel);
         } else {
             channels.unshift(channel);
@@ -1303,7 +1303,7 @@ class Client extends EventEmitter {
             id: channel.id,
             position: index + min,
             lock_permissions: options.lockPermissions,
-            parent_id: options.parentID
+            parent_id: options.parentID,
         })));
     }
 
@@ -1323,7 +1323,7 @@ class Client extends EventEmitter {
                 id: channelPosition.id,
                 position: channelPosition.position,
                 lock_permissions: channelPosition.lockPermissions,
-                parent_id: channelPosition.parentID
+                parent_id: channelPosition.parentID,
             };
         }));
     }
@@ -1343,10 +1343,10 @@ class Client extends EventEmitter {
     * @returns {Promise<ApplicationCommand>}
     */
     editCommand(commandID, command) {
-        if(command.name !== undefined && command.type === 1) {
+        if (command.name !== undefined && command.type === 1) {
             command.name = command.name.toLowerCase();
         }
-        if(command.defaultMemberPermissions !== undefined) {
+        if (command.defaultMemberPermissions !== undefined) {
             command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
@@ -1365,7 +1365,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} Resolves with a [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) object.
     */
     editCommandPermissions(guildID, commandID, permissions) {
-        return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, {permissions});
+        return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, { permissions });
     }
 
     /**
@@ -1417,7 +1417,7 @@ class Client extends EventEmitter {
             features: options.features,
             premium_progress_bar_enabled: options.premiumProgressBarEnabled,
             safety_alerts_channel_id: options.safetyAlertsChannelID,
-            reason: reason
+            reason: reason,
         }).then((guild) => new Guild(guild, this));
     }
 
@@ -1434,10 +1434,10 @@ class Client extends EventEmitter {
     * @returns {Promise<ApplicationCommand>}
     */
     editGuildCommand(guildID, commandID, command) {
-        if(command.name !== undefined && command.type === 1) {
+        if (command.name !== undefined && command.type === 1) {
             command.name = command.name.toLowerCase();
         }
-        if(command.defaultMemberPermissions !== undefined) {
+        if (command.defaultMemberPermissions !== undefined) {
             command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
@@ -1485,7 +1485,7 @@ class Client extends EventEmitter {
             channel_id: options.channelID,
             communication_disabled_until: options.communicationDisabledUntil,
             flags: options.flags,
-            reason: reason
+            reason: reason,
         }).then((member) => new Member(member, this.guilds.get(guildID), this));
     }
 
@@ -1532,7 +1532,7 @@ class Client extends EventEmitter {
             scheduled_end_time: event.scheduledEndTime,
             scheduled_start_time: event.scheduledStartTime,
             status: event.status,
-            reason: reason
+            reason: reason,
         });
     }
 
@@ -1578,7 +1578,7 @@ class Client extends EventEmitter {
         return this.requestHandler.request("PATCH", Endpoints.GUILD_VOICE_STATE(guildID, userID), true, {
             channel_id: options.channelID,
             request_to_speak_timestamp: options.requestToSpeakTimestamp,
-            suppress: options.suppress
+            suppress: options.suppress,
         });
     }
 
@@ -1604,9 +1604,9 @@ class Client extends EventEmitter {
                     channel_id: c.channelID,
                     description: c.description,
                     emoji_id: c.emojiID,
-                    emoji_name: c.emojiName
+                    emoji_name: c.emojiName,
                 };
-            })
+            }),
         });
     }
 
@@ -1641,20 +1641,20 @@ class Client extends EventEmitter {
     * @returns {Promise<Message>}
     */
     editMessage(channelID, messageID, content) {
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = content.attachments ? this._processAttachments(content.attachments) : [];
+        const { files, attachments } = content.attachments ? this._processAttachments(content.attachments) : [];
         content.attachments = attachments;
 
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content, files).then((message) => new Message(message, this));
@@ -1678,7 +1678,7 @@ class Client extends EventEmitter {
     editRole(guildID, roleID, options, reason) {
         options.unicode_emoji = options.unicodeEmoji;
         options.reason = reason;
-        if(options.permissions !== undefined) {
+        if (options.permissions !== undefined) {
             options.permissions = options.permissions instanceof Permission ? String(options.permissions.allow) : String(options.permissions);
         }
         return this.requestHandler.request("PATCH", Endpoints.GUILD_ROLE(guildID, roleID), true, options).then((role) => new Role(role, this.guilds.get(guildID)));
@@ -1690,14 +1690,14 @@ class Client extends EventEmitter {
      * @returns {Promise<Object[]>}
      */
     editRoleConnectionMetadata(metadata) {
-        for(const meta of metadata) {
+        for (const meta of metadata) {
             meta.name_localizations = meta.nameLocalizations;
             meta.description_localizations = meta.descriptionLocalizations;
         }
         return this.requestHandler.request("PUT", Endpoints.ROLE_CONNECTION_METADATA(this.application.id), true, metadata).then((metadata) => metadata.map((meta) => ({
             ...meta,
             nameLocalizations: meta.name_localizations,
-            descriptionLocalizations: meta.description_localizations
+            descriptionLocalizations: meta.description_localizations,
         })));
     }
 
@@ -1709,28 +1709,28 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     editRolePosition(guildID, roleID, position) {
-        if(guildID === roleID) {
+        if (guildID === roleID) {
             return Promise.reject(new Error("Cannot move default role"));
         }
         let roles = this.guilds.get(guildID).roles;
         const role = roles.get(roleID);
-        if(!role) {
+        if (!role) {
             return Promise.reject(new Error(`Role ${roleID} not found`));
         }
-        if(role.position === position) {
+        if (role.position === position) {
             return Promise.resolve();
         }
         const min = Math.min(position, role.position);
         const max = Math.max(position, role.position);
         roles = roles.filter((role) => min <= role.position && role.position <= max && role.id !== roleID).sort((a, b) => a.position - b.position);
-        if(position > role.position) {
+        if (position > role.position) {
             roles.push(role);
         } else {
             roles.unshift(role);
         }
         return this.requestHandler.request("PATCH", Endpoints.GUILD_ROLES(guildID), true, roles.map((role, index) => ({
             id: role.id,
-            position: index + min
+            position: index + min,
         })));
     }
 
@@ -1766,19 +1766,19 @@ class Client extends EventEmitter {
     * @arg {String} [activities[].url] The URL of the activity
     */
     editStatus(status, activities) {
-        if(activities === undefined && typeof status === "object") {
+        if (activities === undefined && typeof status === "object") {
             activities = status;
             status = undefined;
         }
-        if(status) {
+        if (status) {
             this.presence.status = status;
         }
-        if(activities === null) {
+        if (activities === null) {
             activities = [];
-        } else if(activities && !Array.isArray(activities)) {
+        } else if (activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        if(activities !== undefined) {
+        if (activities !== undefined) {
             this.presence.activities = activities;
         }
 
@@ -1803,7 +1803,7 @@ class Client extends EventEmitter {
             name: options.name,
             avatar: options.avatar,
             channel_id: options.channelID,
-            reason: reason
+            reason: reason,
         });
     }
 
@@ -1831,14 +1831,14 @@ class Client extends EventEmitter {
     */
     editWebhookMessage(webhookID, token, messageID, options) {
         let qs = "";
-        if(options.threadID) {
+        if (options.threadID) {
             qs += "&thread_id=" + options.threadID;
         }
-        if(options.allowedMentions) {
+        if (options.allowedMentions) {
             options.allowed_mentions = this._formatAllowedMentions(options.allowedMentions);
         }
 
-        const {files, attachments} = options.attachments ? this._processAttachments(options.attachments) : [];
+        const { files, attachments } = options.attachments ? this._processAttachments(options.attachments) : [];
         options.attachments = attachments;
 
         return this.requestHandler.request("PATCH", Endpoints.WEBHOOK_MESSAGE(webhookID, token, messageID) + (qs ? "?" + qs : ""), false, options, files).then((response) => new Message(response, this));
@@ -1862,10 +1862,10 @@ class Client extends EventEmitter {
         const threadID = options.threadID;
         options.threadID = undefined;
         let qs = "";
-        if(wait) {
+        if (wait) {
             qs += "&wait=true";
         }
-        if(threadID) {
+        if (threadID) {
             qs += "&thread_id=" + threadID;
         }
         return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (qs ? "?" + qs : ""), auth, options);
@@ -1899,14 +1899,14 @@ class Client extends EventEmitter {
     */
     executeWebhook(webhookID, token, options) {
         let qs = "";
-        if(options.wait) {
+        if (options.wait) {
             qs += "&wait=true";
         }
-        if(options.threadID) {
+        if (options.threadID) {
             qs += "&thread_id=" + options.threadID;
         }
 
-        const {files, attachments} = options.attachments ? this._processAttachments(options.attachments) : [];
+        const { files, attachments } = options.attachments ? this._processAttachments(options.attachments) : [];
 
         return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (qs ? "?" + qs : ""), !!options.auth, {
             content: options.content,
@@ -1918,7 +1918,7 @@ class Client extends EventEmitter {
             allowed_mentions: this._formatAllowedMentions(options.allowedMentions),
             components: options.components,
             attachments: attachments,
-            thread_name: options.threadName
+            thread_name: options.threadName,
         }, files).then((response) => options.wait ? new Message(response, this) : undefined);
     }
 
@@ -1929,7 +1929,7 @@ class Client extends EventEmitter {
      * @returns {Object} An object containing the NewsChannel's ID and the new webhook's ID
      */
     followChannel(channelID, webhookChannelID) {
-        return this.requestHandler.request("POST", Endpoints.CHANNEL_FOLLOW(channelID), true, {webhook_channel_id: webhookChannelID});
+        return this.requestHandler.request("POST", Endpoints.CHANNEL_FOLLOW(channelID), true, { webhook_channel_id: webhookChannelID });
     }
 
     /**
@@ -1941,7 +1941,7 @@ class Client extends EventEmitter {
         return this.requestHandler.request("GET", Endpoints.THREADS_GUILD_ACTIVE(guildID), true).then((response) => {
             return {
                 members: response.members.map((member) => new ThreadMember(member, this)),
-                threads: response.threads.map((thread) => Channel.from(thread, this))
+                threads: response.threads.map((thread) => Channel.from(thread, this)),
             };
         });
     }
@@ -1960,7 +1960,7 @@ class Client extends EventEmitter {
             return {
                 hasMore: response.has_more,
                 members: response.members.map((member) => new ThreadMember(member, this)),
-                threads: response.threads.map((thread) => Channel.from(thread, this))
+                threads: response.threads.map((thread) => Channel.from(thread, this)),
             };
         });
     }
@@ -1998,14 +1998,14 @@ class Client extends EventEmitter {
     * @returns {CategoryChannel | PrivateChannel | TextChannel | TextVoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel}
     */
     getChannel(channelID) {
-        if(!channelID) {
+        if (!channelID) {
             throw new Error(`Invalid channel ID: ${channelID}`);
         }
 
-        if(this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
+        if (this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
             return this.guilds.get(this.channelGuildMap[channelID]).channels.get(channelID);
         }
-        if(this.threadGuildMap[channelID] && this.guilds.get(this.threadGuildMap[channelID])) {
+        if (this.threadGuildMap[channelID] && this.guilds.get(this.threadGuildMap[channelID])) {
             return this.guilds.get(this.threadGuildMap[channelID]).threads.get(channelID);
         }
         return this.privateChannels.get(channelID);
@@ -2037,7 +2037,7 @@ class Client extends EventEmitter {
     */
     getCommand(commandID, withLocalizations) {
         let qs = "";
-        if(withLocalizations) {
+        if (withLocalizations) {
             qs += "&with_localizations=true";
         }
         return this.requestHandler.request("GET", Endpoints.COMMAND(this.application.id, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
@@ -2060,7 +2060,7 @@ class Client extends EventEmitter {
     */
     getCommands(withLocalizations) {
         let qs = "";
-        if(withLocalizations) {
+        if (withLocalizations) {
             qs += "&with_localizations=true";
         }
         return this.requestHandler.request("GET", Endpoints.COMMANDS(this.application.id) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
@@ -2072,11 +2072,11 @@ class Client extends EventEmitter {
     * @returns {Promise<PrivateChannel>}
     */
     getDMChannel(userID) {
-        if(this.privateChannelMap[userID]) {
+        if (this.privateChannelMap[userID]) {
             return Promise.resolve(this.privateChannels.get(this.privateChannelMap[userID]));
         }
         return this.requestHandler.request("POST", Endpoints.USER_CHANNELS("@me"), true, {
-            recipient_id: userID
+            recipient_id: userID,
         }).then((privateChannel) => new PrivateChannel(privateChannel, this));
     }
 
@@ -2101,10 +2101,10 @@ class Client extends EventEmitter {
     */
     getGuildAuditLog(guildID, options = {}) {
         options.limit ??= 50; // Legacy behavior
-        if(options.actionType !== undefined) {
+        if (options.actionType !== undefined) {
             options.action_type = options.actionType;
         }
-        if(options.userID !== undefined) {
+        if (options.userID !== undefined) {
             options.user_id = options.userID;
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_AUDIT_LOGS(guildID), true, options).then((data) => {
@@ -2123,7 +2123,7 @@ class Client extends EventEmitter {
                 integrations: data.integrations.map((integration) => new GuildIntegration(integration, guild)),
                 threads: threads,
                 users: users,
-                webhooks: data.webhooks
+                webhooks: data.webhooks,
             };
         });
     }
@@ -2154,21 +2154,21 @@ class Client extends EventEmitter {
         const bans = await this.requestHandler.request("GET", Endpoints.GUILD_BANS(guildID), true, {
             after: options.after,
             before: options.before,
-            limit: options.limit && Math.min(options.limit, 1000)
+            limit: options.limit && Math.min(options.limit, 1000),
         });
 
-        for(const ban of bans) {
+        for (const ban of bans) {
             ban.user = this.users.update(ban.user, this);
         }
 
-        if(options.limit && options.limit > 1000 && bans.length >= 1000) {
+        if (options.limit && options.limit > 1000 && bans.length >= 1000) {
             const page = await this.getGuildBans(guildID, {
                 after: options.before ? undefined : bans[bans.length - 1].user.id,
                 before: options.before ? bans[0].user.id : undefined,
-                limit: options.limit - bans.length
+                limit: options.limit - bans.length,
             });
 
-            if(options.before) {
+            if (options.before) {
                 bans.unshift(...page);
             } else {
                 bans.push(...page);
@@ -2187,7 +2187,7 @@ class Client extends EventEmitter {
     */
     getGuildCommand(guildID, commandID, withLocalizations) {
         let qs = "";
-        if(withLocalizations) {
+        if (withLocalizations) {
             qs += "&with_localizations=true";
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
@@ -2210,7 +2210,7 @@ class Client extends EventEmitter {
     */
     getGuildCommands(guildID, withLocalizations) {
         let qs = "";
-        if(withLocalizations) {
+        if (withLocalizations) {
             qs += "&with_localizations=true";
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_COMMANDS(this.application.id, guildID) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
@@ -2281,13 +2281,13 @@ class Client extends EventEmitter {
 
         options.with_member = options.withMember;
         return this.requestHandler.request("GET", Endpoints.GUILD_SCHEDULED_EVENT_USERS(guildID, eventID), true, options).then((data) => data.map((eventUser) => {
-            if(eventUser.member) {
+            if (eventUser.member) {
                 eventUser.member.id = eventUser.user.id;
             }
             return {
                 guildScheduledEventID: eventUser.guild_scheduled_event_id,
                 member: eventUser.member && guild ? guild.members.update(eventUser.member) : new Member(eventUser.member),
-                user: this.users.update(eventUser.user)
+                user: this.users.update(eventUser.user),
             };
         }));
     }
@@ -2384,7 +2384,7 @@ class Client extends EventEmitter {
             return {
                 hasMore: response.has_more,
                 members: response.members.map((member) => new ThreadMember(member, this)),
-                threads: response.threads.map((thread) => Channel.from(thread, this))
+                threads: response.threads.map((thread) => Channel.from(thread, this)),
             };
         });
     }
@@ -2410,7 +2410,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<User>>}
     */
     getMessageReaction(channelID, messageID, reaction, options = {}) {
-        if(reaction === decodeURI(reaction)) {
+        if (reaction === decodeURI(reaction)) {
             reaction = encodeURIComponent(reaction);
         }
         options.limit ??= 100; // Legacy behavior
@@ -2430,20 +2430,20 @@ class Client extends EventEmitter {
     async getMessages(channelID, options = {}) {
         options.limit ??= 50; // Legacy behavior
         let limit = options.limit;
-        if(limit && limit > 100) {
+        if (limit && limit > 100) {
             let logs = [];
             const get = async (_before, _after) => {
                 const messages = await this.requestHandler.request("GET", Endpoints.CHANNEL_MESSAGES(channelID), true, {
                     limit: 100,
                     before: _before || undefined,
-                    after: _after || undefined
+                    after: _after || undefined,
                 });
-                if(limit <= messages.length) {
+                if (limit <= messages.length) {
                     return (_after ? messages.slice(messages.length - limit, messages.length).map((message) => new Message(message, this)).concat(logs) : logs.concat(messages.slice(0, limit).map((message) => new Message(message, this))));
                 }
                 limit -= messages.length;
                 logs = (_after ? messages.map((message) => new Message(message, this)).concat(logs) : logs.concat(messages.map((message) => new Message(message, this))));
-                if(messages.length < 100) {
+                if (messages.length < 100) {
                     return logs;
                 }
                 this.emit("debug", `Getting ${limit} more messages during getMessages for ${channelID}: ${_before} ${_after}`, -1);
@@ -2455,7 +2455,7 @@ class Client extends EventEmitter {
         return messages.map((message) => {
             try {
                 return new Message(message, this);
-            } catch(err) {
+            } catch (err) {
                 this.emit("error", `Error creating message from channel messages\n${err.stack}\n${JSON.stringify(messages)}`);
                 return null;
             }
@@ -2498,7 +2498,7 @@ class Client extends EventEmitter {
     getPruneCount(guildID, options = {}) {
         return this.requestHandler.request("GET", Endpoints.GUILD_PRUNE(guildID), true, {
             days: options.days,
-            include_roles: options.includeRoles
+            include_roles: options.includeRoles,
         }).then((data) => data.pruned);
     }
 
@@ -2508,7 +2508,7 @@ class Client extends EventEmitter {
     * @returns {Promise<CategoryChannel | PrivateChannel | TextChannel | TextVoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */
     getRESTChannel(channelID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.CHANNEL(channelID), true)
@@ -2522,11 +2522,11 @@ class Client extends EventEmitter {
     * @returns {Promise<Guild>}
     */
     getRESTGuild(guildID, withCounts = false) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {
-            with_counts: withCounts
+            with_counts: withCounts,
         }).then((guild) => new Guild(guild, this));
     }
 
@@ -2536,7 +2536,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<CategoryChannel | TextChannel | TextVoiceChannel | NewsChannel | StageChannel>>}
     */
     getRESTGuildChannels(guildID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_CHANNELS(guildID), true)
@@ -2550,7 +2550,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} An emoji object
     */
     getRESTGuildEmoji(guildID, emojiID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_EMOJI(guildID, emojiID), true);
@@ -2562,7 +2562,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<Object>>} An array of guild emoji objects
     */
     getRESTGuildEmojis(guildID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_EMOJIS(guildID), true);
@@ -2575,7 +2575,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Member>}
     */
     getRESTGuildMember(guildID, memberID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_MEMBER(guildID, memberID), true).then((member) => new Member(member, this.guilds.get(guildID), this));
@@ -2590,7 +2590,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<Member>>}
     */
     getRESTGuildMembers(guildID, options = {}) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_MEMBERS(guildID), true, options).then((members) => members.map((member) => new Member(member, this.guilds.get(guildID), this)));
@@ -2602,7 +2602,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<Role>>}
     */
     getRESTGuildRoles(guildID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_ROLES(guildID), true).then((roles) => roles.map((role) => new Role(role, null)));
@@ -2618,7 +2618,7 @@ class Client extends EventEmitter {
     */
     getRESTGuilds(options = {}) {
         // TODO type
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.USER_GUILDS("@me"), true, options).then((guilds) => guilds.map((guild) => new Guild(guild, this)));
@@ -2633,7 +2633,7 @@ class Client extends EventEmitter {
     * @returns {Promise<GuildScheduledEvent>}
     */
     getRESTGuildScheduledEvent(guildID, eventID, options = {}) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
 
@@ -2648,7 +2648,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} A sticker object
     */
     getRESTGuildSticker(guildID, stickerID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_STICKER(guildID, stickerID), true);
@@ -2660,7 +2660,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Array<Object>>} An array of guild sticker objects
     */
     getRESTGuildStickers(guildID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_STICKERS(guildID), true);
@@ -2672,7 +2672,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} A sticker object
      */
     getRESTSticker(stickerID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.STICKER(stickerID), true);
@@ -2684,7 +2684,7 @@ class Client extends EventEmitter {
     * @returns {Promise<User>}
     */
     getRESTUser(userID) {
-        if(!this.options.restMode) {
+        if (!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.USER(userID), true).then((user) => new User(user, this));
@@ -2698,7 +2698,7 @@ class Client extends EventEmitter {
         return this.requestHandler.request("GET", Endpoints.ROLE_CONNECTION_METADATA(this.application.id), true).then((metadata) => metadata.map((meta) => ({
             ...meta,
             nameLocalizations: meta.name_localizations,
-            descriptionLocalizations: meta.description_localizations
+            descriptionLocalizations: meta.description_localizations,
         })));
     }
 
@@ -2798,17 +2798,17 @@ class Client extends EventEmitter {
     */
     joinVoiceChannel(channelID, options = {}) {
         const channel = this.getChannel(channelID);
-        if(!channel) {
+        if (!channel) {
             return Promise.reject(new Error("Channel not found"));
         }
-        if(channel.guild?.members.has(this.user.id) && !(channel.permissionsOf(this.user.id).allow & Constants.Permissions.voiceConnect)) {
+        if (channel.guild?.members.has(this.user.id) && !(channel.permissionsOf(this.user.id).allow & Constants.Permissions.voiceConnect)) {
             return Promise.reject(new Error("Insufficient permission to connect to voice channel"));
         }
         this.shards.get(this.guildShardMap[this.channelGuildMap[channelID]] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
             guild_id: this.channelGuildMap[channelID] || null,
             channel_id: channelID || null,
             self_mute: options.selfMute || false,
-            self_deaf: options.selfDeaf || false
+            self_deaf: options.selfDeaf || false,
         });
         options.opusOnly ??= this.options.opusOnly;
         return this.voiceConnections.join(this.channelGuildMap[channelID], channelID, options);
@@ -2823,7 +2823,7 @@ class Client extends EventEmitter {
     */
     kickGuildMember(guildID, userID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_MEMBER(guildID, userID), true, {
-            reason
+            reason,
         });
     }
 
@@ -2851,7 +2851,7 @@ class Client extends EventEmitter {
     * @arg {String} channelID The ID of the voice channel
     */
     leaveVoiceChannel(channelID) {
-        if(!channelID || !this.channelGuildMap[channelID]) {
+        if (!channelID || !this.channelGuildMap[channelID]) {
             return;
         }
         this.closeVoiceConnection(this.channelGuildMap[channelID]);
@@ -2882,7 +2882,7 @@ class Client extends EventEmitter {
             days: options.days,
             compute_prune_count: options.computePruneCount,
             include_roles: options.includeRoles,
-            reason: options.reason
+            reason: options.reason,
         }).then((data) => data.pruned);
     }
 
@@ -2898,15 +2898,15 @@ class Client extends EventEmitter {
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
     async purgeChannel(channelID, options) {
-        if(typeof options.filter === "string") {
+        if (typeof options.filter === "string") {
             const filter = options.filter;
             options.filter = (msg) => msg.content.includes(filter);
         }
         let limit = options.limit;
-        if(typeof limit !== "number") {
+        if (typeof limit !== "number") {
             throw new TypeError(`Invalid limit: ${limit}`);
         }
-        if(limit !== -1 && limit <= 0) {
+        if (limit !== -1 && limit <= 0) {
             return 0;
         }
         const toDelete = [];
@@ -2914,15 +2914,15 @@ class Client extends EventEmitter {
         let done = false;
         const checkToDelete = async () => {
             const messageIDs = (done && toDelete) || (toDelete.length >= 100 && toDelete.splice(0, 100));
-            if(messageIDs) {
+            if (messageIDs) {
                 deleted += messageIDs.length;
                 await this.deleteMessages(channelID, messageIDs, options.reason);
-                if(done) {
+                if (done) {
                     return deleted;
                 }
                 await sleep(1000);
                 return checkToDelete();
-            } else if(done) {
+            } else if (done) {
                 return deleted;
             } else {
                 await sleep(250);
@@ -2933,28 +2933,28 @@ class Client extends EventEmitter {
             const messages = await this.getMessages(channelID, {
                 limit: 100,
                 before: _before,
-                after: _after
+                after: _after,
             });
-            if(limit !== -1 && limit <= 0) {
+            if (limit !== -1 && limit <= 0) {
                 done = true;
                 return;
             }
-            for(const message of messages) {
-                if(limit !== -1 && limit <= 0) {
+            for (const message of messages) {
+                if (limit !== -1 && limit <= 0) {
                     break;
                 }
-                if(message.timestamp < Date.now() - 1209600000) { // 14d * 24h * 60m * 60s * 1000ms
+                if (message.timestamp < Date.now() - 1209600000) { // 14d * 24h * 60m * 60s * 1000ms
                     done = true;
                     return;
                 }
-                if(!options.filter || options.filter(message)) {
+                if (!options.filter || options.filter(message)) {
                     toDelete.push(message.id);
                 }
-                if(limit !== -1) {
+                if (limit !== -1) {
                     limit--;
                 }
             }
-            if((limit !== -1 && limit <= 0) || messages.length < 100) {
+            if ((limit !== -1 && limit <= 0) || messages.length < 100) {
                 done = true;
                 return;
             }
@@ -2974,7 +2974,7 @@ class Client extends EventEmitter {
     */
     removeGuildMemberRole(guildID, memberID, roleID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_MEMBER_ROLE(guildID, memberID, roleID), true, {
-            reason
+            reason,
         });
     }
 
@@ -2987,7 +2987,7 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     removeMessageReaction(channelID, messageID, reaction, userID) {
-        if(reaction === decodeURI(reaction)) {
+        if (reaction === decodeURI(reaction)) {
             reaction = encodeURIComponent(reaction);
         }
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_MESSAGE_REACTION_USER(channelID, messageID, reaction, userID || "@me"), true);
@@ -3001,7 +3001,7 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     removeMessageReactionEmoji(channelID, messageID, reaction) {
-        if(reaction === decodeURI(reaction)) {
+        if (reaction === decodeURI(reaction)) {
             reaction = encodeURIComponent(reaction);
         }
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_MESSAGE_REACTION(channelID, messageID, reaction), true);
@@ -3027,7 +3027,7 @@ class Client extends EventEmitter {
     searchGuildMembers(guildID, query, limit) {
         return this.requestHandler.request("GET", Endpoints.GUILD_MEMBERS_SEARCH(guildID), true, {
             query,
-            limit
+            limit,
         }).then((members) => {
             const guild = this.guilds.get(guildID);
             return members.map((member) => new Member(member, guild, this));
@@ -3062,7 +3062,7 @@ class Client extends EventEmitter {
     */
     unbanGuildMember(guildID, userID, reason) {
         return this.requestHandler.request("DELETE", Endpoints.GUILD_BAN(guildID, userID), true, {
-            reason
+            reason,
         });
     }
 
@@ -3077,75 +3077,75 @@ class Client extends EventEmitter {
     }
 
     _formatAllowedMentions(allowed) {
-        if(!allowed) {
+        if (!allowed) {
             return this.options.allowedMentions;
         }
         const result = {
-            parse: []
+            parse: [],
         };
-        if(allowed.everyone) {
+        if (allowed.everyone) {
             result.parse.push("everyone");
         }
-        if(allowed.roles === true) {
+        if (allowed.roles === true) {
             result.parse.push("roles");
-        } else if(Array.isArray(allowed.roles)) {
-            if(allowed.roles.length > 100) {
+        } else if (Array.isArray(allowed.roles)) {
+            if (allowed.roles.length > 100) {
                 throw new Error("Allowed role mentions cannot exceed 100.");
             }
             result.roles = allowed.roles;
         }
-        if(allowed.users === true) {
+        if (allowed.users === true) {
             result.parse.push("users");
-        } else if(Array.isArray(allowed.users)) {
-            if(allowed.users.length > 100) {
+        } else if (Array.isArray(allowed.users)) {
+            if (allowed.users.length > 100) {
                 throw new Error("Allowed user mentions cannot exceed 100.");
             }
             result.users = allowed.users;
         }
-        if(allowed.repliedUser !== undefined) {
+        if (allowed.repliedUser !== undefined) {
             result.replied_user = allowed.repliedUser;
         }
         return result;
     }
 
     _formatImage(url, format, size) {
-        if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
+        if (!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
             format = url.includes("/a_") ? "gif" : this.options.defaultImageFormat;
         }
-        if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
+        if (!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
             size = this.options.defaultImageSize;
         }
         return `${Endpoints.CDN_URL}${url}.${format}?size=${size}`;
     }
 
     _processAttachments(attachments) {
-        if(!attachments) {
+        if (!attachments) {
             return {};
         }
         const files = [];
         const resultAttachments = [];
 
         attachments.forEach((attachment, idx) => {
-            if(attachment.id) {
+            if (attachment.id) {
                 resultAttachments.push(attachment);
             } else {
                 files.push({
                     fieldName: `files[${idx}]`,
                     file: attachment.file,
-                    name: attachment.filename
+                    name: attachment.filename,
                 });
 
                 resultAttachments.push({
                     ...attachment,
                     file: undefined,
-                    id: idx
+                    id: idx,
                 });
             }
         });
 
         return {
             files: files.length ? files : undefined,
-            attachments: resultAttachments
+            attachments: resultAttachments,
         };
     }
 
@@ -3175,7 +3175,7 @@ class Client extends EventEmitter {
             "unavailableGuilds",
             "users",
             "voiceConnections",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -12,7 +12,7 @@ module.exports.ActivityFlags = {
     PLAY:                        1 << 5,
     PARTY_PRIVACY_FRIENDS:       1 << 6,
     PARTY_PRIVACY_VOICE_CHANNEL: 1 << 7,
-    EMBEDDED:                    1 << 8
+    EMBEDDED:                    1 << 8,
 };
 
 module.exports.ActivityTypes = {
@@ -21,7 +21,7 @@ module.exports.ActivityTypes = {
     LISTENING: 2,
     WATCHING:  3,
     CUSTOM:    4,
-    COMPETING: 5
+    COMPETING: 5,
 };
 
 module.exports.ApplicationCommandOptionTypes = {
@@ -35,19 +35,19 @@ module.exports.ApplicationCommandOptionTypes = {
     ROLE:              8,
     MENTIONABLE:       9,
     NUMBER:            10,
-    ATTACHMENT:        11
+    ATTACHMENT:        11,
 };
 
 module.exports.ApplicationCommandPermissionTypes = {
     ROLE:    1,
     USER:    2,
-    CHANNEL: 3
+    CHANNEL: 3,
 };
 
 module.exports.ApplicationCommandTypes = {
     CHAT_INPUT: 1,
     USER:       2,
-    MESSAGE:    3
+    MESSAGE:    3,
 };
 
 module.exports.ApplicationFlags = {
@@ -60,7 +60,7 @@ module.exports.ApplicationFlags = {
     EMBEDDED:                                      1 << 17,
     GATEWAY_MESSAGE_CONTENT:                       1 << 18,
     GATEWAY_MESSAGE_CONTENT_LIMITED:               1 << 19,
-    APPLICATION_COMMAND_BADGE:                     1 << 23
+    APPLICATION_COMMAND_BADGE:                     1 << 23,
 };
 
 module.exports.AuditLogActions = {
@@ -126,11 +126,11 @@ module.exports.AuditLogActions = {
 
     APPLICATION_COMMAND_PERMISSION_UPDATE: 121,
 
-    AUTO_MODERATION_RULE_CREATE:   140,
-    AUTO_MODERATION_RULE_UPDATE:   141,
-    AUTO_MODERATION_RULE_DELETE:   142,
-    AUTO_MODERATION_BLOCK_MESSAGE: 143,
-    AUTO_MODERATION_FLAG_TO_CHANNEL: 144,
+    AUTO_MODERATION_RULE_CREATE:                 140,
+    AUTO_MODERATION_RULE_UPDATE:                 141,
+    AUTO_MODERATION_RULE_DELETE:                 142,
+    AUTO_MODERATION_BLOCK_MESSAGE:               143,
+    AUTO_MODERATION_FLAG_TO_CHANNEL:             144,
     AUTO_MODERATION_USER_COMMUNICATION_DISABLED: 145,
 
     CREATOR_MONETIZATION_REQUEST_CREATED: 150,
@@ -141,30 +141,30 @@ module.exports.AuditLogActions = {
     ROLE_PROMPT_DELETE: 162,
 
     GUILD_HOME_FEATURE_ITEM: 171,
-    GUILD_HOME_REMOVE_ITEM:  172
+    GUILD_HOME_REMOVE_ITEM:  172,
 };
 
 module.exports.AutoModerationActionTypes = {
     BLOCK_MESSAGE:      1,
     SEND_ALERT_MESSAGE: 2,
-    TIMEOUT:            3
+    TIMEOUT:            3,
 };
 
 module.exports.AutoModerationEventTypes = {
-    MESSAGE_SEND: 1
+    MESSAGE_SEND: 1,
 };
 
 module.exports.AutoModerationKeywordPresetTypes = {
     PROFANITY:      1,
     SEXUAL_CONTENT: 2,
-    SLURS:          3
+    SLURS:          3,
 };
 
 module.exports.AutoModerationTriggerTypes = {
     KEYWORD:        1,
     SPAM:           3,
     KEYWORD_PRESET: 4,
-    MENTION_SPAM:   5
+    MENTION_SPAM:   5,
 };
 
 module.exports.ButtonStyles = {
@@ -172,28 +172,28 @@ module.exports.ButtonStyles = {
     SECONDARY: 2,
     SUCCESS:   3,
     DANGER:    4,
-    LINK:      5
+    LINK:      5,
 };
 
 module.exports.ChannelFlags = {
     PINNED:      1 << 1,
-    REQUIRE_TAG: 1 << 4
+    REQUIRE_TAG: 1 << 4,
 };
 
 module.exports.ChannelTypes = {
-    GUILD_TEXT:           0,
-    DM:                   1,
-    GUILD_VOICE:          2,
-    GROUP_DM:             3,
-    GUILD_CATEGORY:       4,
-    GUILD_ANNOUNCEMENT:   5,
-
-    ANNOUNCEMENT_THREAD:  10,
-    PUBLIC_THREAD:        11,
-    PRIVATE_THREAD:       12,
-    GUILD_STAGE_VOICE:    13,
-    GUILD_DIRECTORY:      14,
-    GUILD_FORUM:          15
+    GUILD_TEXT:          0,
+    DM:                  1,
+    GUILD_VOICE:         2,
+    GROUP_DM:            3,
+    GUILD_CATEGORY:      4,
+    GUILD_ANNOUNCEMENT:  5,
+    // non-documented channel types omitted
+    ANNOUNCEMENT_THREAD: 10,
+    PUBLIC_THREAD:       11,
+    PRIVATE_THREAD:      12,
+    GUILD_STAGE_VOICE:   13,
+    GUILD_DIRECTORY:     14,
+    GUILD_FORUM:         15,
 };
 
 module.exports.ComponentTypes = {
@@ -204,29 +204,29 @@ module.exports.ComponentTypes = {
     USER_SELECT:        5,
     ROLE_SELECT:        6,
     MENTIONABLE_SELECT: 7,
-    CHANNEL_SELECT:     8
+    CHANNEL_SELECT:     8,
 };
 
 module.exports.ConnectionVisibilityTypes = {
     NONE:     0,
-    EVERYONE: 1
+    EVERYONE: 1,
 };
 
 module.exports.DefaultMessageNotificationLevels = {
     ALL_MESSAGES:  0,
-    ONLY_MENTIONS: 1
+    ONLY_MENTIONS: 1,
 };
 
 module.exports.ExplicitContentFilterLevels = {
     DISABLED:              0,
     MEMBERS_WITHOUT_ROLES: 1,
-    ALL_MEMBERS:           2
+    ALL_MEMBERS:           2,
 };
 
 module.exports.ForumLayoutTypes = {
     NOT_SET:      0,
     LIST_VIEW:    1,
-    GALLERY_VIEW: 2
+    GALLERY_VIEW: 2,
 };
 
 module.exports.GatewayOPCodes = {
@@ -241,7 +241,7 @@ module.exports.GatewayOPCodes = {
     REQUEST_GUILD_MEMBERS: 8,
     INVALID_SESSION:       9,
     HELLO:                 10,
-    HEARTBEAT_ACK:         11
+    HEARTBEAT_ACK:         11,
 };
 
 module.exports.GuildFeatures = [
@@ -271,25 +271,25 @@ module.exports.GuildFeatures = [
     "VANITY_URL",
     "VERIFIED",
     "VIP_REGIONS",
-    "WELCOME_SCREEN_ENABLED"
+    "WELCOME_SCREEN_ENABLED",
 ];
 
 module.exports.GuildIntegrationExpireBehavior = {
     REMOVE_ROLE: 0,
-    KICK:        1
+    KICK:        1,
 };
 module.exports.GuildIntegrationTypes = [
     "twitch",
     "youtube",
     "discord",
-    "guild_subscription"
+    "guild_subscription",
 ];
 
 module.exports.GuildNSFWLevels = {
     DEFAULT:        0,
     EXPLICIT:       1,
     SAFE:           2,
-    AGE_RESTRICTED: 3
+    AGE_RESTRICTED: 3,
 };
 
 module.exports.ImageFormats = [
@@ -297,12 +297,12 @@ module.exports.ImageFormats = [
     "jpeg",
     "png",
     "webp",
-    "gif"
+    "gif",
 ];
 
 module.exports.ImageSizeBoundaries = {
     MINIMUM: 16,
-    MAXIMUM: 4096
+    MAXIMUM: 4096,
 };
 
 const Intents = {
@@ -324,7 +324,7 @@ const Intents = {
     messageContent:              1 << 15,
     guildScheduledEvents:        1 << 16,
     autoModerationConfiguration: 1 << 20,
-    autoModerationExecution:     1 << 21
+    autoModerationExecution:     1 << 21,
 };
 
 Intents.allNonPrivileged = Intents.guilds
@@ -356,7 +356,7 @@ module.exports.InteractionResponseTypes = {
     DEFERRED_UPDATE_MESSAGE:                 6,
     UPDATE_MESSAGE:                          7,
     APPLICATION_COMMAND_AUTOCOMPLETE_RESULT: 8,
-    MODAL:                                   9
+    MODAL:                                   9,
 };
 
 module.exports.InteractionTypes = {
@@ -364,31 +364,31 @@ module.exports.InteractionTypes = {
     APPLICATION_COMMAND:              2,
     MESSAGE_COMPONENT:                3,
     APPLICATION_COMMAND_AUTOCOMPLETE: 4,
-    MODAL_SUBMIT:                     5
+    MODAL_SUBMIT:                     5,
 };
 
 module.exports.InviteTargetTypes = {
     STREAM:               1,
-    EMBEDDED_APPLICATION: 2
+    EMBEDDED_APPLICATION: 2,
 };
 
 module.exports.MFALevels = {
     NONE:     0,
-    ELEVATED: 1
+    ELEVATED: 1,
 };
 
 module.exports.MemberFlags = {
-    DID_REJOIN:             1 << 0,
-    COMPLETED_ONBOARDING:   1 << 1,
-    BYPASSES_VERIFICATION:  1 << 2,
-    STARTED_ONBOARDING:     1 << 3
+    DID_REJOIN:            1 << 0,
+    COMPLETED_ONBOARDING:  1 << 1,
+    BYPASSES_VERIFICATION: 1 << 2,
+    STARTED_ONBOARDING:    1 << 3,
 };
 
 module.exports.MessageActivityTypes = {
     JOIN:         1,
     SPECTATE:     2,
     LISTEN:       3,
-    JOIN_REQUEST: 5
+    JOIN_REQUEST: 5,
 };
 
 module.exports.MessageFlags = {
@@ -402,7 +402,7 @@ module.exports.MessageFlags = {
     LOADING:                                1 << 7,
     FAILED_TO_MENTION_SOME_ROLES_IN_THREAD: 1 << 8,
     SUPPRESS_NOTIFICATIONS:                 1 << 12,
-    IS_VOICE_MESSAGE:                       1 << 13
+    IS_VOICE_MESSAGE:                       1 << 13,
 };
 
 module.exports.MessageTypes = {
@@ -436,22 +436,22 @@ module.exports.MessageTypes = {
     STAGE_END:                                    28,
     STAGE_SPEAKER:                                29,
     STAGE_TOPIC:                                  31,
-    GUILD_APPLICATION_PREMIUM_SUBSCRIPTION:       32
+    GUILD_APPLICATION_PREMIUM_SUBSCRIPTION:       32,
 };
 
 module.exports.MembershipState = {
     INVITED:  1,
-    ACCEPTED: 2
+    ACCEPTED: 2,
 };
 
 module.exports.OnboardingPromptTypes = {
     MULTIPLE_CHOICE: 0,
-    DROPDOWN:        1
+    DROPDOWN:        1,
 };
 
 module.exports.PermissionOverwriteTypes = {
     ROLE: 0,
-    USER: 1
+    USER: 1,
 };
 
 const Permissions = {
@@ -485,7 +485,7 @@ const Permissions = {
     manageNicknames:                  1n << 27n,
     manageRoles:                      1n << 28n,
     manageWebhooks:                   1n << 29n,
-    manageGuildExpressions:           1n << 30n, manageEmojisAndStickers: 1n << 30n, // [DEPRECATED]
+    manageGuildExpressions:           1n << 30n, manageEmojisAndStickers:          1n << 30n, // [DEPRECATED]
     useApplicationCommands:           1n << 31n,
     voiceRequestToSpeak:              1n << 32n,
     manageEvents:                     1n << 33n,
@@ -498,7 +498,7 @@ const Permissions = {
     moderateMembers:                  1n << 40n,
     viewCreatorMonetizationAnalytics: 1n << 41n,
     useSoundboard:                    1n << 42n,
-    sendVoiceMessages:                1n << 46n
+    sendVoiceMessages:                1n << 46n,
 };
 Permissions.allGuild = Permissions.kickMembers
     | Permissions.banMembers
@@ -558,30 +558,30 @@ module.exports.PremiumTiers = {
     NONE:   0,
     TIER_1: 1,
     TIER_2: 2,
-    TIER_3: 3
+    TIER_3: 3,
 };
 
 module.exports.GuildScheduledEventStatus = {
     SCHEDULED: 1,
     ACTIVE:    2,
     COMPLETED: 3,
-    CANCELED:  4
+    CANCELED:  4,
 };
 
 module.exports.GuildScheduledEventEntityTypes = {
     STAGE_INSTANCE: 1,
     VOICE:          2,
-    EXTERNAL:       3
+    EXTERNAL:       3,
 };
 
 module.exports.GuildScheduledEventPrivacyLevel = {
-    GUILD_ONLY: 2
+    GUILD_ONLY: 2,
 };
 
 module.exports.PremiumTypes = {
     NONE:          0,
     NITRO_CLASSIC: 1,
-    NITRO:         2
+    NITRO:         2,
 };
 
 module.exports.RoleConnectionMetadataTypes = {
@@ -592,24 +592,24 @@ module.exports.RoleConnectionMetadataTypes = {
     DATETIME_LESS_THAN_OR_EQUAL:    5,
     DATETIME_GREATER_THAN_OR_EQUAL: 6,
     BOOLEAN_EQUAL:                  7,
-    BOOLEAN_NOT_EQUAL:              8
+    BOOLEAN_NOT_EQUAL:              8,
 };
 
 module.exports.StageInstancePrivacyLevel = {
     PUBLIC:     1, // [DEPRECATED]
-    GUILD_ONLY: 2
+    GUILD_ONLY: 2,
 };
 
 module.exports.StickerFormats = {
     PNG:    1,
     APNG:   2,
     LOTTIE: 3,
-    GIF:    4
+    GIF:    4,
 };
 
 module.exports.StickerTypes = {
     STANDARD: 1,
-    GUILD:    2
+    GUILD:    2,
 };
 
 module.exports.SystemChannelFlags = {
@@ -618,7 +618,7 @@ module.exports.SystemChannelFlags = {
     SUPPRESS_GUILD_REMINDER_NOTIFICATIONS:                    1 << 2,
     SUPPRESS_JOIN_NOTIFICATION_REPLIES:                       1 << 3,
     SUPPRESS_ROLE_SUBSCRIPTION_PURCHASE_NOTIFICATIONS:        1 << 4,
-    SUPPRESS_ROLE_SUBSCRIPTION_PURCHASE_NOTIFICATION_REPLIES: 1 << 5
+    SUPPRESS_ROLE_SUBSCRIPTION_PURCHASE_NOTIFICATION_REPLIES: 1 << 5,
 };
 
 module.exports.SystemJoinMessages = [
@@ -634,50 +634,50 @@ module.exports.SystemJoinMessages = [
     "Everyone welcome %user%!",
     "Glad you're here, %user%.",
     "Good to see you, %user%.",
-    "Yay you made it, %user%!"
+    "Yay you made it, %user%!",
 ];
 
 module.exports.TextComponentStyle = {
     SMALL:     1,
-    PARAGRAPH: 2
+    PARAGRAPH: 2,
 };
 
 module.exports.ThreadMemberFlags = {
     HAS_INTERACTED: 1 << 0,
     ALL_MESSAGES:   1 << 1,
     ONLY_MENTIONS:  1 << 2,
-    NO_MESSAGES:    1 << 3
+    NO_MESSAGES:    1 << 3,
 };
 
 module.exports.ThreadSortingOrders = {
     LATEST_ACTIVITY: 0,
-    CREATION_DATE:   1
+    CREATION_DATE:   1,
 };
 
 module.exports.TextInputStyles = {
     SHORT:     1,
-    PARAGRAPH: 2
+    PARAGRAPH: 2,
 };
 
 module.exports.UserFlags = {
-    NONE:                         0,
-    STAFF:                        1 << 0,
-    PARTNER:                      1 << 1,
-    HYPESQUAD:                    1 << 2,
-    BUG_HUNTER_LEVEL_1:           1 << 3,
-    HHYPESQUAD_ONLINE_HOUSE_1:    1 << 6,
-    HYPESQUAD_ONLINE_HOUSE_2:     1 << 7,
-    HYPESQUAD_ONLINE_HOUSE_3:     1 << 8,
-    PREMIUM_EARLY_SUPPORTER:      1 << 9,
-    TEAM_PSEUDO_USER:             1 << 10,
-    SYSTEM:                       1 << 12,
-    BUG_HUNTER_LEVEL_2:           1 << 14,
-    VERIFIED_BOT:                 1 << 16,
-    VERIFIED_DEVELOPER:           1 << 17,
-    CERTIFIED_MODERATOR:          1 << 18,
-    BOT_HTTP_INTERACTIONS:        1 << 19,
-    SPAMMER:                      1 << 20,
-    ACTIVE_DEVELOPER:             1 << 22
+    NONE:                      0,
+    STAFF:                     1 << 0,
+    PARTNER:                   1 << 1,
+    HYPESQUAD:                 1 << 2,
+    BUG_HUNTER_LEVEL_1:        1 << 3,
+    HHYPESQUAD_ONLINE_HOUSE_1: 1 << 6,
+    HYPESQUAD_ONLINE_HOUSE_2:  1 << 7,
+    HYPESQUAD_ONLINE_HOUSE_3:  1 << 8,
+    PREMIUM_EARLY_SUPPORTER:   1 << 9,
+    TEAM_PSEUDO_USER:          1 << 10,
+    SYSTEM:                    1 << 12,
+    BUG_HUNTER_LEVEL_2:        1 << 14,
+    VERIFIED_BOT:              1 << 16,
+    VERIFIED_DEVELOPER:        1 << 17,
+    CERTIFIED_MODERATOR:       1 << 18,
+    BOT_HTTP_INTERACTIONS:     1 << 19,
+    SPAMMER:                   1 << 20,
+    ACTIVE_DEVELOPER:          1 << 22,
 };
 
 module.exports.VerificationLevels = {
@@ -685,12 +685,12 @@ module.exports.VerificationLevels = {
     LOW:       1,
     MEDIUM:    2,
     HIGH:      3,
-    VERY_HIGH: 4
+    VERY_HIGH: 4,
 };
 
 module.exports.VideoQualityModes = {
     AUTO: 1,
-    FULL: 2
+    FULL: 2,
 };
 
 module.exports.VoiceOPCodes = {
@@ -704,11 +704,11 @@ module.exports.VoiceOPCodes = {
     RESUME:              7,
     HELLO:               8,
     RESUMED:             9,
-    CLIENT_DISCONNECT:   13
+    CLIENT_DISCONNECT:   13,
 };
 
 module.exports.WebhookTypes = {
     INCOMING:         1,
     CHANNEL_FOLLOWER: 2,
-    APPLICATION:      3
+    APPLICATION:      3,
 };

--- a/lib/errors/DiscordHTTPError.js
+++ b/lib/errors/DiscordHTTPError.js
@@ -6,32 +6,32 @@ class DiscordHTTPError extends Error {
 
         Object.defineProperty(this, "req", {
             enumerable: false,
-            value: req
+            value: req,
         });
         Object.defineProperty(this, "res", {
             enumerable: false,
-            value: res
+            value: res,
         });
         Object.defineProperty(this, "response", {
             enumerable: false,
-            value: response
+            value: response,
         });
 
         Object.defineProperty(this, "code", {
             enumerable: false,
-            value: res.statusCode
+            value: res.statusCode,
         });
         let message = `${res.statusCode} ${res.statusMessage} on ${req.method} ${req.path}`;
         const errors = this.flattenErrors(response);
-        if(errors.length > 0) {
+        if (errors.length > 0) {
             message += "\n  " + errors.join("\n  ");
         }
         Object.defineProperty(this, "message", {
             enumerable: false,
-            value: message
+            value: message,
         });
 
-        if(stack) {
+        if (stack) {
             this.stack = this.name + ": " + this.message + "\n" + stack;
         } else {
             Error.captureStackTrace(this, DiscordHTTPError);
@@ -48,11 +48,11 @@ class DiscordHTTPError extends Error {
 
     flattenErrors(errors, keyPrefix = "") {
         let messages = [];
-        for(const fieldName in errors) {
-            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
+        for (const fieldName in errors) {
+            if (!Object.hasOwn(errors, fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
-            if(Array.isArray(errors[fieldName])) {
+            if (Array.isArray(errors[fieldName])) {
                 messages = messages.concat(errors[fieldName].map((str) => `${keyPrefix + fieldName}: ${str}`));
             }
         }

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -6,36 +6,36 @@ class DiscordRESTError extends Error {
 
         Object.defineProperty(this, "req", {
             enumerable: false,
-            value: req
+            value: req,
         });
         Object.defineProperty(this, "res", {
             enumerable: false,
-            value: res
+            value: res,
         });
         Object.defineProperty(this, "response", {
             enumerable: false,
-            value: response
+            value: response,
         });
 
         Object.defineProperty(this, "code", {
             enumerable: false,
-            value: +response.code || -1
+            value: +response.code || -1,
         });
         let message = response.message || "Unknown error";
-        if(response.errors) {
+        if (response.errors) {
             message += "\n  " + this.flattenErrors(response.errors).join("\n  ");
         } else {
             const errors = this.flattenErrors(response);
-            if(errors.length > 0) {
+            if (errors.length > 0) {
                 message += "\n  " + errors.join("\n  ");
             }
         }
         Object.defineProperty(this, "message", {
             enumerable: false,
-            value: message
+            value: message,
         });
 
-        if(stack) {
+        if (stack) {
             this.stack = this.name + ": " + this.message + "\n" + stack;
         } else {
             Error.captureStackTrace(this, DiscordRESTError);
@@ -52,15 +52,15 @@ class DiscordRESTError extends Error {
 
     flattenErrors(errors, keyPrefix = "") {
         let messages = [];
-        for(const fieldName in errors) {
-            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
+        for (const fieldName in errors) {
+            if (!Object.hasOwn(errors, fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
-            if(errors[fieldName]._errors) {
+            if (errors[fieldName]._errors) {
                 messages = messages.concat(errors[fieldName]._errors.map((obj) => `${keyPrefix + fieldName}: ${obj.message}`));
-            } else if(Array.isArray(errors[fieldName])) {
+            } else if (Array.isArray(errors[fieldName])) {
                 messages = messages.concat(errors[fieldName].map((str) => `${keyPrefix + fieldName}: ${str}`));
-            } else if(typeof errors[fieldName] === "object") {
+            } else if (typeof errors[fieldName] === "object") {
                 messages = messages.concat(this.flattenErrors(errors[fieldName], keyPrefix + fieldName + "."));
             }
         }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -7,7 +7,7 @@ const Channel = require("../structures/Channel");
 const GuildChannel = require("../structures/GuildChannel");
 const Message = require("../structures/Message");
 const PrivateChannel = require("../structures/PrivateChannel");
-const {GATEWAY_VERSION, GatewayOPCodes, ChannelTypes} = require("../Constants");
+const { GATEWAY_VERSION, GatewayOPCodes, ChannelTypes } = require("../Constants");
 const ExtendedUser = require("../structures/ExtendedUser");
 const User = require("../structures/User");
 const Invite = require("../structures/Invite");
@@ -25,21 +25,21 @@ const WebSocket = typeof window !== "undefined" ? require("../util/BrowserWebSoc
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 let Erlpack;
 try {
     Erlpack = require("erlpack");
-} catch{ // eslint-disable no-empty
+} catch { // eslint-disable no-empty
 }
 let ZlibSync;
 try {
     ZlibSync = require("zlib-sync");
-} catch{
+} catch {
     try {
         ZlibSync = require("pako");
-    } catch{ // eslint-disable no-empty
+    } catch { // eslint-disable no-empty
     }
 }
 
@@ -78,8 +78,8 @@ class Shard extends EventEmitter {
     }
 
     checkReady() {
-        if(!this.ready) {
-            if(Object.keys(this.getAllUsersCount).length === 0) {
+        if (!this.ready) {
+            if (Object.keys(this.getAllUsersCount).length === 0) {
                 this.ready = true;
                 /**
                 * Fired when the shard turns ready
@@ -94,7 +94,7 @@ class Shard extends EventEmitter {
     * Tells the shard to connect
     */
     connect() {
-        if(this.ws && this.ws.readyState != WebSocket.CLOSED) {
+        if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
             this.emit("error", new Error("Existing connection detected"), this.id);
             return;
         }
@@ -106,10 +106,10 @@ class Shard extends EventEmitter {
     createGuild(_guild) {
         this.client.guildShardMap[_guild.id] = this.id;
         const guild = this.client.guilds.add(_guild, this.client, true);
-        if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
+        if (this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
             this.getAllUsersCount[guild.id] = true;
             this.requestGuildMembers(guild.id, {
-                presences: this.client.shards.options.intents && this.client.shards.options.intents & Constants.Intents.guildPresences
+                presences: this.client.shards.options.intents && this.client.shards.options.intents & Constants.Intents.guildPresences,
             });
         }
         return guild;
@@ -122,21 +122,21 @@ class Shard extends EventEmitter {
     * @arg {Error} [error] The error that causes the disconnect
     */
     disconnect(options = {}, error) {
-        if(!this.ws) {
+        if (!this.ws) {
             return;
         }
 
-        if(this.heartbeatInterval) {
+        if (this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
         }
 
-        if(this.ws.readyState !== WebSocket.CLOSED) {
+        if (this.ws.readyState !== WebSocket.CLOSED) {
             this.ws.removeListener("message", this.#onWSMessage);
             this.ws.removeListener("close", this.#onWSClose);
             try {
-                if(options.reconnect && this.sessionID) {
-                    if(this.ws.readyState === WebSocket.OPEN) {
+                if (options.reconnect && this.sessionID) {
+                    if (this.ws.readyState === WebSocket.OPEN) {
                         this.ws.close(4901, "Dysnomia: reconnect");
                     } else {
                         this.emit("debug", `Terminating websocket (state: ${this.ws.readyState})`, this.id);
@@ -145,14 +145,14 @@ class Shard extends EventEmitter {
                 } else {
                     this.ws.close(1000, "Dysnomia: normal");
                 }
-            } catch(err) {
+            } catch (err) {
                 this.emit("error", err, this.id);
             }
         }
         this.ws = null;
         this.reset();
 
-        if(error) {
+        if (error) {
             this.emit("error", error, this.id);
         }
 
@@ -163,20 +163,20 @@ class Shard extends EventEmitter {
         */
         super.emit("disconnect", error);
 
-        if(this.sessionID && this.connectAttempts >= this.client.shards.options.maxResumeAttempts) {
+        if (this.sessionID && this.connectAttempts >= this.client.shards.options.maxResumeAttempts) {
             this.emit("debug", `Automatically invalidating session due to excessive resume attempts | Attempt ${this.connectAttempts}`, this.id);
             this.sessionID = null;
             this.resumeURL = null;
         }
 
-        if(options.reconnect === "auto" && this.client.shards.options.autoreconnect) {
+        if (options.reconnect === "auto" && this.client.shards.options.autoreconnect) {
             /**
             * Fired when stuff happens and gives more info
             * @event Client#debug
             * @prop {String} message The debug message
             * @prop {Number} id The ID of the shard
             */
-            if(this.sessionID) {
+            if (this.sessionID) {
                 this.emit("debug", `Immediately reconnecting for potential resume | Attempt ${this.connectAttempts}`, this.id);
                 this.client.shards.connect(this);
             } else {
@@ -186,7 +186,7 @@ class Shard extends EventEmitter {
                 }, this.reconnectInterval);
                 this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
             }
-        } else if(!options.reconnect) {
+        } else if (!options.reconnect) {
             this.hardReset();
         }
     }
@@ -210,20 +210,20 @@ class Shard extends EventEmitter {
     * @arg {String} [activities[].url] The URL of the activity
     */
     editStatus(status, activities) {
-        if(activities === undefined && typeof status === "object") {
+        if (activities === undefined && typeof status === "object") {
             activities = status;
             status = undefined;
         }
-        if(status) {
+        if (status) {
             this.presence.status = status;
         }
-        if(activities === null) {
+        if (activities === null) {
             activities = [];
-        } else if(activities && !Array.isArray(activities)) {
+        } else if (activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        if(activities !== undefined) {
-            if(activities.length > 0 && !activities[0].hasOwnProperty("type")) {
+        if (activities !== undefined) {
+            if (activities.length > 0 && !Object.hasOwn(activities[0], "type")) {
                 activities[0].type = activities[0].url ? 1 : 0;
             }
             this.presence.activities = activities;
@@ -234,7 +234,7 @@ class Shard extends EventEmitter {
 
     emit(event, ...args) {
         this.client.emit.call(this.client, event, ...args);
-        if(event !== "error" || this.listeners("error").length > 0) {
+        if (event !== "error" || this.listeners("error").length > 0) {
             super.emit.call(this, event, ...args);
         }
     }
@@ -249,7 +249,7 @@ class Shard extends EventEmitter {
         this.ws = null;
         this.heartbeatInterval = null;
         this.guildCreateTimeout = null;
-        this.globalBucket = new Bucket(120, 60000, {reservedTokens: 5});
+        this.globalBucket = new Bucket(120, 60000, { reservedTokens: 5 });
         this.presenceUpdateBucket = new Bucket(5, 20000);
         this.presence = JSON.parse(JSON.stringify(this.client.presence)); // Fast copy
         this.#token = this.client._token;
@@ -257,20 +257,20 @@ class Shard extends EventEmitter {
 
     heartbeat(normal) {
         // Can only heartbeat after identify/resume succeeds, session will be killed otherwise, discord/discord-api-docs#1619
-        if(this.status === "resuming" || this.status === "identifying") {
+        if (this.status === "resuming" || this.status === "identifying") {
             return;
         }
-        if(normal) {
-            if(!this.lastHeartbeatAck) {
+        if (normal) {
+            if (!this.lastHeartbeatAck) {
                 this.emit("debug", "Heartbeat timeout; " + JSON.stringify({
                     lastReceived: this.lastHeartbeatReceived,
                     lastSent: this.lastHeartbeatSent,
                     interval: this.heartbeatInterval,
                     status: this.status,
-                    timestamp: Date.now()
+                    timestamp: Date.now(),
                 }));
                 return this.disconnect({
-                    reconnect: "auto"
+                    reconnect: "auto",
                 }, new Error("Server didn't acknowledge previous heartbeat, possible lost connection"));
             }
             this.lastHeartbeatAck = false;
@@ -280,7 +280,7 @@ class Shard extends EventEmitter {
     }
 
     identify() {
-        if(this.client.shards.options.compress && !ZlibSync) {
+        if (this.client.shards.options.compress && !ZlibSync) {
             /**
             * Fired when the shard encounters an error
             * @event Client#error
@@ -300,32 +300,32 @@ class Shard extends EventEmitter {
             properties: {
                 "os": process.platform,
                 "browser": "Dysnomia",
-                "device": "Dysnomia"
-            }
+                "device": "Dysnomia",
+            },
         };
-        if(this.client.shards.options.maxShards > 1) {
+        if (this.client.shards.options.maxShards > 1) {
             identify.shard = [this.id, this.client.shards.options.maxShards];
         }
-        if(this.presence.status) {
+        if (this.presence.status) {
             identify.presence = this.presence;
         }
         this.sendWS(GatewayOPCodes.IDENTIFY, identify);
     }
 
     initializeWS() {
-        if(!this.#token) {
+        if (!this.#token) {
             return this.disconnect(null, new Error("Token not specified"));
         }
 
         this.status = "connecting";
-        if(this.client.shards.options.compress) {
+        if (this.client.shards.options.compress) {
             this.emit("debug", "Initializing zlib-sync-based compression");
             this.#zlibSync = new ZlibSync.Inflate({
-                chunkSize: 128 * 1024
+                chunkSize: 128 * 1024,
             });
         }
-        if(this.sessionID) {
-            if(!this.resumeURL) {
+        if (this.sessionID) {
+            if (!this.resumeURL) {
                 this.emit("warn", "Resume url is not currently present. Discord may disconnect you quicker.");
             }
             this.ws = new WebSocket(this.resumeURL || this.client.gatewayURL, this.client.options.ws);
@@ -338,16 +338,16 @@ class Shard extends EventEmitter {
         this.ws.on("close", this.#onWSClose);
 
         this.connectTimeout = setTimeout(() => {
-            if(this.connecting) {
+            if (this.connecting) {
                 this.disconnect({
-                    reconnect: "auto"
+                    reconnect: "auto",
                 }, new Error("Connection timeout"));
             }
         }, this.client.shards.options.connectionTimeout);
     }
 
     onPacket(packet) {
-        if(this.listeners("rawWS").length > 0 || this.client.listeners("rawWS").length) {
+        if (this.listeners("rawWS").length > 0 || this.client.listeners("rawWS").length) {
             /**
             * Fired when the shard receives a websocket packet
             * @event Client#rawWS
@@ -357,8 +357,8 @@ class Shard extends EventEmitter {
             this.emit("rawWS", packet, this.id);
         }
 
-        if(packet.s) {
-            if(packet.s > this.seq + 1 && this.ws && this.status !== "resuming") {
+        if (packet.s) {
+            if (packet.s > this.seq + 1 && this.ws && this.status !== "resuming") {
                 /**
                 * Fired to warn of something weird but non-breaking happening
                 * @event Client#warn
@@ -370,9 +370,9 @@ class Shard extends EventEmitter {
             this.seq = packet.s;
         }
 
-        switch(packet.op) {
+        switch (packet.op) {
             case GatewayOPCodes.DISPATCH: {
-                if(!this.client.shards.options.disableEvents[packet.t]) {
+                if (!this.client.shards.options.disableEvents[packet.t]) {
                     this.wsEvent(packet);
                 }
                 break;
@@ -392,13 +392,13 @@ class Shard extends EventEmitter {
             case GatewayOPCodes.RECONNECT: {
                 this.emit("debug", "Reconnecting due to server request", this.id);
                 this.disconnect({
-                    reconnect: "auto"
+                    reconnect: "auto",
                 });
                 break;
             }
             case GatewayOPCodes.HELLO: {
-                if(packet.d.heartbeat_interval > 0) {
-                    if(this.heartbeatInterval) {
+                if (packet.d.heartbeat_interval > 0) {
+                    if (this.heartbeatInterval) {
                         clearInterval(this.heartbeatInterval);
                     }
                     this.heartbeatInterval = setInterval(() => this.heartbeat(true), packet.d.heartbeat_interval);
@@ -406,12 +406,12 @@ class Shard extends EventEmitter {
 
                 this.discordServerTrace = packet.d._trace;
                 this.connecting = false;
-                if(this.connectTimeout) {
+                if (this.connectTimeout) {
                     clearTimeout(this.connectTimeout);
                 }
                 this.connectTimeout = null;
 
-                if(this.sessionID) {
+                if (this.sessionID) {
                     this.resume();
                 } else {
                     this.identify();
@@ -447,18 +447,18 @@ class Shard extends EventEmitter {
             user_ids: options?.userIDs,
             query: options?.query,
             nonce: Date.now().toString() + Math.random().toString(36),
-            presences: options?.presences
+            presences: options?.presences,
         };
-        if(!opts.user_ids && !opts.query) {
+        if (!opts.user_ids && !opts.query) {
             opts.query = "";
         }
-        if(!opts.query && !opts.user_ids && (this.client.shards.options.intents && !(this.client.shards.options.intents & Constants.Intents.guildMembers))) {
+        if (!opts.query && !opts.user_ids && (this.client.shards.options.intents && !(this.client.shards.options.intents & Constants.Intents.guildMembers))) {
             throw new Error("Cannot request all members without guildMembers intent");
         }
-        if(opts.presences && (this.client.shards.options.intents && !(this.client.shards.options.intents & Constants.Intents.guildPresences))) {
+        if (opts.presences && (this.client.shards.options.intents && !(this.client.shards.options.intents & Constants.Intents.guildPresences))) {
             throw new Error("Cannot request members presences without guildPresences intent");
         }
-        if(opts.user_ids?.length > 100) {
+        if (opts.user_ids?.length > 100) {
             throw new Error("Cannot request more than 100 users by their ID");
         }
         this.sendWS(GatewayOPCodes.REQUEST_GUILD_MEMBERS, opts);
@@ -469,7 +469,7 @@ class Shard extends EventEmitter {
             timeout: setTimeout(() => {
                 res(this.requestMembersPromise[opts.nonce].members);
                 delete this.requestMembersPromise[opts.nonce];
-            }, options?.timeout || this.client.shards.options.requestTimeout)
+            }, options?.timeout || this.client.shards.options.requestTimeout),
         });
     }
 
@@ -477,9 +477,9 @@ class Shard extends EventEmitter {
         this.connecting = false;
         this.ready = false;
         this.preReady = false;
-        if(this.requestMembersPromise !== undefined) {
-            for(const guildID in this.requestMembersPromise) {
-                if(!this.requestMembersPromise.hasOwnProperty(guildID)) {
+        if (this.requestMembersPromise !== undefined) {
+            for (const guildID in this.requestMembersPromise) {
+                if (!Object.hasOwn(this.requestMembersPromise, guildID)) {
                     continue;
                 }
                 clearTimeout(this.requestMembersPromise[guildID].timeout);
@@ -493,19 +493,19 @@ class Shard extends EventEmitter {
         this.lastHeartbeatReceived = null;
         this.lastHeartbeatSent = null;
         this.status = "disconnected";
-        if(this.connectTimeout) {
+        if (this.connectTimeout) {
             clearTimeout(this.connectTimeout);
         }
         this.connectTimeout = null;
     }
 
     restartGuildCreateTimeout() {
-        if(this.guildCreateTimeout) {
+        if (this.guildCreateTimeout) {
             clearTimeout(this.guildCreateTimeout);
             this.guildCreateTimeout = null;
         }
-        if(!this.ready) {
-            if(this.client.unavailableGuilds.size === 0) {
+        if (!this.ready) {
+            if (this.client.unavailableGuilds.size === 0) {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
@@ -519,7 +519,7 @@ class Shard extends EventEmitter {
         this.sendWS(GatewayOPCodes.RESUME, {
             token: this.#token,
             session_id: this.sessionID,
-            seq: this.seq
+            seq: this.seq,
         });
     }
 
@@ -528,25 +528,25 @@ class Shard extends EventEmitter {
             activities: this.presence.activities,
             afk: !!this.presence.afk,
             since: this.presence.status === "idle" ? Date.now() : null,
-            status: this.presence.status
+            status: this.presence.status,
         });
     }
 
     sendWS(op, _data, priority = false) {
-        if(this.ws?.readyState === WebSocket.OPEN) {
+        if (this.ws?.readyState === WebSocket.OPEN) {
             let i = 0;
             let waitFor = 1;
             const func = () => {
-                if(++i >= waitFor && this.ws?.readyState === WebSocket.OPEN) {
-                    const data = Erlpack ? Erlpack.pack({op: op, d: _data}) : JSON.stringify({op: op, d: _data});
+                if (++i >= waitFor && this.ws?.readyState === WebSocket.OPEN) {
+                    const data = Erlpack ? Erlpack.pack({ op: op, d: _data }) : JSON.stringify({ op: op, d: _data });
                     this.ws.send(data);
-                    if(_data.token) {
+                    if (_data.token) {
                         delete _data.token;
                     }
-                    this.emit("debug", JSON.stringify({op: op, d: _data}), this.id);
+                    this.emit("debug", JSON.stringify({ op: op, d: _data }), this.id);
                 }
             };
-            if(op === GatewayOPCodes.PRESENCE_UPDATE) {
+            if (op === GatewayOPCodes.PRESENCE_UPDATE) {
                 ++waitFor;
                 this.presenceUpdateBucket.queue(func, priority);
             }
@@ -555,10 +555,10 @@ class Shard extends EventEmitter {
     }
 
     wsEvent(packet) {
-        switch(packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
+        switch (packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
             case "AUTO_MODERATION_ACTION_EXECUTION": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in AUTO_MODERATION_ACTION_EXECUTION`);
                     break;
                 }
@@ -580,14 +580,14 @@ class Shard extends EventEmitter {
                     messageID: packet.d.message_id,
                     ruleID: packet.d.rule_id,
                     ruleTriggerType: packet.d.rule_trigger_type,
-                    userID: packet.d.user_id
+                    userID: packet.d.user_id,
                 });
                 break;
             }
 
             case "AUTO_MODERATION_RULE_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in AUTO_MODERATION_RULE_CREATE`);
                     break;
                 }
@@ -603,7 +603,7 @@ class Shard extends EventEmitter {
             }
             case "AUTO_MODERATION_RULE_DELETE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in AUTO_MODERATION_RULE_DELETE`);
                     break;
                 }
@@ -619,7 +619,7 @@ class Shard extends EventEmitter {
             }
             case "AUTO_MODERATION_RULE_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in AUTO_MODERATION_RULE_DELETE`);
                     break;
                 }
@@ -635,17 +635,17 @@ class Shard extends EventEmitter {
                 break;
             }
             case "PRESENCE_UPDATE": {
-                if(packet.d.user.username !== undefined) {
+                if (packet.d.user.username !== undefined) {
                     let user = this.client.users.get(packet.d.user.id);
                     let oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
+                    if (user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
                             username: user.username,
                             discriminator: user.discriminator,
-                            avatar: user.avatar
+                            avatar: user.avatar,
                         };
                     }
-                    if(!user || oldUser) {
+                    if (!user || oldUser) {
                         user = this.client.users.update(packet.d.user, this.client);
                         /**
                         * Fired when a user's avatar, discriminator or username changes
@@ -660,20 +660,20 @@ class Shard extends EventEmitter {
                     }
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user.id);
                 let oldPresence = null;
-                if(member) {
+                if (member) {
                     oldPresence = {
                         activities: member.activities,
                         clientStatus: member.clientStatus,
-                        status: member.status
+                        status: member.status,
                     };
                 }
-                if((!member && packet.d.user.username) || oldPresence) {
+                if ((!member && packet.d.user.username) || oldPresence) {
                     member = guild.members.update(packet.d, guild);
                     /**
                     * Fired when a guild member's status or game changes
@@ -692,26 +692,26 @@ class Shard extends EventEmitter {
                 break;
             }
             case "VOICE_STATE_UPDATE": { // (╯°□°）╯︵ ┻━┻
-                if(packet.d.guild_id && packet.d.user_id === this.client.user.id) {
+                if (packet.d.guild_id && packet.d.user_id === this.client.user.id) {
                     const voiceConnection = this.client.voiceConnections.get(packet.d.guild_id);
-                    if(voiceConnection) {
-                        if(packet.d.channel_id === null) {
+                    if (voiceConnection) {
+                        if (packet.d.channel_id === null) {
                             this.client.voiceConnections.leave(packet.d.guild_id);
-                        } else if(voiceConnection.channelID !== packet.d.channel_id) {
+                        } else if (voiceConnection.channelID !== packet.d.channel_id) {
                             voiceConnection.switchChannel(packet.d.channel_id, true);
                         }
                     }
                 }
-                if(packet.d.self_stream === undefined) {
+                if (packet.d.self_stream === undefined) {
                     packet.d.self_stream = false;
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user_id);
-                if(!member) {
-                    if(!packet.d.member) {
+                if (!member) {
+                    if (!packet.d.member) {
                         this.emit("voiceStateUpdate", {
                             id: packet.d.user_id,
                             voiceState: {
@@ -720,8 +720,8 @@ class Shard extends EventEmitter {
                                 selfDeaf: packet.d.self_deaf,
                                 selfMute: packet.d.self_mute,
                                 selfStream: packet.d.self_stream,
-                                selfVideo: packet.d.self_video
-                            }
+                                selfVideo: packet.d.self_video,
+                            },
                         }, null);
                         break;
                     }
@@ -730,7 +730,7 @@ class Shard extends EventEmitter {
                     member = guild.members.add(packet.d.member, guild);
 
                     const channel = guild.channels.find((channel) => (channel.type === ChannelTypes.GUILD_VOICE || channel.type === ChannelTypes.GUILD_STAGE_VOICE) && channel.voiceMembers.get(packet.d.id));
-                    if(channel) {
+                    if (channel) {
                         channel.voiceMembers.remove(packet.d);
                         this.emit("debug", "VOICE_STATE_UPDATE member null but in channel: " + packet.d.id, this.id);
                     }
@@ -741,21 +741,21 @@ class Shard extends EventEmitter {
                     selfDeaf: member.voiceState.selfDeaf,
                     selfMute: member.voiceState.selfMute,
                     selfStream: member.voiceState.selfStream,
-                    selfVideo: member.voiceState.selfVideo
+                    selfVideo: member.voiceState.selfVideo,
                 };
                 const oldChannelID = member.voiceState.channelID;
                 member.update(packet.d, this.client);
-                if(oldChannelID != packet.d.channel_id) {
+                if (oldChannelID !== packet.d.channel_id) {
                     let oldChannel, newChannel;
-                    if(oldChannelID) {
+                    if (oldChannelID) {
                         oldChannel = guild.channels.get(oldChannelID);
-                        if(oldChannel && oldChannel.type !== ChannelTypes.GUILD_VOICE && oldChannel.type !== ChannelTypes.GUILD_STAGE_VOICE) {
+                        if (oldChannel && oldChannel.type !== ChannelTypes.GUILD_VOICE && oldChannel.type !== ChannelTypes.GUILD_STAGE_VOICE) {
                             this.emit("warn", "Old channel not a recognized voice channel: " + oldChannelID, this.id);
                             oldChannel = null;
                         }
                     }
-                    if(packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && (newChannel.type === ChannelTypes.GUILD_VOICE || newChannel.type === ChannelTypes.GUILD_STAGE_VOICE)) { // Welcome to Discord, where one can "join" text channels
-                        if(oldChannel) {
+                    if (packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && (newChannel.type === ChannelTypes.GUILD_VOICE || newChannel.type === ChannelTypes.GUILD_STAGE_VOICE)) { // Welcome to Discord, where one can "join" text channels
+                        if (oldChannel) {
                             /**
                             * Fired when a guild member switches voice channels
                             * @event Client#voiceChannelSwitch
@@ -774,7 +774,7 @@ class Shard extends EventEmitter {
                             */
                             this.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
-                    } else if(oldChannel) {
+                    } else if (oldChannel) {
                         oldChannel.voiceMembers.remove(member);
                         /**
                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
@@ -785,7 +785,7 @@ class Shard extends EventEmitter {
                         this.emit("voiceChannelLeave", member, oldChannel);
                     }
                 }
-                if(oldState.mute !== member.voiceState.mute || oldState.deaf !== member.voiceState.deaf || oldState.selfMute !== member.voiceState.selfMute || oldState.selfDeaf !== member.voiceState.selfDeaf || oldState.selfStream !== member.voiceState.selfStream || oldState.selfVideo !== member.voiceState.selfVideo) {
+                if (oldState.mute !== member.voiceState.mute || oldState.deaf !== member.voiceState.deaf || oldState.selfMute !== member.voiceState.selfMute || oldState.selfDeaf !== member.voiceState.selfDeaf || oldState.selfStream !== member.voiceState.selfStream || oldState.selfVideo !== member.voiceState.selfVideo) {
                     /**
                     * Fired when a guild member's voice state changes
                     * @event Client#voiceStateUpdate
@@ -805,11 +805,11 @@ class Shard extends EventEmitter {
             case "TYPING_START": {
                 let member = null;
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(guild) {
+                if (guild) {
                     packet.d.member.id = packet.d.user_id;
                     member = guild.members.update(packet.d.member, guild);
                 }
-                if(this.client.listeners("typingStart").length > 0) {
+                if (this.client.listeners("typingStart").length > 0) {
                     /**
                     * Fired when a user begins typing
                     * @event Client#typingStart
@@ -817,15 +817,15 @@ class Shard extends EventEmitter {
                     * @prop {User | Object} user The user. If the user is not cached, this will be an object with an `id` key. No other property is guaranteed
                     * @prop {Member?} member The guild member, if typing in a guild channel, or `null`, if typing in a PrivateChannel
                     */
-                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
+                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || { id: packet.d.channel_id }, this.client.users.get(packet.d.user_id) || { id: packet.d.user_id }, member);
                 }
                 break;
             }
             case "MESSAGE_CREATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(channel) { // MESSAGE_CREATE just when deleting o.o
+                if (channel) { // MESSAGE_CREATE just when deleting o.o
                     channel.lastMessageID = packet.d.id;
-                    if(channel instanceof ThreadChannel) {
+                    if (channel instanceof ThreadChannel) {
                         channel.messageCount++;
                         channel.totalMessageSent++;
                     }
@@ -842,16 +842,16 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_UPDATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     packet.d.channel = {
-                        id: packet.d.channel_id
+                        id: packet.d.channel_id,
                     };
                     this.emit("messageUpdate", packet.d, null);
                     break;
                 }
                 const message = channel.messages.get(packet.d.id);
                 let oldMessage = null;
-                if(message) {
+                if (message) {
                     oldMessage = {
                         attachments: Array.from(message.attachments.values()),
                         channelMentions: message.channelMentions,
@@ -863,9 +863,9 @@ class Shard extends EventEmitter {
                         mentions: message.mentions,
                         pinned: message.pinned,
                         roleMentions: message.roleMentions,
-                        tts: message.tts
+                        tts: message.tts,
                     };
-                } else if(!packet.d.timestamp) {
+                } else if (!packet.d.timestamp) {
                     packet.d.channel = channel;
                     this.emit("messageUpdate", packet.d, null);
                     break;
@@ -892,7 +892,7 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_DELETE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(channel instanceof ThreadChannel) {
+                if (channel instanceof ThreadChannel) {
                     channel.messageCount--;
                 }
 
@@ -905,15 +905,15 @@ class Shard extends EventEmitter {
                     id: packet.d.id,
                     channel: channel || {
                         id: packet.d.channel_id,
-                        guild: packet.d.guild_id ? {id: packet.d.guild_id} : undefined
+                        guild: packet.d.guild_id ? { id: packet.d.guild_id } : undefined,
                     },
-                    guildID: packet.d.guild_id
+                    guildID: packet.d.guild_id,
                 });
                 break;
             }
             case "MESSAGE_DELETE_BULK": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(channel instanceof ThreadChannel) {
+                if (channel instanceof ThreadChannel) {
                     channel.messageCount -= packet.d.ids.length;
                 }
 
@@ -923,11 +923,11 @@ class Shard extends EventEmitter {
                 * @prop {Array<Message> | Array<Object>} messages An array of (potentially partial) message objects. If a message is not cached, it will be an object with `id` and `channel` keys If the uncached messages are from a guild, the messages will also contain a `guildID` key, and the channel will contain a `guild` with an `id` key. No other property is guaranteed
                 */
                 this.emit("messageDeleteBulk", packet.d.ids.map((id) => (channel?.messages.remove({
-                    id
+                    id,
                 }) || {
                     id: id,
-                    channel: {id: packet.d.channel_id, guild: packet.d.guild_id ? {id: packet.d.guild_id} : undefined},
-                    guildID: packet.d.guild_id
+                    channel: { id: packet.d.channel_id, guild: packet.d.guild_id ? { id: packet.d.guild_id } : undefined },
+                    guildID: packet.d.guild_id,
                 })));
                 break;
             }
@@ -935,35 +935,35 @@ class Shard extends EventEmitter {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 let member;
-                if(channel?.guild) {
-                    if(packet.d.member) {
+                if (channel?.guild) {
+                    if (packet.d.member) {
                         // Updates the member cache with this member for future events.
                         packet.d.member.id = packet.d.user_id;
                         member = channel.guild.members.update(packet.d.member, channel.guild);
                     }
                 }
-                if(message) {
+                if (message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if(message.reactions[reaction]) {
+                    if (message.reactions[reaction]) {
                         ++message.reactions[reaction].count;
-                        if(packet.d.user_id === this.client.user.id) {
+                        if (packet.d.user_id === this.client.user.id) {
                             message.reactions[reaction].me = true;
                         }
                     } else {
                         message.reactions[reaction] = {
                             count: 1,
-                            me: packet.d.user_id === this.client.user.id
+                            me: packet.d.user_id === this.client.user.id,
                         };
                     }
                 } else {
                     message = {
                         id: packet.d.message_id,
-                        channel: channel || {id: packet.d.channel_id}
+                        channel: channel || { id: packet.d.channel_id },
                     };
 
-                    if(packet.d.guild_id) {
+                    if (packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
-                        message.channel.guild ??= {id: packet.d.guild_id};
+                        message.channel.guild ??= { id: packet.d.guild_id };
                     }
                 }
                 /**
@@ -976,32 +976,32 @@ class Shard extends EventEmitter {
                 * @prop {String} emoji.name The emoji name
                 * @prop {Member | Object} reactor The member, if the reaction is in a guild. If the reaction is not in a guild, this will be an object with an `id` key. No other property is guaranteed
                 */
-                this.emit("messageReactionAdd", message, packet.d.emoji, member || {id: packet.d.user_id});
+                this.emit("messageReactionAdd", message, packet.d.emoji, member || { id: packet.d.user_id });
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 let message = channel?.messages.get(packet.d.message_id);
-                if(message) {
+                if (message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
                     const reactionObj = message.reactions[reaction];
-                    if(reactionObj) {
+                    if (reactionObj) {
                         --reactionObj.count;
-                        if(reactionObj.count === 0) {
+                        if (reactionObj.count === 0) {
                             delete message.reactions[reaction];
-                        } else if(packet.d.user_id === this.client.user.id) {
+                        } else if (packet.d.user_id === this.client.user.id) {
                             reactionObj.me = false;
                         }
                     }
                 } else {
                     message = {
                         id: packet.d.message_id,
-                        channel: channel || {id: packet.d.channel_id}
+                        channel: channel || { id: packet.d.channel_id },
                     };
 
-                    if(packet.d.guild_id) {
+                    if (packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
-                        message.channel.guild ??= {id: packet.d.guild_id};
+                        message.channel.guild ??= { id: packet.d.guild_id };
                     }
                 }
                 /**
@@ -1020,17 +1020,17 @@ class Shard extends EventEmitter {
             case "MESSAGE_REACTION_REMOVE_ALL": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 let message = channel?.messages.get(packet.d.message_id);
-                if(message) {
+                if (message) {
                     message.reactions = {};
                 }
-                if(!message) {
+                if (!message) {
                     message = {
                         id: packet.d.message_id,
-                        channel: channel || {id: packet.d.channel_id}
+                        channel: channel || { id: packet.d.channel_id },
                     };
-                    if(packet.d.guild_id) {
+                    if (packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
-                        message.channel.guild ??= {id: packet.d.guild_id};
+                        message.channel.guild ??= { id: packet.d.guild_id };
                     }
                 }
                 /**
@@ -1044,18 +1044,18 @@ class Shard extends EventEmitter {
             case "MESSAGE_REACTION_REMOVE_EMOJI": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 let message = channel?.messages.get(packet.d.message_id);
-                if(message) {
+                if (message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
                     delete message.reactions[reaction];
                 }
-                if(!message) {
+                if (!message) {
                     message = {
                         id: packet.d.message_id,
-                        channel: channel || {id: packet.d.channel_id}
+                        channel: channel || { id: packet.d.channel_id },
                     };
-                    if(packet.d.guild_id) {
+                    if (packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
-                        message.channel.guild ??= {id: packet.d.guild_id};
+                        message.channel.guild ??= { id: packet.d.guild_id };
                     }
                 }
                 /**
@@ -1072,7 +1072,7 @@ class Shard extends EventEmitter {
             }
             case "GUILD_MEMBER_ADD": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
+                if (!guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_MEMBER_ADD`);
                     break;
                 }
@@ -1089,36 +1089,36 @@ class Shard extends EventEmitter {
             }
             case "GUILD_MEMBER_UPDATE": {
                 // Check for member update if guildPresences intent isn't set, to prevent emitting twice
-                if(!(this.client.shards.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
+                if (!(this.client.shards.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
                     let user = this.client.users.get(packet.d.user.id);
                     let oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
+                    if (user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
                             username: user.username,
                             discriminator: user.discriminator,
-                            avatar: user.avatar
+                            avatar: user.avatar,
                         };
                     }
-                    if(!user || oldUser) {
+                    if (!user || oldUser) {
                         user = this.client.users.update(packet.d.user, this.client);
                         this.emit("userUpdate", user, oldUser);
                     }
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_MEMBER_UPDATE`);
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user.id);
                 let oldMember = null;
-                if(member) {
+                if (member) {
                     oldMember = {
                         avatar: member.avatar,
                         communicationDisabledUntil: member.communicationDisabledUntil,
                         roles: member.roles,
                         nick: member.nick,
                         premiumSince: member.premiumSince,
-                        pending: member.pending
+                        pending: member.pending,
                     };
                 }
                 member = guild.members.update(packet.d, guild);
@@ -1139,11 +1139,11 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_MEMBER_REMOVE": {
-                if(packet.d.user.id === this.client.user.id) { // The bot is probably leaving
+                if (packet.d.user.id === this.client.user.id) { // The bot is probably leaving
                     break;
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     break;
                 }
                 --guild.memberCount;
@@ -1156,15 +1156,15 @@ class Shard extends EventEmitter {
                 */
                 this.emit("guildMemberRemove", guild, guild.members.remove(packet.d) || {
                     id: packet.d.id,
-                    user: new User(packet.d.user, this.client)
+                    user: new User(packet.d.user, this.client),
                 });
                 break;
             }
             case "GUILD_CREATE": {
-                if(!packet.d.unavailable) {
+                if (!packet.d.unavailable) {
                     const guild = this.createGuild(packet.d);
-                    if(this.ready) {
-                        if(this.client.unavailableGuilds.remove(packet.d)) {
+                    if (this.ready) {
+                        if (this.client.unavailableGuilds.remove(packet.d)) {
                             /**
                             * Fired when a guild becomes available
                             * @event Client#guildAvailable
@@ -1198,7 +1198,7 @@ class Shard extends EventEmitter {
             }
             case "GUILD_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Guild ${packet.d.id} undefined in GUILD_UPDATE`);
                     break;
                 }
@@ -1236,8 +1236,8 @@ class Shard extends EventEmitter {
                     verificationLevel: guild.verificationLevel,
                     welcomeScreen: guild.welcomeScreen && {
                         description: guild.welcomeScreen.description,
-                        welcomeChannels: guild.welcomeScreen.welcomeChannels
-                    }
+                        welcomeChannels: guild.welcomeScreen.welcomeChannels,
+                    },
                 };
                 /**
                 * Fired when a guild is updated
@@ -1279,8 +1279,8 @@ class Shard extends EventEmitter {
             }
             case "GUILD_DELETE": {
                 const voiceConnection = this.client.voiceConnections.get(packet.d.id);
-                if(voiceConnection) {
-                    if(voiceConnection.channelID) {
+                if (voiceConnection) {
+                    if (voiceConnection.channelID) {
                         this.client.leaveVoiceChannel(voiceConnection.channelID);
                     } else {
                         this.client.voiceConnections.leave(packet.d.id);
@@ -1292,7 +1292,7 @@ class Shard extends EventEmitter {
                 guild?.channels.forEach((channel) => {  // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
                     delete this.client.channelGuildMap[channel.id];
                 });
-                if(packet.d.unavailable) {
+                if (packet.d.unavailable) {
                     /**
                     * Fired when a guild becomes unavailable
                     * @event Client#guildUnavailable
@@ -1309,7 +1309,7 @@ class Shard extends EventEmitter {
                     * @prop {Guild | Object} guild The guild. If the guild was not cached, it will be an object with an `id` key. No other property is guaranteed
                     */
                     this.emit("guildDelete", guild || {
-                        id: packet.d.id
+                        id: packet.d.id,
                     });
                 }
                 break;
@@ -1322,7 +1322,7 @@ class Shard extends EventEmitter {
                 * @prop {User} user The banned user
                 */
                 this.emit("guildBanAdd", this.client.guilds.get(packet.d.guild_id) || {
-                    id: packet.d.guild_id
+                    id: packet.d.guild_id,
                 }, this.client.users.update(packet.d.user, this.client));
                 break;
             }
@@ -1334,7 +1334,7 @@ class Shard extends EventEmitter {
                 * @prop {User} user The banned user
                 */
                 this.emit("guildBanRemove", this.client.guilds.get(packet.d.guild_id) || {
-                    id: packet.d.guild_id
+                    id: packet.d.guild_id,
                 }, this.client.users.update(packet.d.user, this.client));
                 break;
             }
@@ -1346,7 +1346,7 @@ class Shard extends EventEmitter {
                 * @prop {Role} role The role
                 */
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_ROLE_CREATE`);
                     break;
                 }
@@ -1355,12 +1355,12 @@ class Shard extends EventEmitter {
             }
             case "GUILD_ROLE_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Guild ${packet.d.guild_id} undefined in GUILD_ROLE_UPDATE`);
                     break;
                 }
                 const role = guild.roles.add(packet.d.role, guild);
-                if(!role) {
+                if (!role) {
                     this.emit("debug", `Role ${packet.d.role} in guild ${packet.d.guild_id} undefined in GUILD_ROLE_UPDATE`);
                     break;
                 }
@@ -1374,7 +1374,7 @@ class Shard extends EventEmitter {
                     permissions: role.permissions,
                     position: role.position,
                     tags: role.tags,
-                    unicodeEmoji: role.unicodeEmoji
+                    unicodeEmoji: role.unicodeEmoji,
                 };
                 /**
                 * Fired when a guild role is updated
@@ -1404,25 +1404,25 @@ class Shard extends EventEmitter {
                 * @prop {Role} role The role
                 */
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_ROLE_DELETE`);
                     break;
                 }
-                if(!guild.roles.has(packet.d.role_id)) {
+                if (!guild.roles.has(packet.d.role_id)) {
                     this.emit("debug", `Missing role ${packet.d.role_id} in GUILD_ROLE_DELETE`);
                     break;
                 }
-                this.emit("guildRoleDelete", guild, guild.roles.remove({id: packet.d.role_id}));
+                this.emit("guildRoleDelete", guild, guild.roles.remove({ id: packet.d.role_id }));
                 break;
             }
             case "INVITE_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_CREATE`);
                     break;
                 }
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_CREATE`);
                     break;
                 }
@@ -1435,18 +1435,18 @@ class Shard extends EventEmitter {
                 this.emit("inviteCreate", guild, new Invite({
                     ...packet.d,
                     guild,
-                    channel
+                    channel,
                 }, this.client));
                 break;
             }
             case "INVITE_DELETE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_DELETE`);
                     break;
                 }
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_DELETE`);
                     break;
                 }
@@ -1459,15 +1459,15 @@ class Shard extends EventEmitter {
                 this.emit("inviteDelete", guild, new Invite({
                     ...packet.d,
                     guild,
-                    channel
+                    channel,
                 }, this.client));
                 break;
             }
             case "CHANNEL_CREATE": {
                 const channel = Channel.from(packet.d, this.client);
-                if(packet.d.guild_id) {
+                if (packet.d.guild_id) {
                     channel.guild ??= this.client.guilds.get(packet.d.guild_id);
-                    if(!channel.guild) {
+                    if (!channel.guild) {
                         this.emit("debug", `Received CHANNEL_CREATE for channel in missing guild ${packet.d.guild_id}`);
                         break;
                     }
@@ -1487,11 +1487,11 @@ class Shard extends EventEmitter {
             }
             case "CHANNEL_UPDATE": {
                 let channel = this.client.getChannel(packet.d.id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 let oldChannel;
-                if(channel instanceof GuildChannel) {
+                if (channel instanceof GuildChannel) {
                     oldChannel = {
                         availableTags: channel.availableTags,
                         bitrate: channel.bitrate,
@@ -1511,26 +1511,26 @@ class Shard extends EventEmitter {
                         topic: channel.topic,
                         type: channel.type,
                         userLimit: channel.userLimit,
-                        videoQualityMode: channel.videoQualityMode
+                        videoQualityMode: channel.videoQualityMode,
                     };
                 } else {
                     this.emit("warn", `Unexpected CHANNEL_UPDATE for channel ${packet.d.id} with type ${oldType}`);
                 }
                 const oldType = channel.type;
-                if(oldType === packet.d.type) {
+                if (oldType === packet.d.type) {
                     channel.update(packet.d);
                 } else {
                     this.emit("debug", `Channel ${packet.d.id} changed from type ${oldType} to ${packet.d.type}`);
                     const newChannel = Channel.from(packet.d, this.client);
-                    if(packet.d.guild_id) {
+                    if (packet.d.guild_id) {
                         const guild = this.client.guilds.get(packet.d.guild_id);
-                        if(!guild) {
+                        if (!guild) {
                             this.emit("debug", `Received CHANNEL_UPDATE for channel in missing guild ${packet.d.guild_id}`);
                             break;
                         }
                         guild.channels.remove(channel);
                         guild.channels.add(newChannel, this.client);
-                    } else if(channel instanceof PrivateChannel) {
+                    } else if (channel instanceof PrivateChannel) {
                         this.client.privateChannels.remove(channel);
                         this.client.privateChannels.add(newChannel, this.client);
                     } else {
@@ -1568,10 +1568,10 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_DELETE": {
-                if(packet.d.type === ChannelTypes.DM || packet.d.type === undefined) {
-                    if(this.id === 0) {
+                if (packet.d.type === ChannelTypes.DM || packet.d.type === undefined) {
+                    if (this.id === 0) {
                         const channel = this.client.privateChannels.remove(packet.d);
-                        if(channel) {
+                        if (channel) {
                             delete this.client.privateChannelMap[channel.recipient.id];
                             /**
                             * Fired when a channel is deleted
@@ -1581,18 +1581,18 @@ class Shard extends EventEmitter {
                             this.emit("channelDelete", channel);
                         }
                     }
-                } else if(packet.d.guild_id) {
+                } else if (packet.d.guild_id) {
                     delete this.client.channelGuildMap[packet.d.id];
                     const guild = this.client.guilds.get(packet.d.guild_id);
-                    if(!guild) {
+                    if (!guild) {
                         this.emit("debug", `Missing guild ${packet.d.guild_id} in CHANNEL_DELETE`);
                         break;
                     }
                     const channel = guild.channels.remove(packet.d);
-                    if(!channel) {
+                    if (!channel) {
                         break;
                     }
-                    if(channel.type === ChannelTypes.GUILD_VOICE || channel.type === ChannelTypes.GUILD_STAGE_VOICE) {
+                    if (channel.type === ChannelTypes.GUILD_VOICE || channel.type === ChannelTypes.GUILD_STAGE_VOICE) {
                         channel.voiceMembers.forEach((member) => {
                             channel.voiceMembers.remove(member);
                             this.emit("voiceChannelLeave", member, channel);
@@ -1606,7 +1606,7 @@ class Shard extends EventEmitter {
             }
             case "GUILD_MEMBERS_CHUNK": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Received GUILD_MEMBERS_CHUNK, but guild ${packet.d.guild_id} is ` + (this.client.unavailableGuilds.has(packet.d.guild_id) ? "unavailable" : "missing"), this.id);
                     break;
                 }
@@ -1621,17 +1621,17 @@ class Shard extends EventEmitter {
                     member?.update(presence);
                 });
 
-                if(this.requestMembersPromise.hasOwnProperty(packet.d.nonce)) {
+                if (Object.hasOwn(this.requestMembersPromise, packet.d.nonce)) {
                     this.requestMembersPromise[packet.d.nonce].members.push(...members);
                 }
 
-                if(packet.d.chunk_index >= packet.d.chunk_count - 1) {
-                    if(this.requestMembersPromise.hasOwnProperty(packet.d.nonce)) {
+                if (packet.d.chunk_index >= packet.d.chunk_count - 1) {
+                    if (Object.hasOwn(this.requestMembersPromise, packet.d.nonce)) {
                         clearTimeout(this.requestMembersPromise[packet.d.nonce].timeout);
                         this.requestMembersPromise[packet.d.nonce].res(this.requestMembersPromise[packet.d.nonce].members);
                         delete this.requestMembersPromise[packet.d.nonce];
                     }
-                    if(this.getAllUsersCount.hasOwnProperty(guild.id)) {
+                    if (Object.hasOwn(this.getAllUsersCount, guild.id)) {
                         delete this.getAllUsersCount[guild.id];
                         this.checkReady();
                     }
@@ -1655,7 +1655,7 @@ class Shard extends EventEmitter {
                 this.reconnectInterval = 1000;
 
                 this.connecting = false;
-                if(this.connectTimeout) {
+                if (this.connectTimeout) {
                     clearTimeout(this.connectTimeout);
                 }
                 this.connectTimeout = null;
@@ -1663,7 +1663,7 @@ class Shard extends EventEmitter {
                 this.presence.status = "online";
                 this.client.shards._readyPacketCB(this.id);
 
-                if(packet.t === "RESUMED") {
+                if (packet.t === "RESUMED") {
                     // Can only heartbeat after resume succeeds, discord/discord-api-docs#1619
                     this.heartbeat();
 
@@ -1679,24 +1679,24 @@ class Shard extends EventEmitter {
                 } else {
                     this.resumeURL = `${packet.d.resume_gateway_url}?v=${Constants.GATEWAY_VERSION}&encoding=${Erlpack ? "etf" : "json"}`;
 
-                    if(this.client.options.compress) {
+                    if (this.client.options.compress) {
                         this.resumeURL += "&compress=zlib-stream";
                     }
                 }
 
                 this.client.user = this.client.users.update(new ExtendedUser(packet.d.user, this.client), this.client);
-                if(!this.client._token.startsWith("Bot ")) {
+                if (!this.client._token.startsWith("Bot ")) {
                     this.client._token = "Bot " + this.client._token;
                 }
 
-                if(packet.d._trace) {
+                if (packet.d._trace) {
                     this.discordServerTrace = packet.d._trace;
                 }
 
                 this.sessionID = packet.d.session_id;
 
                 packet.d.guilds.forEach((guild) => {
-                    if(guild.unavailable) {
+                    if (guild.unavailable) {
                         this.client.guilds.remove(guild);
                         this.client.unavailableGuilds.add(guild, this.client, true);
                     } else {
@@ -1714,7 +1714,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("shardPreReady", this.id);
 
-                if(this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
+                if (this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
                     this.restartGuildCreateTimeout();
                 } else {
                     this.checkReady();
@@ -1732,11 +1732,11 @@ class Shard extends EventEmitter {
             case "USER_UPDATE": {
                 let user = this.client.users.get(packet.d.id);
                 let oldUser = null;
-                if(user) {
+                if (user) {
                     oldUser = {
                         username: user.username,
                         discriminator: user.discriminator,
-                        avatar: user.avatar
+                        avatar: user.avatar,
                     };
                 }
                 user = this.client.users.update(packet.d, this.client);
@@ -1747,7 +1747,7 @@ class Shard extends EventEmitter {
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 let oldEmojis = null;
                 let emojis = packet.d.emojis;
-                if(guild) {
+                if (guild) {
                     oldEmojis = guild.emojis;
                     guild.update(packet.d);
                     emojis = guild.emojis;
@@ -1759,14 +1759,14 @@ class Shard extends EventEmitter {
                 * @prop {Array} emojis The updated emojis of the guild
                 * @prop {Array?} oldEmojis The old emojis of the guild. If the guild is uncached, this will be null
                 */
-                this.emit("guildEmojisUpdate", guild || {id: packet.d.guild_id}, emojis, oldEmojis);
+                this.emit("guildEmojisUpdate", guild || { id: packet.d.guild_id }, emojis, oldEmojis);
                 break;
             }
             case "GUILD_STICKERS_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 let oldStickers = null;
                 let stickers = packet.d.stickers;
-                if(guild) {
+                if (guild) {
                     oldStickers = guild.stickers;
                     guild.update(packet.d);
                     stickers = guild.stickers;
@@ -1778,12 +1778,12 @@ class Shard extends EventEmitter {
                 * @prop {Array} stickers The updated stickers of the guild
                 * @prop {Array?} oldStickers The old stickers of the guild. If the guild is uncached, this will be null
                 */
-                this.emit("guildStickersUpdate", guild || {id: packet.d.guild_id}, stickers, oldStickers);
+                this.emit("guildStickersUpdate", guild || { id: packet.d.guild_id }, stickers, oldStickers);
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     this.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;
                 }
@@ -1809,19 +1809,19 @@ class Shard extends EventEmitter {
                 */
                 this.emit("webhooksUpdate", {
                     channelID: packet.d.channel_id,
-                    guildID: packet.d.guild_id
+                    guildID: packet.d.guild_id,
                 });
                 break;
             }
             case "THREAD_CREATE": {
                 const channel = Channel.from(packet.d, this.client);
                 channel.guild ??= this.client.guilds.get(packet.d.guild_id);
-                if(!channel.guild) {
+                if (!channel.guild) {
                     this.emit("debug", `Received THREAD_CREATE for channel in missing guild ${packet.d.guild_id}`);
                     break;
                 }
                 const parent = this.client.getChannel(packet.d.parent_id);
-                if(parent?.type === ChannelTypes.GUILD_FORUM) {
+                if (parent?.type === ChannelTypes.GUILD_FORUM) {
                     parent.lastThreadID = packet.d.id;
                 }
 
@@ -1837,13 +1837,13 @@ class Shard extends EventEmitter {
             }
             case "THREAD_UPDATE": {
                 const channel = this.client.getChannel(packet.d.id);
-                if(!channel) {
+                if (!channel) {
                     const thread = Channel.from(packet.d, this.client);
                     this.emit("threadUpdate", this.client.guilds.get(packet.d.guild_id).threads.add(thread, this.client), null);
                     this.client.threadGuildMap[packet.d.id] = packet.d.guild_id;
                     break;
                 }
-                if(!(channel instanceof ThreadChannel)) {
+                if (!(channel instanceof ThreadChannel)) {
                     this.emit("warn", `Unexpected THREAD_UPDATE for channel ${packet.d.id} with type ${channel.type}`);
                     break;
                 }
@@ -1852,7 +1852,7 @@ class Shard extends EventEmitter {
                     flags: channel.flags,
                     name: channel.name,
                     rateLimitPerUser: channel.rateLimitPerUser,
-                    threadMetadata: channel.threadMetadata
+                    threadMetadata: channel.threadMetadata,
                 };
                 channel.update(packet.d);
 
@@ -1877,12 +1877,12 @@ class Shard extends EventEmitter {
             case "THREAD_DELETE": {
                 delete this.client.threadGuildMap[packet.d.id];
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in THREAD_DELETE`);
                     break;
                 }
                 const channel = guild.threads.remove(packet.d);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 /**
@@ -1895,12 +1895,12 @@ class Shard extends EventEmitter {
             }
             case "THREAD_LIST_SYNC": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in THREAD_LIST_SYNC`);
                     break;
                 }
                 const deletedThreads = (packet.d.channel_ids || guild.threads.map((c) => c.id)) // REVIEW Is this a good name?
-                    .filter((c) => !packet.d.threads.some((t) => t.id === c)).map((id) => guild.threads.remove({id}) || {id});
+                    .filter((c) => !packet.d.threads.some((t) => t.id === c)).map((id) => guild.threads.remove({ id }) || { id });
                 const activeThreads = packet.d.threads.map((t) => guild.threads.update(t, this.client));
                 const joinedThreadsMember = packet.d.members.map((m) => guild.threads.get(m.id).members.update(m, this.client));
                 /**
@@ -1916,7 +1916,7 @@ class Shard extends EventEmitter {
             }
             case "THREAD_MEMBER_UPDATE": {
                 const channel = this.client.getChannel(packet.d.id);
-                if(!channel) {
+                if (!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBER_UPDATE`);
                     break;
                 }
@@ -1924,9 +1924,9 @@ class Shard extends EventEmitter {
                 // Thanks Discord
                 packet.d.thread_id = packet.d.id;
                 let member = channel.members.get((packet.d.id = packet.d.user_id));
-                if(member) {
+                if (member) {
                     oldMember = {
-                        flags: member.flags
+                        flags: member.flags,
                     };
                 }
                 member = channel.members.update(packet.d, this.client);
@@ -1943,13 +1943,13 @@ class Shard extends EventEmitter {
             }
             case "THREAD_MEMBERS_UPDATE": {
                 const channel = this.client.getChannel(packet.d.id);
-                if(!channel) {
+                if (!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBERS_UPDATE`);
                     break;
                 }
                 channel.update(packet.d);
                 const addedMembers = packet.d.added_members?.map((m) => {
-                    if(m.presence) {
+                    if (m.presence) {
                         m.presence.id = m.presence.user.id;
                         this.client.users.update(m.presence.user, this.client);
                     }
@@ -1958,15 +1958,15 @@ class Shard extends EventEmitter {
                     m.id = m.user_id;
                     m.member.id = m.member.user.id;
                     const guild = this.client.guilds.get(packet.d.guild_id);
-                    if(guild) {
-                        if(m.presence) {
+                    if (guild) {
+                        if (m.presence) {
                             guild.members.update(m.presence, guild);
                         }
                         guild.members.update(m.member, guild);
                     }
                     return channel.members.update(m, this.client);
                 });
-                const removedMembers = packet.d.removed_member_ids?.map((id) => channel.members.remove({id}) || {id});
+                const removedMembers = packet.d.removed_member_ids?.map((id) => channel.members.remove({ id }) || { id });
                 /**
                 * Fired when anyone is added or removed from a thread. If the `guildMembers` intent is not specified, this will only apply for the current user
                 * @event Client#threadMembersUpdate
@@ -1979,7 +1979,7 @@ class Shard extends EventEmitter {
             }
             case "STAGE_INSTANCE_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in STAGE_INSTANCE_CREATE`);
                     break;
                 }
@@ -1993,17 +1993,17 @@ class Shard extends EventEmitter {
             }
             case "STAGE_INSTANCE_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("stageInstanceUpdate", packet.d, null);
                     break;
                 }
                 const stageInstance = guild.stageInstances.get(packet.d.id);
                 let oldStageInstance = null;
-                if(stageInstance) {
+                if (stageInstance) {
                     oldStageInstance = {
                         discoverableDisabled: stageInstance.discoverableDisabled,
                         privacyLevel: stageInstance.privacyLevel,
-                        topic: stageInstance.topic
+                        topic: stageInstance.topic,
                     };
                 }
                 /**
@@ -2020,7 +2020,7 @@ class Shard extends EventEmitter {
             }
             case "STAGE_INSTANCE_DELETE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("stageInstanceDelete", new StageInstance(packet.d, this.client));
                     break;
                 }
@@ -2038,12 +2038,12 @@ class Shard extends EventEmitter {
                 * @event Client#guildIntegrationsUpdate
                 * @prop {Guild} guild The guild where the integration was updated. If the guild isn't cached, this will be an object with an `id` key. No other properties are guaranteed
                 */
-                this.emit("guildIntegrationsUpdate", this.client.guilds.get(packet.d.guild_id) || {id: packet.d.guild_id});
+                this.emit("guildIntegrationsUpdate", this.client.guilds.get(packet.d.guild_id) || { id: packet.d.guild_id });
                 break;
             }
             case "GUILD_SCHEDULED_EVENT_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("guildScheduledEventCreate", new GuildScheduledEvent(packet.d, this.client));
                     break;
                 }
@@ -2058,14 +2058,14 @@ class Shard extends EventEmitter {
             }
             case "GUILD_SCHEDULED_EVENT_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("guildScheduledEventUpdate", new GuildScheduledEvent(packet.d, this.client), null);
                     break;
                 }
 
                 const event = guild.events.get(packet.d.id);
                 let oldEvent = null;
-                if(event) {
+                if (event) {
                     oldEvent = {
                         channel: event.channel,
                         description: event.description,
@@ -2077,7 +2077,7 @@ class Shard extends EventEmitter {
                         privacyLevel: event.privacyLevel,
                         scheduledEndTime: event.scheduledEndTime,
                         scheduledStartTime: event.scheduledStartTime,
-                        status: event.status
+                        status: event.status,
                     };
                 }
 
@@ -2104,7 +2104,7 @@ class Shard extends EventEmitter {
             }
             case "GUILD_SCHEDULED_EVENT_DELETE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.emit("guildScheduledEventDelete", new GuildScheduledEvent(packet.d, this.client));
                     break;
                 }
@@ -2117,16 +2117,16 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_SCHEDULED_EVENT_USER_ADD": {
-                const user = this.client.users.get(packet.d.user_id) || {id: packet.d.user_id};
+                const user = this.client.users.get(packet.d.user_id) || { id: packet.d.user_id };
 
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
-                    this.emit("guildScheduledEventUserAdd", {id: packet.d.guild_scheduled_event_id, guild: {id: packet.d.guild_id}}, user);
+                if (!guild) {
+                    this.emit("guildScheduledEventUserAdd", { id: packet.d.guild_scheduled_event_id, guild: { id: packet.d.guild_id } }, user);
                     break;
                 }
 
                 const event = guild.events.get(packet.d.guild_scheduled_event_id);
-                if(event) {
+                if (event) {
                     ++event.userCount;
                 }
 
@@ -2136,20 +2136,20 @@ class Shard extends EventEmitter {
                 * @prop {GuildScheduledEvent | Object} event The guild event that the user subscribed to. If the event is uncached, this will be an object with `id` and `guild` keys. No other property is guaranteed
                 * @prop {User | Object} user The user that subscribed to the Guild Event. If the user is uncached, this will be an object with an `id` key. No other property is guaranteed
                 */
-                this.emit("guildScheduledEventUserAdd", event || {id: packet.d.guild_scheduled_event_id, guild: guild}, user);
+                this.emit("guildScheduledEventUserAdd", event || { id: packet.d.guild_scheduled_event_id, guild: guild }, user);
                 break;
             }
             case "GUILD_SCHEDULED_EVENT_USER_REMOVE": {
-                const user = this.client.users.get(packet.d.user_id) || {id: packet.d.user_id};
+                const user = this.client.users.get(packet.d.user_id) || { id: packet.d.user_id };
 
                 const guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
-                    this.emit("guildScheduledEventUserRemove", {id: packet.d.guild_scheduled_event_id, guild: {id: packet.d.guild_id}}, user);
+                if (!guild) {
+                    this.emit("guildScheduledEventUserRemove", { id: packet.d.guild_scheduled_event_id, guild: { id: packet.d.guild_id } }, user);
                     break;
                 }
 
                 const event = guild.events.get(packet.d.guild_scheduled_event_id);
-                if(event) {
+                if (event) {
                     --event.userCount;
                 }
 
@@ -2159,7 +2159,7 @@ class Shard extends EventEmitter {
                 * @prop {GuildScheduledEvent | string} event The guild event that the user unsubscribed to. This will be the guild event ID if the guild was uncached
                 * @prop {User | string} user The user that unsubscribed to the Guild Event. This will be the user ID if the user was uncached
                 */
-                this.emit("guildScheduledEventUserRemove", event || {id: packet.d.guild_scheduled_event_id, guild: guild}, user);
+                this.emit("guildScheduledEventUserRemove", event || { id: packet.d.guild_scheduled_event_id, guild: guild }, user);
                 break;
             }
             case "INTERACTION_CREATE": {
@@ -2183,7 +2183,7 @@ class Shard extends EventEmitter {
             case "GUILD_AUDIT_LOG_ENTRY_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
 
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_AUDIT_LOG_ENTRY_CREATE`);
                     break;
                 }
@@ -2199,7 +2199,7 @@ class Shard extends EventEmitter {
             case "INTEGRATION_CREATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
 
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INTEGRAITON_CREATE`);
                     break;
                 }
@@ -2216,7 +2216,7 @@ class Shard extends EventEmitter {
             case "INTEGRATION_UPDATE": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
 
-                if(!guild) {
+                if (!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INTEGRATION_UPDATE`);
                     break;
                 }
@@ -2242,10 +2242,10 @@ class Shard extends EventEmitter {
                  * @prop {String} integration.id The integrationID
                  */
                 this.emit("integrationDelete", guild || {
-                    id: packet.d.guild_id
+                    id: packet.d.guild_id,
                 }, {
                     applicationID: packet.d.application_id,
-                    id: packet.d.id
+                    id: packet.d.id,
                 });
                 break;
             }
@@ -2267,70 +2267,70 @@ class Shard extends EventEmitter {
         this.emit("debug", "WS disconnected: " + JSON.stringify({
             code: code,
             reason: reason,
-            status: this.status
+            status: this.status,
         }));
         let err = !code || code === 1000 ? null : new Error(code + ": " + reason);
         let reconnect = "auto";
-        if(code) {
+        if (code) {
             this.emit("debug", `${code === 1000 ? "Clean" : "Unclean"} WS close: ${code}: ${reason}`, this.id);
-            if(code === 4001) {
+            if (code === 4001) {
                 err = new Error("Gateway received invalid OP code");
-            } else if(code === 4002) {
+            } else if (code === 4002) {
                 err = new Error("Gateway received invalid message");
-            } else if(code === 4003) {
+            } else if (code === 4003) {
                 err = new Error("Not authenticated");
                 this.sessionID = null;
                 this.resumeURL = null;
-            } else if(code === 4004) {
+            } else if (code === 4004) {
                 err = new Error("Authentication failed");
                 this.sessionID = null;
                 this.resumeURL = null;
                 reconnect = false;
                 this.emit("error", new Error(`Invalid token: ${this.#token}`));
-            } else if(code === 4005) {
+            } else if (code === 4005) {
                 err = new Error("Already authenticated");
-            } else if(code === 4006 || code === 4009) {
+            } else if (code === 4006 || code === 4009) {
                 err = new Error("Invalid session");
                 this.sessionID = null;
                 this.resumeURL = null;
-            } else if(code === 4007) {
+            } else if (code === 4007) {
                 err = new Error("Invalid sequence number: " + this.seq);
                 this.seq = 0;
-            } else if(code === 4008) {
+            } else if (code === 4008) {
                 err = new Error("Gateway connection was ratelimited");
-            } else if(code === 4010) {
+            } else if (code === 4010) {
                 err = new Error("Invalid shard key");
                 this.sessionID = null;
                 this.resumeURL = null;
                 reconnect = false;
-            } else if(code === 4011) {
+            } else if (code === 4011) {
                 err = new Error("Shard has too many guilds (>2500)");
                 this.sessionID = null;
                 this.resumeURL = null;
                 reconnect = false;
-            } else if(code === 4013) {
+            } else if (code === 4013) {
                 err = new Error("Invalid intents specified");
                 this.sessionID = null;
                 this.resumeURL = null;
                 reconnect = false;
-            } else if(code === 4014) {
+            } else if (code === 4014) {
                 err = new Error("Disallowed intents specified");
                 this.sessionID = null;
                 this.resumeURL = null;
                 reconnect = false;
-            } else if(code === 1006) {
+            } else if (code === 1006) {
                 err = new Error("Connection reset by peer");
-            } else if(code !== 1000 && reason) {
+            } else if (code !== 1000 && reason) {
                 err = new Error(code + ": " + reason);
             }
-            if(err) {
+            if (err) {
                 err.code = code;
             }
         } else {
             this.emit("debug", "WS close: unknown code: " + reason, this.id);
         }
         this.disconnect({
-            reconnect
+            reconnect,
         }, err);
     }
 
@@ -2340,17 +2340,17 @@ class Shard extends EventEmitter {
 
     #onWSMessageUnbound(data) {
         try {
-            if(data instanceof ArrayBuffer) {
-                if(this.client.shards.options.compress || Erlpack) {
+            if (data instanceof ArrayBuffer) {
+                if (this.client.shards.options.compress || Erlpack) {
                     data = Buffer.from(data);
                 }
-            } else if(Array.isArray(data)) { // Fragmented messages
+            } else if (Array.isArray(data)) { // Fragmented messages
                 data = Buffer.concat(data); // Copyfull concat is slow, but no alternative
             }
-            if(this.client.shards.options.compress) {
-                if(data.length >= 4 && data.readUInt32BE(data.length - 4) === 0xFFFF) {
+            if (this.client.shards.options.compress) {
+                if (data.length >= 4 && data.readUInt32BE(data.length - 4) === 0xFFFF) {
                     this.#zlibSync.push(data, ZlibSync.Z_SYNC_FLUSH);
-                    if(this.#zlibSync.err) {
+                    if (this.#zlibSync.err) {
                         this.emit("error", new Error(`zlib error ${this.#zlibSync.err}: ${this.#zlibSync.msg}`));
                         return;
                     }
@@ -2358,12 +2358,12 @@ class Shard extends EventEmitter {
                     data = Buffer.from(this.#zlibSync.result);
 
                     try {
-                        if(Erlpack) {
+                        if (Erlpack) {
                             data = Erlpack.unpack(data);
                         } else {
                             data = JSON.parse(data.toString());
                         }
-                    } catch(err) {
+                    } catch (err) {
                         this.emit("error", Error(`parsing error: ${err.message}`));
                         return;
                     }
@@ -2372,12 +2372,12 @@ class Shard extends EventEmitter {
                 } else {
                     this.#zlibSync.push(data, false);
                 }
-            } else if(Erlpack) {
+            } else if (Erlpack) {
                 return this.onPacket(Erlpack.unpack(data));
             } else {
                 return this.onPacket(JSON.parse(data.toString()));
             }
-        } catch(err) {
+        } catch (err) {
             this.emit("error", err, this.id);
         }
     }
@@ -2417,7 +2417,7 @@ class Shard extends EventEmitter {
             "sessionID",
             "reconnectInterval",
             "connectAttempts",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -7,48 +7,48 @@ const Constants = require("../Constants");
 let ZlibSync;
 try {
     ZlibSync = require("zlib-sync");
-} catch{
+} catch {
     try {
         ZlibSync = require("pako");
-    } catch{ // eslint-disable no-empty
+    } catch { // eslint-disable no-empty
     }
 }
 class ShardManager extends Collection {
-    #client;
     buckets = new Map();
     connectQueue = [];
     connectTimeout = null;
+    #client;
 
     constructor(client, options = {}) {
         super(Shard);
         this.#client = client;
         this.options = Object.assign({
-            autoreconnect:        true,
-            compress:             false,
-            connectionTimeout:    30000,
-            disableEvents:        {},
-            firstShardID:         0,
-            getAllUsers:          false,
-            guildCreateTimeout:   2000,
-            intents:              Constants.Intents.allNonPrivileged,
-            largeThreshold:       250,
+            autoreconnect: true,
+            compress: false,
+            connectionTimeout: 30000,
+            disableEvents: {},
+            firstShardID: 0,
+            getAllUsers: false,
+            guildCreateTimeout: 2000,
+            intents: Constants.Intents.allNonPrivileged,
+            largeThreshold: 250,
             maxReconnectAttempts: Infinity,
-            maxResumeAttempts:    10,
-            maxConcurrency:       1,
-            maxShards:            1,
+            maxResumeAttempts: 10,
+            maxConcurrency: 1,
+            maxShards: 1,
             seedVoiceConnections: false,
-            requestTimeout:       15000,
-            reconnectDelay:       ((lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000)
+            requestTimeout: 15000,
+            reconnectDelay: ((lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000),
         }, options);
 
-        if(typeof this.options.intents !== "undefined") {
+        if (typeof this.options.intents !== "undefined") {
             // Resolve intents option to the proper integer
-            if(Array.isArray(this.options.intents)) {
+            if (Array.isArray(this.options.intents)) {
                 let bitmask = 0;
-                for(const intent of this.options.intents) {
-                    if(Constants.Intents[intent]) {
+                for (const intent of this.options.intents) {
+                    if (Constants.Intents[intent]) {
                         bitmask |= Constants.Intents[intent];
-                    } else if(typeof intent === "number") {
+                    } else if (typeof intent === "number") {
                         bitmask |= intent;
                     } else {
                         this.#client.emit("warn", `Unknown intent: ${intent}`);
@@ -58,16 +58,16 @@ class ShardManager extends Collection {
             }
 
             // Ensure requesting all guild members isn't destined to fail
-            if(this.options.getAllUsers && !(this.options.intents & Constants.Intents.guildMembers)) {
+            if (this.options.getAllUsers && !(this.options.intents & Constants.Intents.guildMembers)) {
                 throw new Error("Cannot request all members without guildMembers intent");
             }
         }
 
-        if(this.options.lastShardID === undefined && this.options.maxShards !== "auto") {
+        if (this.options.lastShardID === undefined && this.options.maxShards !== "auto") {
             this.options.lastShardID = this.options.maxShards - 1;
         }
 
-        if(typeof window !== "undefined" || !ZlibSync) {
+        if (typeof window !== "undefined" || !ZlibSync) {
             this.options.compress = false; // zlib does not like Blobs, Pako is not here
         }
     }
@@ -79,7 +79,7 @@ class ShardManager extends Collection {
 
     spawn(id) {
         let shard = this.get(id);
-        if(!shard) {
+        if (!shard) {
             shard = this.add(new Shard(id, this.#client));
             shard.on("ready", () => {
                 /**
@@ -88,11 +88,11 @@ class ShardManager extends Collection {
                 * @prop {Number} id The ID of the shard
                 */
                 this.#client.emit("shardReady", shard.id);
-                if(this.#client.ready) {
+                if (this.#client.ready) {
                     return;
                 }
-                for(const other of this.values()) {
-                    if(!other.ready) {
+                for (const other of this.values()) {
+                    if (!other.ready) {
                         return;
                     }
                 }
@@ -110,11 +110,11 @@ class ShardManager extends Collection {
                 * @prop {Number} id The ID of the shard
                 */
                 this.#client.emit("shardResume", shard.id);
-                if(this.#client.ready) {
+                if (this.#client.ready) {
                     return;
                 }
-                for(const other of this.values()) {
-                    if(!other.ready) {
+                for (const other of this.values()) {
+                    if (!other.ready) {
                         return;
                     }
                 }
@@ -129,8 +129,8 @@ class ShardManager extends Collection {
                 * @prop {Number} id The ID of the shard
                 */
                 this.#client.emit("shardDisconnect", error, shard.id);
-                for(const other of this.values()) {
-                    if(other.ready) {
+                for (const other of this.values()) {
+                    if (other.ready) {
                         return;
                     }
                 }
@@ -143,31 +143,31 @@ class ShardManager extends Collection {
                 this.#client.emit("disconnect");
             });
         }
-        if(shard.status === "disconnected") {
+        if (shard.status === "disconnected") {
             return this.connect(shard);
         }
     }
 
     tryConnect() {
         // nothing in queue
-        if(this.connectQueue.length === 0) {
+        if (this.connectQueue.length === 0) {
             return;
         }
 
         // loop over the connectQueue
-        for(const shard of this.connectQueue) {
+        for (const shard of this.connectQueue) {
             // find the bucket for our shard
             const rateLimitKey = (shard.id % this.options.maxConcurrency) || 0;
             const lastConnect = this.buckets.get(rateLimitKey) || 0;
 
             // has enough time passed since the last connect for this bucket (5s/bucket)?
             // alternatively if we have a sessionID, we can skip this check
-            if(!shard.sessionID && Date.now() - lastConnect < 5000) {
+            if (!shard.sessionID && Date.now() - lastConnect < 5000) {
                 continue;
             }
 
             // Are there any connecting shards in the same bucket we should wait on?
-            if(this.some((s) => s.connecting && ((s.id % this.options.maxConcurrency) || 0) === rateLimitKey)) {
+            if (this.some((s) => s.connecting && ((s.id % this.options.maxConcurrency) || 0) === rateLimitKey)) {
                 continue;
             }
 
@@ -181,7 +181,7 @@ class ShardManager extends Collection {
         }
 
         // set the next timeout if we have more shards to connect
-        if(!this.connectTimeout && this.connectQueue.length > 0) {
+        if (!this.connectTimeout && this.connectQueue.length > 0) {
             this.connectTimeout = setTimeout(() => {
                 this.connectTimeout = null;
                 this.tryConnect();
@@ -206,7 +206,7 @@ class ShardManager extends Collection {
             "connectQueue",
             "connectTimeout",
             "options",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const {REST_VERSION} = require("../Constants");
+const { REST_VERSION } = require("../Constants");
 
 module.exports.BASE_URL = "/api/v" + REST_VERSION;
 module.exports.CDN_URL = "https://cdn.discordapp.com";

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -15,11 +15,12 @@ const Zlib = require("node:zlib");
 * Handles API requests
 */
 class RequestHandler {
-    #client;
     globalBlock = false;
     ratelimits = {};
     readyQueue = [];
     userAgent = `DiscordBot (https://github.com/projectdysnomia/dysnomia, ${require("../../package.json").version})`;
+    #client;
+
     constructor(client, options) {
         this.options = options = Object.assign({
             agent: null,
@@ -29,7 +30,7 @@ class RequestHandler {
             https: true,
             latencyThreshold: 30000,
             ratelimiterOffset: 0,
-            requestTimeout: 15000
+            requestTimeout: 15000,
         }, options);
 
         this.#client = client;
@@ -38,9 +39,9 @@ class RequestHandler {
             raw: new Array(10).fill(this.options.ratelimiterOffset),
             timeOffset: 0,
             timeOffsets: new Array(10).fill(0),
-            lastTimeOffsetCheck: 0
+            lastTimeOffsetCheck: 0,
         };
-        if(this.options.forceQueueing) {
+        if (this.options.forceQueueing) {
             this.globalBlock = true;
             this.#client.once("shardPreReady", () => this.globalUnblock());
         }
@@ -48,7 +49,7 @@ class RequestHandler {
 
     globalUnblock() {
         this.globalBlock = false;
-        while(this.readyQueue.length > 0) {
+        while (this.readyQueue.length > 0) {
             this.readyQueue.shift()();
         }
     }
@@ -77,54 +78,54 @@ class RequestHandler {
             const actualCall = (cb) => {
                 const headers = {
                     "User-Agent": this.userAgent,
-                    "Accept-Encoding": "gzip,deflate"
+                    "Accept-Encoding": "gzip,deflate",
                 };
                 let data;
                 let finalURL = url;
 
                 try {
-                    if(auth) {
+                    if (auth) {
                         headers.Authorization = this.#client._token;
                     }
-                    if(body?.reason) { // Audit log reason sniping
+                    if (body?.reason) { // Audit log reason sniping
                         headers["X-Audit-Log-Reason"] = encodeURIComponent(body.reason);
                         delete body.reason;
                     }
-                    if(file) {
-                        if(Array.isArray(file)) {
+                    if (file) {
+                        if (Array.isArray(file)) {
                             data = new MultipartData();
                             headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
                             file.forEach(function(f) {
-                                if(!f.file) {
+                                if (!f.file) {
                                     return;
                                 }
                                 const attachedFieldName = f.fieldName || f.name;
-                                if(attachedFieldName === "payload_json") { // Use the body parameter to supply payload_json instead
+                                if (attachedFieldName === "payload_json") { // Use the body parameter to supply payload_json instead
                                     return;
                                 }
                                 data.attach(attachedFieldName, f.file, f.name);
                             });
-                            if(body) {
+                            if (body) {
                                 data.attach("payload_json", body);
                             }
                             data = data.finish();
-                        } else if(file.file) {
+                        } else if (file.file) {
                             data = new MultipartData();
                             headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
                             data.attach(file.fieldName || "file", file.file, file.name);
-                            if(body) {
+                            if (body) {
                                 data.attach("payload_json", body);
                             }
                             data = data.finish();
                         } else {
                             throw new Error("Invalid file object");
                         }
-                    } else if(body) {
-                        if(method === "GET" || method === "DELETE") {
+                    } else if (body) {
+                        if (method === "GET" || method === "DELETE") {
                             let qs = "";
                             Object.keys(body).forEach(function(key) {
-                                if(body[key] != undefined) {
-                                    if(Array.isArray(body[key])) {
+                                if (body[key] != null) {
+                                    if (Array.isArray(body[key])) {
                                         body[key].forEach(function(val) {
                                             qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
                                         });
@@ -140,7 +141,7 @@ class RequestHandler {
                             headers["Content-Type"] = "application/json";
                         }
                     }
-                } catch(err) {
+                } catch (err) {
                     cb();
                     reject(err);
                     return;
@@ -155,9 +156,9 @@ class RequestHandler {
                         host: this.options.domain,
                         path: this.options.baseURL + finalURL,
                         headers: headers,
-                        agent: this.options.agent
+                        agent: this.options.agent,
                     });
-                } catch(err) {
+                } catch (err) {
                     cb();
                     reject(err);
                     return;
@@ -179,12 +180,12 @@ class RequestHandler {
 
                 req.once("response", (resp) => {
                     latency = Date.now() - latency;
-                    if(!this.options.disableLatencyCompensation) {
+                    if (!this.options.disableLatencyCompensation) {
                         this.latencyRef.raw.push(latency);
                         this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
                     }
 
-                    if(this.#client.listeners("rawREST").length) {
+                    if (this.#client.listeners("rawREST").length) {
                         /**
                          * Fired when the Client's RequestHandler receives a response
                          * @event Client#rawREST
@@ -201,13 +202,13 @@ class RequestHandler {
                          * @prop {Boolean} request.short Whether or not the request was prioritized in its ratelimiting queue
                          * @prop {String} request.url URL of the endpoint
                          */
-                        this.#client.emit("rawREST", {method, url, auth, body, file, route, short, resp, latency});
+                        this.#client.emit("rawREST", { method, url, auth, body, file, route, short, resp, latency });
                     }
 
                     const headerNow = Date.parse(resp.headers["date"]);
-                    if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
+                    if (this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
                         const timeOffset = headerNow + 500 - (this.latencyRef.lastTimeOffsetCheck = Date.now());
-                        if(this.latencyRef.timeOffset - this.latencyRef.latency >= this.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this.options.latencyThreshold) {
+                        if (this.latencyRef.timeOffset - this.latencyRef.latency >= this.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this.options.latencyThreshold) {
                             this.#client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
                         }
                         this.latencyRef.timeOffset = this.latencyRef.timeOffset - ~~(this.latencyRef.timeOffsets.shift() / 10) + ~~(timeOffset / 10);
@@ -224,10 +225,10 @@ class RequestHandler {
                     let response = "";
 
                     let _respStream = resp;
-                    if(resp.headers["content-encoding"]) {
-                        if(resp.headers["content-encoding"].includes("gzip")) {
+                    if (resp.headers["content-encoding"]) {
+                        if (resp.headers["content-encoding"].includes("gzip")) {
                             _respStream = resp.pipe(Zlib.createGunzip());
-                        } else if(resp.headers["content-encoding"].includes("deflate")) {
+                        } else if (resp.headers["content-encoding"].includes("deflate")) {
                             _respStream = resp.pipe(Zlib.createInflate());
                         }
                     }
@@ -240,11 +241,11 @@ class RequestHandler {
                     }).once("end", () => {
                         const now = Date.now();
 
-                        if(resp.headers["x-ratelimit-limit"]) {
+                        if (resp.headers["x-ratelimit-limit"]) {
                             this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
                         }
 
-                        if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == undefined || resp.headers["x-ratelimit-limit"] == undefined) && this.ratelimits[route].limit !== 1) {
+                        if (method !== "GET" && (resp.headers["x-ratelimit-remaining"] == null || resp.headers["x-ratelimit-limit"] == null) && this.ratelimits[route].limit !== 1) {
                             this.#client.emit("debug", `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n`
                                 + `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
                                 + "content-type = " +  + "\n"
@@ -257,16 +258,16 @@ class RequestHandler {
                         this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
 
                         const retryAfter = Number(resp.headers["x-ratelimit-reset-after"] || resp.headers["retry-after"]) * 1000;
-                        if(retryAfter >= 0) {
-                            if(resp.headers["x-ratelimit-global"]) {
+                        if (retryAfter >= 0) {
+                            if (resp.headers["x-ratelimit-global"]) {
                                 this.globalBlock = true;
                                 setTimeout(() => this.globalUnblock(), retryAfter || 1);
                             } else {
                                 this.ratelimits[route].reset = (retryAfter || 1) + now;
                             }
-                        } else if(resp.headers["x-ratelimit-reset"]) {
+                        } else if (resp.headers["x-ratelimit-reset"]) {
                             let resetTime = +resp.headers["x-ratelimit-reset"] * 1000;
-                            if(route.endsWith("/reactions/:id") && (+resp.headers["x-ratelimit-reset"] * 1000 - headerNow) === 1000) {
+                            if (route.endsWith("/reactions/:id") && (+resp.headers["x-ratelimit-reset"] * 1000 - headerNow) === 1000) {
                                 resetTime = now + 250;
                             }
                             this.ratelimits[route].reset = Math.max(resetTime - this.latencyRef.latency, now);
@@ -274,25 +275,25 @@ class RequestHandler {
                             this.ratelimits[route].reset = now;
                         }
 
-                        if(resp.statusCode !== 429) {
+                        if (resp.statusCode !== 429) {
                             const content = typeof body === "object" ? `${body.content} ` : "";
                             this.#client.emit("debug", `${content}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
-                        if(resp.statusCode >= 300) {
-                            if(resp.statusCode === 429) {
+                        if (resp.statusCode >= 300) {
+                            if (resp.statusCode === 429) {
                                 const content = typeof body === "object" ? `${body.content} ` : "";
                                 let delay = retryAfter;
-                                if(resp.headers["x-ratelimit-scope"] === "shared") {
+                                if (resp.headers["x-ratelimit-scope"] === "shared") {
                                     try {
                                         delay = JSON.parse(response).retry_after * 1000;
-                                    } catch(err) {
+                                    } catch (err) {
                                         reject(err);
                                         return;
                                     }
                                 }
                                 this.#client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left) | Scope ${resp.headers["x-ratelimit-scope"]}`);
-                                if(delay) {
+                                if (delay) {
                                     setTimeout(() => {
                                         cb();
                                         this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
@@ -303,7 +304,7 @@ class RequestHandler {
                                     this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
                                     return;
                                 }
-                            } else if(resp.statusCode === 502 && ++attempts < 4) {
+                            } else if (resp.statusCode === 502 && ++attempts < 4) {
                                 this.#client.emit("debug", "A wild 502 appeared! Thanks CloudFlare!");
                                 setTimeout(() => {
                                     this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
@@ -312,23 +313,23 @@ class RequestHandler {
                             }
                             cb();
 
-                            if(response.length > 0) {
-                                if(resp.headers["content-type"] === "application/json") {
+                            if (response.length > 0) {
+                                if (resp.headers["content-type"] === "application/json") {
                                     try {
                                         response = JSON.parse(response);
-                                    } catch(err) {
+                                    } catch (err) {
                                         reject(err);
                                         return;
                                     }
                                 }
                             }
 
-                            let {stack} = _stackHolder;
-                            if(stack.startsWith("Error\n")) {
+                            let { stack } = _stackHolder;
+                            if (stack.startsWith("Error\n")) {
                                 stack = stack.substring(6);
                             }
                             let err;
-                            if(response.code) {
+                            if (response.code) {
                                 err = new DiscordRESTError(req, resp, response, stack);
                             } else {
                                 err = new DiscordHTTPError(req, resp, response, stack);
@@ -337,11 +338,11 @@ class RequestHandler {
                             return;
                         }
 
-                        if(response.length > 0) {
-                            if(resp.headers["content-type"] === "application/json") {
+                        if (response.length > 0) {
+                            if (resp.headers["content-type"] === "application/json") {
                                 try {
                                     response = JSON.parse(response);
-                                } catch(err) {
+                                } catch (err) {
                                     cb();
                                     reject(err);
                                     return;
@@ -359,8 +360,8 @@ class RequestHandler {
                     req.abort();
                 });
 
-                if(Array.isArray(data)) {
-                    for(const chunk of data) {
+                if (Array.isArray(data)) {
+                    for (const chunk of data) {
                         req.write(chunk);
                     }
                     req.end();
@@ -369,7 +370,7 @@ class RequestHandler {
                 }
             };
 
-            if(this.globalBlock && auth) {
+            if (this.globalBlock && auth) {
                 this.readyQueue.push(() => {
                     this.ratelimits[route] ??= new SequentialBucket(1, this.latencyRef);
                     this.ratelimits[route].queue(actualCall, short);
@@ -385,21 +386,21 @@ class RequestHandler {
         let route = url.replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function(match, p) {
             return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
         }).replace(/\/reactions\/[^/]+/g, "/reactions/:id").replace(/\/reactions\/:id\/[^/]+/g, "/reactions/:id/:userID").replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
-        if(method === "DELETE" && route.endsWith("/messages/:id")) {
+        if (method === "DELETE" && route.endsWith("/messages/:id")) {
             const messageID = url.slice(url.lastIndexOf("/") + 1);
             const createdAt = Base.getCreatedAt(messageID);
-            if(Date.now() - this.latencyRef.latency - createdAt >= 1000 * 60 * 60 * 24 * 14) {
+            if (Date.now() - this.latencyRef.latency - createdAt >= 1000 * 60 * 60 * 24 * 14) {
                 method += "_OLD";
-            } else if(Date.now() - this.latencyRef.latency - createdAt <= 1000 * 10) {
+            } else if (Date.now() - this.latencyRef.latency - createdAt <= 1000 * 10) {
                 method += "_NEW";
             }
             route = method + route;
-        } else if(method === "GET" && /\/guilds\/[0-9]+\/channels$/.test(route)) {
+        } else if (method === "GET" && /\/guilds\/[0-9]+\/channels$/.test(route)) {
             route = "/guilds/:id/channels";
         }
-        if(method === "PUT" || method === "DELETE") {
+        if (method === "PUT" || method === "DELETE") {
             const index = route.indexOf("/reactions");
-            if(index !== -1) {
+            if (index !== -1) {
                 route = "MODIFY" + route.slice(0, index + 10);
             }
         }
@@ -422,7 +423,7 @@ class RequestHandler {
             "ratelimits",
             "readyQueue",
             "userAgent",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Base = require("./Base");
 
 /**
@@ -27,31 +29,31 @@ class ApplicationCommand extends Base {
         this.type = data.type;
         this.version = data.version;
 
-        if(data.guild_id !== undefined) {
+        if (data.guild_id !== undefined) {
             this.guildID = data.guild_id;
         }
 
-        if(data.name_localizations !== undefined) {
+        if (data.name_localizations !== undefined) {
             this.nameLocalizations = data.name_localizations;
         }
 
-        if(data.description_localizations !== undefined) {
+        if (data.description_localizations !== undefined) {
             this.descriptionLocalizations = data.description_localizations;
         }
 
-        if(data.options !== undefined) {
+        if (data.options !== undefined) {
             this.options = data.options;
         }
 
-        if(data.default_member_permissions !== undefined) {
+        if (data.default_member_permissions !== undefined) {
             this.defaultMemberPermissions = data.default_member_permissions;
         }
 
-        if(data.dm_permission !== undefined) {
+        if (data.dm_permission !== undefined) {
             this.dmPermission = data.dm_permission;
         }
 
-        if(data.nsfw !== undefined) {
+        if (data.nsfw !== undefined) {
             this.nsfw = data.nsfw;
         }
     }
@@ -94,7 +96,7 @@ class ApplicationCommand extends Base {
             "options",
             "type",
             "version",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Attachment.js
+++ b/lib/structures/Attachment.js
@@ -31,19 +31,19 @@ class Attachment extends Base {
     }
 
     update(data) {
-        if(data.description !== undefined) {
+        if (data.description !== undefined) {
             this.description = data.description;
         }
-        if(data.content_type !== undefined) {
+        if (data.content_type !== undefined) {
             this.contentType = data.content_type;
         }
-        if(data.height !== undefined) {
+        if (data.height !== undefined) {
             this.height = data.height;
         }
-        if(data.width !== undefined) {
+        if (data.width !== undefined) {
             this.width = data.width;
         }
-        if(data.ephemeral !== undefined) {
+        if (data.ephemeral !== undefined) {
             this.ephemeral = data.ephemeral;
         }
     }
@@ -61,7 +61,7 @@ class Attachment extends Base {
             "ephemeral",
             "durationSecs",
             "waveform",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/AutoModerationRule.js
+++ b/lib/structures/AutoModerationRule.js
@@ -24,7 +24,7 @@ class AutoModerationRule extends Base {
 
         this.actions = data.actions.map((action) => ({
             type: action.type,
-            metadata: action.metadata
+            metadata: action.metadata,
         }));
 
         this.creatorID = data.creator_id;

--- a/lib/structures/AutocompleteInteraction.js
+++ b/lib/structures/AutocompleteInteraction.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Interaction = require("./Interaction");
-const {InteractionResponseTypes} = require("../Constants");
+const { InteractionResponseTypes } = require("../Constants");
 
 /**
 * Represents an application command autocomplete interaction. See Interaction for more properties.
@@ -48,12 +48,12 @@ class AutocompleteInteraction extends Interaction {
     * @returns {Promise}
     */
     result(choices) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
-            data: {choices}
+            data: { choices },
         }).then(() => this.update());
     }
 }

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -9,7 +9,7 @@ const util = require("node:util");
  */
 class Base {
     constructor(id) {
-        if(id) {
+        if (id) {
             this.id = id;
         }
     }
@@ -38,9 +38,9 @@ class Base {
 
     [util.inspect.custom]() {
         // http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
-        const copy = new {[this.constructor.name]: class {}}[this.constructor.name]();
-        for(const key in this) {
-            if(this.hasOwnProperty(key) && !key.startsWith("_") && this[key] !== undefined) {
+        const copy = new { [this.constructor.name]: class {} }[this.constructor.name]();
+        for (const key in this) {
+            if (Object.hasOwn(this, key) && !key.startsWith("_") && this[key] !== undefined) {
                 copy[key] = this[key];
             }
         }
@@ -53,24 +53,24 @@ class Base {
 
     toJSON(props = []) {
         const json = {};
-        if(this.id) {
+        if (this.id) {
             json.id = this.id;
             json.createdAt = this.createdAt;
         }
-        for(const prop of props) {
+        for (const prop of props) {
             const value = this[prop];
             const type = typeof value;
-            if(value === undefined) {
+            if (value === undefined) {
                 continue;
-            } else if(type !== "object" && type !== "function" && type !== "bigint" || value === null) {
+            } else if (type !== "object" && type !== "function" && type !== "bigint" || value === null) {
                 json[prop] = value;
-            } else if(value.toJSON !== undefined) {
+            } else if (value.toJSON !== undefined) {
                 json[prop] = value.toJSON();
-            } else if(value.values !== undefined) {
+            } else if (value.values !== undefined) {
                 json[prop] = [...value.values()];
-            } else if(type === "bigint") {
+            } else if (type === "bigint") {
                 json[prop] = value.toString();
-            } else if(type === "object") {
+            } else if (type === "object") {
                 json[prop] = value;
             }
         }

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -19,22 +19,22 @@ class CategoryChannel extends GuildChannel {
 
     update(data) {
         super.update(data);
-        if(data.permission_overwrites) {
+        if (data.permission_overwrites) {
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
     }
 
     get channels() {
         const channels = new Collection(GuildChannel);
-        if(this.guild?.channels) {
-            for(const channel of this.guild.channels.values()) {
-                if(channel.parentID === this.id) {
+        if (this.guild?.channels) {
+            for (const channel of this.guild.channels.values()) {
+                if (channel.parentID === this.id) {
                     channels.add(channel);
                 }
             }
@@ -46,7 +46,7 @@ class CategoryChannel extends GuildChannel {
         return super.toJSON([
             "permissionOverwrites",
             "position",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Base = require("./Base");
-const {ChannelTypes} = require("../Constants");
+const { ChannelTypes } = require("../Constants");
 
 /**
 * Represents a channel. You also probably want to look at CategoryChannel, NewsChannel, PrivateChannel, TextChannel, and TextVoiceChannel.
@@ -23,7 +23,7 @@ class Channel extends Base {
     }
 
     static from(data, client) {
-        switch(data.type) {
+        switch (data.type) {
             case ChannelTypes.GUILD_TEXT: {
                 return new TextChannel(data, client);
             }
@@ -55,8 +55,8 @@ class Channel extends Base {
                 return new ForumChannel(data, client);
             }
         }
-        if(data.guild_id) {
-            if(data.last_message_id !== undefined) {
+        if (data.guild_id) {
+            if (data.last_message_id !== undefined) {
                 client.emit("warn", new Error(`Unknown guild text channel type: ${data.type}\n${JSON.stringify(data)}`));
                 return new TextChannel(data, client);
             }
@@ -70,7 +70,7 @@ class Channel extends Base {
     toJSON(props = []) {
         return super.toJSON([
             "type",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -9,7 +9,7 @@ const Message = require("./Message");
 const Attachment = require("./Attachment");
 const Collection = require("../util/Collection");
 
-const {InteractionResponseTypes} = require("../Constants");
+const { InteractionResponseTypes } = require("../Constants");
 
 /**
 * Represents an application command interaction. See Interaction for more properties.
@@ -39,9 +39,9 @@ class CommandInteraction extends Interaction {
         super(data, client);
         this.#client = client;
 
-        if(data.data.resolved !== undefined) {
+        if (data.data.resolved !== undefined) {
             //Users
-            if(data.data.resolved.users !== undefined) {
+            if (data.data.resolved.users !== undefined) {
                 const usermap = new Collection(User);
                 Object.entries(data.data.resolved.users).forEach(([id, user]) => {
                     usermap.set(id, this.#client.users.update(user, client));
@@ -49,12 +49,12 @@ class CommandInteraction extends Interaction {
                 this.data.resolved.users = usermap;
             }
             //Members
-            if(data.data.resolved.members !== undefined) {
+            if (data.data.resolved.members !== undefined) {
                 const membermap = new Collection(Member);
                 Object.entries(data.data.resolved.members).forEach(([id, member]) => {
                     member.id = id;
-                    member.user = {id};
-                    if(this.channel.guild) {
+                    member.user = { id };
+                    if (this.channel.guild) {
                         membermap.set(id, this.channel.guild.members.update(member, this.channel.guild));
                     } else {
                         const guild = this.#client.guilds.get(data.guild_id);
@@ -64,7 +64,7 @@ class CommandInteraction extends Interaction {
                 this.data.resolved.members = membermap;
             }
             //Roles
-            if(data.data.resolved.roles !== undefined) {
+            if (data.data.resolved.roles !== undefined) {
                 const rolemap = new Collection(Role);
                 Object.entries(data.data.resolved.roles).forEach(([id, role]) => {
                     rolemap.set(id, new Role(role, this.channel.guild));
@@ -72,7 +72,7 @@ class CommandInteraction extends Interaction {
                 this.data.resolved.roles = rolemap;
             }
             //Channels
-            if(data.data.resolved.channels !== undefined) {
+            if (data.data.resolved.channels !== undefined) {
                 const channelmap = new Collection(Channel);
                 Object.entries(data.data.resolved.channels).forEach(([id, channel]) => {
                     channelmap.set(id, Channel.from(channel, this.#client) || new Channel(channel, this.#client));
@@ -80,7 +80,7 @@ class CommandInteraction extends Interaction {
                 this.data.resolved.channels = channelmap;
             }
             //Messages
-            if(data.data.resolved.messages !== undefined) {
+            if (data.data.resolved.messages !== undefined) {
                 const messagemap = new Collection(Message);
                 Object.entries(data.data.resolved.messages).forEach(([id, message]) => {
                     messagemap.set(id, new Message(message, this.#client));
@@ -88,7 +88,7 @@ class CommandInteraction extends Interaction {
                 this.data.resolved.messages = messagemap;
             }
             //Attachments
-            if(data.data.resolved.attachments !== undefined) {
+            if (data.data.resolved.attachments !== undefined) {
                 const attachmentsmap = new Collection(Attachment);
                 Object.entries(data.data.resolved.attachments).forEach(([id, attachment]) => {
                     attachmentsmap.set(id, new Attachment(attachment));
@@ -127,19 +127,19 @@ class CommandInteraction extends Interaction {
     * @returns {Promise<Message?>}
     */
     createFollowup(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("createFollowup cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
-        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({wait: true}, content));
+        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({ wait: true }, content));
     }
 
     /**
@@ -161,28 +161,28 @@ class CommandInteraction extends Interaction {
     * @returns {Promise}
     */
     createMessage(content) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             return this.createFollowup(content);
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const { files, attachments } = this.#client._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
+            data: content,
         }, files).then(() => this.update());
     }
 
@@ -197,7 +197,7 @@ class CommandInteraction extends Interaction {
     async createModal(content) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.MODAL,
-            data: content
+            data: content,
         }).then(() => this.update());
     }
 
@@ -208,14 +208,14 @@ class CommandInteraction extends Interaction {
     * @returns {Promise}
     */
     defer(flags) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
             data: {
-                flags: flags || 0
-            }
+                flags: flags || 0,
+            },
         }).then(() => this.update());
     }
 
@@ -225,7 +225,7 @@ class CommandInteraction extends Interaction {
     * @returns {Promise}
     */
     deleteMessage(messageID) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, messageID);
@@ -237,7 +237,7 @@ class CommandInteraction extends Interaction {
     * @returns {Promise}
     */
     deleteOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");
@@ -263,15 +263,15 @@ class CommandInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -297,15 +297,15 @@ class CommandInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     editOriginalMessage(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -318,7 +318,7 @@ class CommandInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     getOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("getOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, or defer first.");
         }
         return this.#client.getWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -8,7 +8,7 @@ const Channel = require("./Channel");
 const Message = require("./Message");
 const Collection = require("../util/Collection");
 
-const {InteractionResponseTypes} = require("../Constants");
+const { InteractionResponseTypes } = require("../Constants");
 
 /**
 * Represents a message component interaction. See Interaction for more properties
@@ -35,9 +35,9 @@ class ComponentInteraction extends Interaction {
         super(data, client);
         this.#client = client;
 
-        if(data.data.resolved !== undefined) {
+        if (data.data.resolved !== undefined) {
             //Users
-            if(data.data.resolved.users !== undefined) {
+            if (data.data.resolved.users !== undefined) {
                 const usermap = new Collection(User);
                 Object.entries(data.data.resolved.users).forEach(([id, user]) => {
                     usermap.set(id, this.#client.users.update(user, client));
@@ -45,12 +45,12 @@ class ComponentInteraction extends Interaction {
                 this.data.resolved.users = usermap;
             }
             //Members
-            if(data.data.resolved.members !== undefined) {
+            if (data.data.resolved.members !== undefined) {
                 const membermap = new Collection(Member);
                 Object.entries(data.data.resolved.members).forEach(([id, member]) => {
                     member.id = id;
-                    member.user = {id};
-                    if(this.channel.guild) {
+                    member.user = { id };
+                    if (this.channel.guild) {
                         membermap.set(id, this.channel.guild.members.update(member, this.channel.guild));
                     } else {
                         const guild = this.#client.guilds.get(data.guild_id);
@@ -60,7 +60,7 @@ class ComponentInteraction extends Interaction {
                 this.data.resolved.members = membermap;
             }
             //Roles
-            if(data.data.resolved.roles !== undefined) {
+            if (data.data.resolved.roles !== undefined) {
                 const rolemap = new Collection(Role);
                 Object.entries(data.data.resolved.roles).forEach(([id, role]) => {
                     rolemap.set(id, new Role(role, this.channel.guild));
@@ -68,7 +68,7 @@ class ComponentInteraction extends Interaction {
                 this.data.resolved.roles = rolemap;
             }
             //Channels
-            if(data.data.resolved.channels !== undefined) {
+            if (data.data.resolved.channels !== undefined) {
                 const channelmap = new Collection(Channel);
                 Object.entries(data.data.resolved.channels).forEach(([id, channel]) => {
                     channelmap.set(id, Channel.from(channel, this.#client) || new Channel(channel, this.#client));
@@ -77,7 +77,7 @@ class ComponentInteraction extends Interaction {
             }
         }
 
-        if(data.message !== undefined) {
+        if (data.message !== undefined) {
             this.message = new Message(data.message, this.#client);
         }
     }
@@ -109,19 +109,19 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise<Message?>}
     */
     createFollowup(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("createFollowup cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
-        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({wait: true}, content));
+        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({ wait: true }, content));
     }
 
     /**
@@ -143,28 +143,28 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     createMessage(content) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             return this.createFollowup(content);
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const { files, attachments } = this.#client._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
+            data: content,
         }, files).then(() => this.update());
     }
 
@@ -179,7 +179,7 @@ class ComponentInteraction extends Interaction {
     async createModal(content) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.MODAL,
-            data: content
+            data: content,
         }).then(() => this.update());
     }
 
@@ -190,14 +190,14 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     defer(flags) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
             data: {
-                flags: flags || 0
-            }
+                flags: flags || 0,
+            },
         }).then(() => this.update());
     }
 
@@ -207,11 +207,11 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     deferUpdate() {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.DEFERRED_UPDATE_MESSAGE
+            type: InteractionResponseTypes.DEFERRED_UPDATE_MESSAGE,
         }).then(() => this.update());
     }
 
@@ -221,7 +221,7 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     deleteMessage(messageID) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, messageID);
@@ -233,7 +233,7 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     deleteOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");
@@ -259,15 +259,15 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -293,15 +293,15 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     editOriginalMessage(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -331,28 +331,28 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise}
     */
     editParent(content) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             return this.editOriginalMessage(content);
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const { files, attachments } = this.#client._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.UPDATE_MESSAGE,
-            data: content
+            data: content,
         }, files).then(() => this.update());
     }
 
@@ -362,7 +362,7 @@ class ComponentInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     getOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("getOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.getWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");

--- a/lib/structures/ExtendedUser.js
+++ b/lib/structures/ExtendedUser.js
@@ -18,16 +18,16 @@ class ExtendedUser extends User {
 
     update(data) {
         super.update(data);
-        if(data.email !== undefined) {
+        if (data.email !== undefined) {
             this.email = data.email;
         }
-        if(data.verified !== undefined) {
+        if (data.verified !== undefined) {
             this.verified = data.verified;
         }
-        if(data.mfa_enabled !== undefined) {
+        if (data.mfa_enabled !== undefined) {
             this.mfaEnabled = data.mfa_enabled;
         }
-        if(data.premium_type !== undefined) {
+        if (data.premium_type !== undefined) {
             this.premiumType = data.premium_type;
         }
     }
@@ -38,7 +38,7 @@ class ExtendedUser extends User {
             "mfaEnabled",
             "premium",
             "verified",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/ForumChannel.js
+++ b/lib/structures/ForumChannel.js
@@ -32,49 +32,49 @@ class ForumChannel extends GuildChannel {
 
     update(data) {
         super.update(data);
-        if(data.available_tags !== undefined) {
+        if (data.available_tags !== undefined) {
             this.availableTags = data.available_tags.map((tag) => ({
                 id: tag.id,
                 name: tag.name,
                 moderated: tag.moderated,
                 emojiID: tag.emoji_id,
-                emojiName: tag.emoji_name
+                emojiName: tag.emoji_name,
             }));
         }
-        if(data.default_auto_archive_duration !== undefined) {
+        if (data.default_auto_archive_duration !== undefined) {
             this.defaultAutoArchiveDuration = data.default_auto_archive_duration;
         }
-        if(data.default_thread_rate_limit_per_user !== undefined) {
+        if (data.default_thread_rate_limit_per_user !== undefined) {
             this.defaultThreadRateLimitPerUser = data.default_thread_rate_limit_per_user;
         }
-        if(data.default_forum_layout !== undefined) {
+        if (data.default_forum_layout !== undefined) {
             this.defaultForumLayout = data.default_forum_layout;
         }
-        if(data.default_reaction_emoji !== undefined) {
+        if (data.default_reaction_emoji !== undefined) {
             this.defaultReactionEmoji = data.default_reaction_emoji && {
                 emojiID: data.default_reaction_emoji.emoji_id,
-                emojiName: data.default_reaction_emoji.emoji_name
+                emojiName: data.default_reaction_emoji.emoji_name,
             };
         }
-        if(data.default_sort_order !== undefined) {
+        if (data.default_sort_order !== undefined) {
             this.defaultSortOrder = data.default_sort_order;
         }
-        if(data.rate_limit_per_user !== undefined) {
+        if (data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
-        if(data.topic !== undefined) {
+        if (data.topic !== undefined) {
             this.topic = data.topic;
         }
-        if(data.permission_overwrites) {
+        if (data.permission_overwrites) {
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
-        if(data.nsfw !== undefined) {
+        if (data.nsfw !== undefined) {
             this.nsfw = data.nsfw;
         }
     }
@@ -172,7 +172,7 @@ class ForumChannel extends GuildChannel {
             "position",
             "rateLimitPerUser",
             "topic",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -10,7 +10,7 @@ const Role = require("./Role");
 const VoiceState = require("./VoiceState");
 const Permission = require("./Permission");
 const GuildScheduledEvent = require("./GuildScheduledEvent");
-const {Permissions} = require("../Constants");
+const { Permissions } = require("../Constants");
 const StageInstance = require("./StageInstance");
 const ThreadChannel = require("./ThreadChannel");
 
@@ -91,28 +91,28 @@ class Guild extends Base {
         this.roles = new Collection(Role);
         this.applicationID = data.application_id;
 
-        if(data.widget_enabled !== undefined) {
+        if (data.widget_enabled !== undefined) {
             this.widgetEnabled = data.widget_enabled;
         }
-        if(data.widget_channel_id !== undefined) {
+        if (data.widget_channel_id !== undefined) {
             this.widgetChannelID = data.widget_channel_id;
         }
 
-        if(data.approximate_member_count !== undefined) {
+        if (data.approximate_member_count !== undefined) {
             this.approximateMemberCount = data.approximate_member_count;
         }
-        if(data.approximate_presence_count !== undefined) {
+        if (data.approximate_presence_count !== undefined) {
             this.approximatePresenceCount = data.approximate_presence_count;
         }
 
-        if(data.roles) {
-            for(const role of data.roles) {
+        if (data.roles) {
+            for (const role of data.roles) {
                 this.roles.add(role, this);
             }
         }
 
-        if(data.channels) {
-            for(const channelData of data.channels) {
+        if (data.channels) {
+            for (const channelData of data.channels) {
                 channelData.guild_id = this.id;
                 const channel = Channel.from(channelData, client);
                 channel.guild = this;
@@ -121,8 +121,8 @@ class Guild extends Base {
             }
         }
 
-        if(data.threads) {
-            for(const threadData of data.threads) {
+        if (data.threads) {
+            for (const threadData of data.threads) {
                 threadData.guild_id = this.id;
                 const channel = Channel.from(threadData, client);
                 channel.guild = this;
@@ -131,25 +131,25 @@ class Guild extends Base {
             }
         }
 
-        if(data.members) {
-            for(const member of data.members) {
+        if (data.members) {
+            for (const member of data.members) {
                 member.id = member.user.id;
                 this.members.add(member, this);
             }
         }
 
-        if(data.stage_instances) {
-            for(const stageInstance of data.stage_instances) {
+        if (data.stage_instances) {
+            for (const stageInstance of data.stage_instances) {
                 stageInstance.guild_id = this.id;
                 this.stageInstances.add(stageInstance, client);
             }
         }
 
-        if(data.presences) {
-            for(const presence of data.presences) {
-                if(!this.members.get(presence.user.id)) {
+        if (data.presences) {
+            for (const presence of data.presences) {
+                if (!this.members.get(presence.user.id)) {
                     let userData = client.users.get(presence.user.id);
-                    if(userData) {
+                    if (userData) {
                         userData = `{username: ${userData.username}, id: ${userData.id}, discriminator: ${userData.discriminator}}`;
                     }
                     client.emit("debug", `Presence without member. ${presence.user.id}. In global user cache: ${userData}. ` + JSON.stringify(presence), this.shard.id);
@@ -160,9 +160,9 @@ class Guild extends Base {
             }
         }
 
-        if(data.voice_states) {
-            for(const voiceState of data.voice_states) {
-                if(!this.members.get(voiceState.user_id)) {
+        if (data.voice_states) {
+            for (const voiceState of data.voice_states) {
+                if (!this.members.get(voiceState.user_id)) {
                     continue;
                 }
                 voiceState.id = voiceState.user_id;
@@ -170,18 +170,18 @@ class Guild extends Base {
                     const channel = this.channels.get(voiceState.channel_id);
                     const member = this.members.update(voiceState);
                     channel?.voiceMembers?.add(member);
-                } catch(err) {
+                } catch (err) {
                     client.emit("error", err, this.shard.id);
                     continue;
                 }
-                if(client.options.seedVoiceConnections && voiceState.id === client.user.id && !client.voiceConnections.get(this.id)) {
+                if (client.options.seedVoiceConnections && voiceState.id === client.user.id && !client.voiceConnections.get(this.id)) {
                     process.nextTick(() => this.#client.joinVoiceChannel(voiceState.channel_id));
                 }
             }
         }
 
-        if(data.guild_scheduled_events) {
-            for(const event of data.guild_scheduled_events) {
+        if (data.guild_scheduled_events) {
+            for (const event of data.guild_scheduled_events) {
                 this.events.add(event, client);
             }
         }
@@ -189,97 +189,97 @@ class Guild extends Base {
     }
 
     update(data) {
-        if(data.name !== undefined) {
+        if (data.name !== undefined) {
             this.name = data.name;
         }
-        if(data.verification_level !== undefined) {
+        if (data.verification_level !== undefined) {
             this.verificationLevel = data.verification_level;
         }
-        if(data.splash !== undefined) {
+        if (data.splash !== undefined) {
             this.splash = data.splash;
         }
-        if(data.discovery_splash !== undefined) {
+        if (data.discovery_splash !== undefined) {
             this.discoverySplash = data.discovery_splash;
         }
-        if(data.banner !== undefined) {
+        if (data.banner !== undefined) {
             this.banner = data.banner;
         }
-        if(data.owner_id !== undefined) {
+        if (data.owner_id !== undefined) {
             this.ownerID = data.owner_id;
         }
-        if(data.icon !== undefined) {
+        if (data.icon !== undefined) {
             this.icon = data.icon;
         }
-        if(data.features !== undefined) {
+        if (data.features !== undefined) {
             this.features = data.features;
         }
-        if(data.emojis !== undefined) {
+        if (data.emojis !== undefined) {
             this.emojis = data.emojis;
         }
-        if(data.stickers !== undefined) {
+        if (data.stickers !== undefined) {
             this.stickers = data.stickers;
         }
-        if(data.afk_channel_id !== undefined) {
+        if (data.afk_channel_id !== undefined) {
             this.afkChannelID = data.afk_channel_id;
         }
-        if(data.afk_timeout !== undefined) {
+        if (data.afk_timeout !== undefined) {
             this.afkTimeout = data.afk_timeout;
         }
-        if(data.default_message_notifications !== undefined) {
+        if (data.default_message_notifications !== undefined) {
             this.defaultNotifications = data.default_message_notifications;
         }
-        if(data.mfa_level !== undefined) {
+        if (data.mfa_level !== undefined) {
             this.mfaLevel = data.mfa_level;
         }
-        if(data.large !== undefined) {
+        if (data.large !== undefined) {
             this.large = data.large;
         }
-        if(data.max_presences !== undefined) {
+        if (data.max_presences !== undefined) {
             this.maxPresences = data.max_presences;
         }
-        if(data.explicit_content_filter !== undefined) {
+        if (data.explicit_content_filter !== undefined) {
             this.explicitContentFilter = data.explicit_content_filter;
         }
-        if(data.system_channel_id !== undefined) {
+        if (data.system_channel_id !== undefined) {
             this.systemChannelID = data.system_channel_id;
         }
-        if(data.system_channel_flags !== undefined) {
+        if (data.system_channel_flags !== undefined) {
             this.systemChannelFlags = data.system_channel_flags;
         }
-        if(data.premium_progress_bar_enabled !== undefined) {
+        if (data.premium_progress_bar_enabled !== undefined) {
             this.premiumProgressBarEnabled = data.premium_progress_bar_enabled;
         }
-        if(data.premium_tier !== undefined) {
+        if (data.premium_tier !== undefined) {
             this.premiumTier = data.premium_tier;
         }
-        if(data.premium_subscription_count !== undefined) {
+        if (data.premium_subscription_count !== undefined) {
             this.premiumSubscriptionCount = data.premium_subscription_count;
         }
-        if(data.vanity_url_code !== undefined) {
+        if (data.vanity_url_code !== undefined) {
             this.vanityURL = data.vanity_url_code;
         }
-        if(data.preferred_locale !== undefined) {
+        if (data.preferred_locale !== undefined) {
             this.preferredLocale = data.preferred_locale;
         }
-        if(data.description !== undefined) {
+        if (data.description !== undefined) {
             this.description = data.description;
         }
-        if(data.max_members !== undefined) {
+        if (data.max_members !== undefined) {
             this.maxMembers = data.max_members;
         }
-        if(data.public_updates_channel_id !== undefined) {
+        if (data.public_updates_channel_id !== undefined) {
             this.publicUpdatesChannelID = data.public_updates_channel_id;
         }
-        if(data.rules_channel_id !== undefined) {
+        if (data.rules_channel_id !== undefined) {
             this.rulesChannelID = data.rules_channel_id;
         }
-        if(data.max_video_channel_users !== undefined) {
+        if (data.max_video_channel_users !== undefined) {
             this.maxVideoChannelUsers = data.max_video_channel_users;
         }
-        if(data.max_stage_video_channel_users !== undefined) {
+        if (data.max_stage_video_channel_users !== undefined) {
             this.maxStageVideoChannelUsers = data.max_stage_video_channel_users;
         }
-        if(data.welcome_screen !== undefined) {
+        if (data.welcome_screen !== undefined) {
             this.welcomeScreen = {
                 description: data.welcome_screen.description,
                 welcomeChannels: data.welcome_screen.welcome_channels?.map((c) => {
@@ -287,15 +287,15 @@ class Guild extends Base {
                         channelID: c.channel,
                         description: c.description,
                         emojiID: c.emoji_id,
-                        emojiName: c.emoji_name
+                        emojiName: c.emoji_name,
                     };
-                })
+                }),
             };
         }
-        if(data.nsfw_level !== undefined) {
+        if (data.nsfw_level !== undefined) {
             this.nsfwLevel = data.nsfw_level;
         }
-        if(data.safety_alerts_channel_id !== undefined) {
+        if (data.safety_alerts_channel_id !== undefined) {
             this.safetyAlertsChannelID = data.safety_alerts_channel_id;
         }
     }
@@ -1204,21 +1204,21 @@ class Guild extends Base {
     */
     permissionsOf(memberID) {
         const member = typeof memberID === "string" ? this.members.get(memberID) : memberID;
-        if(member.id === this.ownerID) {
+        if (member.id === this.ownerID) {
             return new Permission(Permissions.all);
         } else {
             let permissions = this.roles.get(this.id).permissions.allow;
-            if(permissions & Permissions.administrator) {
+            if (permissions & Permissions.administrator) {
                 return new Permission(Permissions.all);
             }
-            for(let role of member.roles) {
+            for (let role of member.roles) {
                 role = this.roles.get(role);
-                if(!role) {
+                if (!role) {
                     continue;
                 }
 
-                const {allow: perm} = role.permissions;
-                if(perm & Permissions.administrator) {
+                const { allow: perm } = role.permissions;
+                if (perm & Permissions.administrator) {
                     permissions = Permissions.all;
                     break;
                 } else {
@@ -1328,7 +1328,7 @@ class Guild extends Base {
             "welcomeScreen",
             "widgetChannelID",
             "widgetEnabled",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -2,7 +2,7 @@
 
 const Base = require("./Base");
 const Invite = require("./Invite");
-const {AuditLogActions} = require("../Constants");
+const { AuditLogActions } = require("../Constants");
 
 /**
 * Represents a guild audit log entry describing a moderation action
@@ -52,59 +52,59 @@ class GuildAuditLogEntry extends Base {
         this.actionType = data.action_type;
         this.reason = data.reason || null;
         this.user = guild.shard.client.users.get(data.user_id) || {
-            id: data.user_id
+            id: data.user_id,
         };
         this.before = null;
         this.after = null;
-        if(data.changes) {
+        if (data.changes) {
             this.before = {};
             this.after = {};
             data.changes.forEach((change) => {
-                if(change.old_value != undefined) {
+                if (change.old_value !== undefined) {
                     this.before[change.key] = change.old_value;
                 }
-                if(change.new_value != undefined) {
+                if (change.new_value !== undefined) {
                     this.after[change.key] = change.new_value;
                 }
             });
         }
 
-        if(data.target_id) {
+        if (data.target_id) {
             this.targetID = data.target_id;
         }
-        if(data.options) {
-            if(data.options.application_id) {
+        if (data.options) {
+            if (data.options.application_id) {
                 this.applicationID = data.options.application_id;
             }
-            if(data.options.auto_moderation_rule_name) {
+            if (data.options.auto_moderation_rule_name) {
                 this.autoModerationRuleName = data.options.auto_moderation_rule_name;
             }
-            if(data.options.auto_moderation_rule_trigger_type) {
+            if (data.options.auto_moderation_rule_trigger_type) {
                 this.autoModerationRuleTriggerType = data.options.auto_moderation_rule_trigger_type;
             }
-            if(data.options.count) {
+            if (data.options.count) {
                 this.count = +data.options.count;
             }
-            if(data.options.channel_id) {
+            if (data.options.channel_id) {
                 this.channel = guild.threads.get(data.options.channel_id) || guild.channels.get(data.options.channel_id);
 
-                if(data.options.message_id) {
-                    this.message = this.channel?.messages.get(data.options.message_id) || {id: data.options.message_id};
+                if (data.options.message_id) {
+                    this.message = this.channel?.messages.get(data.options.message_id) || { id: data.options.message_id };
                 }
             }
-            if(data.options.delete_member_days) {
+            if (data.options.delete_member_days) {
                 this.deleteMemberDays = +data.options.delete_member_days;
                 this.membersRemoved = +data.options.members_removed;
             }
-            if(data.options.type) {
-                if(data.options.type === "1") {
+            if (data.options.type) {
+                if (data.options.type === "1") {
                     this.member = guild.members.get(data.options.id) || {
-                        id: data.options.id
+                        id: data.options.id,
                     };
-                } else if(data.options.type === "0") {
+                } else if (data.options.type === "0") {
                     this.role = guild.roles.get(data.options.id) || {
                         id: data.options.id,
-                        name: data.options.role_name
+                        name: data.options.role_name,
                     };
                 }
             }
@@ -112,51 +112,51 @@ class GuildAuditLogEntry extends Base {
     }
 
     get target() { // pay more, get less
-        if(this.actionType < 10) { // Guild
+        if (this.actionType < 10) { // Guild
             return this.guild;
-        } else if(this.actionType < 20) { // Channel
+        } else if (this.actionType < 20) { // Channel
             return this.guild?.channels.get(this.targetID);
-        } else if(this.actionType < 30) { // Member
-            if(this.actionType === AuditLogActions.MEMBER_MOVE || this.actionType === AuditLogActions.MEMBER_DISCONNECT) { // MEMBER_MOVE / MEMBER_DISCONNECT
+        } else if (this.actionType < 30) { // Member
+            if (this.actionType === AuditLogActions.MEMBER_MOVE || this.actionType === AuditLogActions.MEMBER_DISCONNECT) { // MEMBER_MOVE / MEMBER_DISCONNECT
                 return null;
             }
             return this.guild?.members.get(this.targetID);
-        } else if(this.actionType < 40) { // Role
+        } else if (this.actionType < 40) { // Role
             return this.guild?.roles.get(this.targetID);
-        } else if(this.actionType < 50) { // Invite
+        } else if (this.actionType < 50) { // Invite
             const changes = this.actionType === 42 ? this.before : this.after; // Apparently the meaning of life is a deleted invite
             return new Invite({
                 code: changes.code,
                 channel: {
-                    id: changes.channel_id
+                    id: changes.channel_id,
                 },
                 guild: this.guild,
                 uses: changes.uses,
                 max_uses: changes.max_uses,
                 max_age: changes.max_age,
-                temporary: changes.temporary
+                temporary: changes.temporary,
             }, this.guild?.shard.client);
-        } else if(this.actionType < 60) { // Webhook
+        } else if (this.actionType < 60) { // Webhook
             return null; // Go get the webhook yourself
-        } else if(this.actionType < 70) { // Emoji
+        } else if (this.actionType < 70) { // Emoji
             return this.guild?.emojis.find((emoji) => emoji.id === this.targetID);
-        } else if(this.actionType < 80) { // Message
+        } else if (this.actionType < 80) { // Message
             return this.guild?.shard.client.users.get(this.targetID);
-        } else if(this.actionType < 83) { // Integrations
+        } else if (this.actionType < 83) { // Integrations
             return null;
-        } else if(this.actionType < 90) { // Stage Instances
+        } else if (this.actionType < 90) { // Stage Instances
             return this.guild?.stageInstances.get(this.targetID);
-        } else if(this.actionType < 100) { // Sticker
+        } else if (this.actionType < 100) { // Sticker
             return this.guild?.stickers.find((sticker) => sticker.id === this.targetID);
-        } else if(this.actionType < 110) { // Guild Scheduled Events
+        } else if (this.actionType < 110) { // Guild Scheduled Events
             return this.guild?.events.get(this.targetID);
-        } else if(this.actionType < 120) { // Thread
+        } else if (this.actionType < 120) { // Thread
             return this.guild?.threads.get(this.targetID);
-        } else if(this.actionType < 140) { // Application Command
+        } else if (this.actionType < 140) { // Application Command
             return null;
-        } else if(this.actionType < 143) { // Auto Moderation Rule Updates
+        } else if (this.actionType < 143) { // Auto Moderation Rule Updates
             return null;
-        } else if(this.actionType < 146) { // Auto Moderation Actions
+        } else if (this.actionType < 146) { // Auto Moderation Actions
             return this.guild?.shard.client.users.get(this.targetID);
         } else {
             throw new Error("Unrecognized action type: " + this.actionType);
@@ -177,7 +177,7 @@ class GuildAuditLogEntry extends Base {
             "role",
             "targetID",
             "user",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -2,7 +2,7 @@
 
 const Channel = require("./Channel");
 const Permission = require("./Permission");
-const {Permissions} = require("../Constants");
+const { Permissions } = require("../Constants");
 
 /**
 * Represents a guild channel. You also probably want to look at CategoryChannel, NewsChannel, StoreChannel, TextChannel, ThreadChannel, and TextVoiceChannel. See Channel for extra properties.
@@ -18,10 +18,10 @@ class GuildChannel extends Channel {
     constructor(data, client) {
         super(data, client);
         this.guild = client.guilds.get(data.guild_id) || {
-            id: data.guild_id
+            id: data.guild_id,
         };
 
-        if(data.permissions !== undefined) {
+        if (data.permissions !== undefined) {
             this.permissions = new Permission(data.permissions, 0);
         }
 
@@ -29,16 +29,16 @@ class GuildChannel extends Channel {
     }
 
     update(data) {
-        if(data.type !== undefined) {
+        if (data.type !== undefined) {
             this.type = data.type;
         }
-        if(data.name !== undefined) {
+        if (data.name !== undefined) {
             this.name = data.name;
         }
-        if(data.parent_id !== undefined) {
+        if (data.parent_id !== undefined) {
             this.parentID = data.parent_id;
         }
-        if(data.flags !== undefined) {
+        if (data.flags !== undefined) {
             this.flags = data.flags;
         }
     }
@@ -126,25 +126,25 @@ class GuildChannel extends Channel {
     permissionsOf(memberID) {
         const member = typeof memberID === "string" ? this.guild.members.get(memberID) : memberID;
         let permission = this.guild.permissionsOf(member).allow;
-        if(permission & Permissions.administrator) {
+        if (permission & Permissions.administrator) {
             return new Permission(Permissions.all);
         }
         const channel = this instanceof ThreadChannel ? this.guild.channels.get(this.parentID) : this;
         let overwrite = channel?.permissionOverwrites.get(this.guild.id);
-        if(overwrite) {
+        if (overwrite) {
             permission = (permission & ~overwrite.deny) | overwrite.allow;
         }
         let deny = 0n;
         let allow = 0n;
-        for(const roleID of member.roles) {
-            if((overwrite = channel?.permissionOverwrites.get(roleID))) {
+        for (const roleID of member.roles) {
+            if ((overwrite = channel?.permissionOverwrites.get(roleID))) {
                 deny |= overwrite.deny;
                 allow |= overwrite.allow;
             }
         }
         permission = (permission & ~deny) | allow;
         overwrite = channel?.permissionOverwrites.get(member.id);
-        if(overwrite) {
+        if (overwrite) {
             permission = (permission & ~overwrite.deny) | overwrite.allow;
         }
         return new Permission(permission);
@@ -155,7 +155,7 @@ class GuildChannel extends Channel {
             "name",
             "parentID",
             "flags",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildIntegration.js
+++ b/lib/structures/GuildIntegration.js
@@ -31,10 +31,10 @@ class GuildIntegration extends Base {
         this.guild = guild;
         this.name = data.name;
         this.type = data.type;
-        if(data.role_id !== undefined) {
+        if (data.role_id !== undefined) {
             this.roleID = data.role_id;
         }
-        if(data.user) {
+        if (data.user) {
             this.user = guild.shard.client.users.add(data.user, guild.shard.client);
         }
         this.account = data.account; // not worth making a class for
@@ -43,31 +43,31 @@ class GuildIntegration extends Base {
 
     update(data) {
         this.enabled = data.enabled;
-        if(data.syncing !== undefined) {
+        if (data.syncing !== undefined) {
             this.syncing = data.syncing;
         }
-        if(data.expire_behavior !== undefined) {
+        if (data.expire_behavior !== undefined) {
             this.expireBehavior = data.expire_behavior;
         }
-        if(data.expire_behavior !== undefined) {
+        if (data.expire_behavior !== undefined) {
             this.expireGracePeriod = data.expire_grace_period;
         }
-        if(data.enable_emoticons !== undefined) {
+        if (data.enable_emoticons !== undefined) {
             this.enableEmoticons = data.enable_emoticons;
         }
-        if(data.subscriber_count !== undefined) {
+        if (data.subscriber_count !== undefined) {
             this.subscriberCount = data.subscriber_count;
         }
-        if(data.synced_at !== undefined) {
+        if (data.synced_at !== undefined) {
             this.syncedAt = data.synced_at;
         }
-        if(data.revoked !== undefined) {
+        if (data.revoked !== undefined) {
             this.revoked = data.revoked;
         }
-        if(data.application !== undefined) {
+        if (data.application !== undefined) {
             this.application = data.application;
         }
-        if(data.scopes !== undefined) {
+        if (data.scopes !== undefined) {
             this.scopes = data.scopes;
         }
     }
@@ -97,7 +97,7 @@ class GuildIntegration extends Base {
             "syncing",
             "type",
             "user",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -92,7 +92,7 @@ class GuildPreview extends Base {
             "icon",
             "name",
             "splash",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -29,57 +29,57 @@ class GuildScheduledEvent extends Base {
         super(data.id);
 
         this.#client = client;
-        if(data.creator !== undefined) {
+        if (data.creator !== undefined) {
             this.creator = client.users.update(data.creator, this.client);
         } else {
             this.creator = null;
         }
         this.guild = client.guilds.get(data.guild_id) || {
-            id: data.guild_id
+            id: data.guild_id,
         };
         this.scheduledEndTime = null;
         this.update(data);
     }
 
     update(data) {
-        if(data.channel_id !== undefined) {
-            if(data.channel_id !== null) {
-                this.channel = this.#client.guilds.get(data.guild_id)?.channels.get(data.channel_id) || {id: data.channel_id};
+        if (data.channel_id !== undefined) {
+            if (data.channel_id !== null) {
+                this.channel = this.#client.guilds.get(data.guild_id)?.channels.get(data.channel_id) || { id: data.channel_id };
             } else {
                 this.channel = null;
             }
         }
-        if(data.name !== undefined) {
+        if (data.name !== undefined) {
             this.name = data.name;
         }
-        if(data.description !== undefined) {
+        if (data.description !== undefined) {
             this.description = data.description;
         }
-        if(data.scheduled_start_time !== undefined) {
+        if (data.scheduled_start_time !== undefined) {
             this.scheduledStartTime = Date.parse(data.scheduled_start_time);
         }
-        if(data.scheduled_end_time !== undefined) {
+        if (data.scheduled_end_time !== undefined) {
             this.scheduledEndTime = Date.parse(data.scheduled_end_time);
         }
-        if(data.privacy_level !== undefined) {
+        if (data.privacy_level !== undefined) {
             this.privacyLevel = data.privacy_level;
         }
-        if(data.status !== undefined) {
+        if (data.status !== undefined) {
             this.status = data.status;
         }
-        if(data.entity_type !== undefined) {
+        if (data.entity_type !== undefined) {
             this.entityType = data.entity_type;
         }
-        if(data.entity_id !== undefined) {
+        if (data.entity_id !== undefined) {
             this.entityID = data.entity_id;
         }
-        if(data.entity_metadata !== undefined) {
+        if (data.entity_metadata !== undefined) {
             this.entityMetadata = data.entity_metadata;
         }
-        if(data.user_count !== undefined) {
+        if (data.user_count !== undefined) {
             this.userCount = data.user_count;
         }
-        if(data.image !== undefined) {
+        if (data.image !== undefined) {
             this.image = data.image;
         }
     }
@@ -145,7 +145,7 @@ class GuildScheduledEvent extends Base {
             "scheduledStartTime",
             "status",
             "userCount",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const Base = require("./Base");
 const Guild = require("./Guild");
 
@@ -25,7 +27,7 @@ class GuildTemplate {
         this.isDirty = data.is_dirty;
         this.name = data.name;
         this.serializedSourceGuild = new Guild(data.serialized_source_guild, client);
-        this.sourceGuild = client.guilds.get(data.source_guild_id) || {id: data.source_guild_id};
+        this.sourceGuild = client.guilds.get(data.source_guild_id) || { id: data.source_guild_id };
         this.updatedAt = Date.parse(data.updated_at);
         this.usageCount = data.usage_count;
     }
@@ -79,7 +81,7 @@ class GuildTemplate {
             "sourceGuild",
             "updatedAt",
             "usageCount",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Base = require("./Base");
-const {InteractionTypes} = require("../Constants");
+const { InteractionTypes } = require("../Constants");
 const Member = require("./Member");
 const Permission = require("./Permission");
 
@@ -34,20 +34,20 @@ class Interaction extends Base {
         this.version = data.version;
         this.acknowledged = false;
 
-        if(data.channel !== undefined) {
+        if (data.channel !== undefined) {
             this.channel = this.#client.getChannel(data.channel.id) || data.channel;
         }
 
-        if(data.data !== undefined) {
+        if (data.data !== undefined) {
             this.data = JSON.parse(JSON.stringify(data.data));
         }
 
-        if(data.guild_id !== undefined) {
+        if (data.guild_id !== undefined) {
             this.guildID = data.guild_id;
         }
 
-        if(data.member !== undefined) {
-            if(this.channel.guild) {
+        if (data.member !== undefined) {
+            if (this.channel.guild) {
                 data.member.id = data.member.user.id;
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
             } else {
@@ -57,19 +57,19 @@ class Interaction extends Base {
             this.user = this.member.user;
         }
 
-        if(data.user !== undefined) {
+        if (data.user !== undefined) {
             this.user = this.#client.users.update(data.user, client);
         }
 
-        if(data.locale !== undefined) {
+        if (data.locale !== undefined) {
             this.locale = data.locale;
         }
 
-        if(data.guild_locale !== undefined) {
+        if (data.guild_locale !== undefined) {
             this.guildLocale = data.guild_locale;
         }
 
-        if(data.app_permissions !== undefined) {
+        if (data.app_permissions !== undefined) {
             this.appPermissions = new Permission(data.app_permissions);
         }
     }
@@ -79,7 +79,7 @@ class Interaction extends Base {
     }
 
     static from(data, client) {
-        switch(data.type) {
+        switch (data.type) {
             case InteractionTypes.APPLICATION_COMMAND: {
                 return new CommandInteraction(data, client);
             }
@@ -109,7 +109,7 @@ class Interaction extends Base {
             "token",
             "type",
             "version",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Invite.js
+++ b/lib/structures/Invite.js
@@ -39,19 +39,19 @@ class Invite extends Base {
         super();
         this.#client = client;
         this.code = data.code;
-        if(data.guild && client.guilds.has(data.guild.id)) {
+        if (data.guild && client.guilds.has(data.guild.id)) {
             this.channel = client.guilds.get(data.guild.id).channels.update(data.channel, client);
         } else {
             this.channel = data.channel;
         }
-        if(data.guild) {
-            if(client.guilds.has(data.guild.id)) {
+        if (data.guild) {
+            if (client.guilds.has(data.guild.id)) {
                 this.guild = client.guilds.update(data.guild, client);
             } else {
                 this.guild = new Guild(data.guild, client);
             }
         }
-        if(data.inviter) {
+        if (data.inviter) {
             this.inviter = client.users.add(data.inviter, client);
         }
         this.uses = data.uses !== undefined ? data.uses : null;
@@ -61,7 +61,7 @@ class Invite extends Base {
         this.#createdAt = data.created_at !== undefined ? data.created_at : null;
         this.presenceCount = data.approximate_presence_count !== undefined ? data.approximate_presence_count : null;
         this.memberCount = data.approximate_member_count !== undefined ? data.approximate_member_count : null;
-        if(data.stage_instance !== undefined) {
+        if (data.stage_instance !== undefined) {
             data.stage_instance.members = data.stage_instance.members.map((m) => {
                 m.id = m.user.id;
                 return m;
@@ -70,24 +70,24 @@ class Invite extends Base {
                 members: data.stage_instance.members.map((m) => this.guild.members.update(m, this.guild)),
                 participantCount: data.stage_instance.participant_count,
                 speakerCount: data.stage_instance.speaker_count,
-                topic: data.stage_instance.topic
+                topic: data.stage_instance.topic,
             };
         } else {
             this.stageInstance = null;
         }
-        if(data.target_application !== undefined) {
+        if (data.target_application !== undefined) {
             this.targetApplication = data.target_application;
         }
-        if(data.target_type !== undefined) {
+        if (data.target_type !== undefined) {
             this.targetType = data.target_type;
         }
-        if(data.target_user !== undefined) {
+        if (data.target_user !== undefined) {
             this.targetUser = client.users.update(data.target_user, this.#client);
         }
-        if(data.expires_at !== undefined) {
+        if (data.expires_at !== undefined) {
             this.expiresAt = Date.parse(data.expires_at);
         }
-        if(data.guild_scheduled_event !== undefined) {
+        if (data.guild_scheduled_event !== undefined) {
             this.guildScheduledEvent = new GuildScheduledEvent(data.guild_scheduled_event, client);
         }
     }
@@ -122,7 +122,7 @@ class Invite extends Base {
             "revoked",
             "temporary",
             "uses",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -46,19 +46,19 @@ const VoiceState = require("./VoiceState");
 class Member extends Base {
     constructor(data, guild, client) {
         super(data.id || data.user.id);
-        if(!data.id && data.user) {
+        if (!data.id && data.user) {
             data.id = data.user.id;
         }
-        if((this.guild = guild)) {
+        if ((this.guild = guild)) {
             this.user = guild.shard.client.users.get(data.id);
-            if(!this.user && data.user) {
+            if (!this.user && data.user) {
                 this.user = guild.shard.client.users.add(data.user, guild.shard.client);
             }
-            if(!this.user) {
+            if (!this.user) {
                 throw new Error("User associated with Member not found: " + data.id);
             }
-        } else if(data.user) {
-            if(!client) {
+        } else if (data.user) {
+            if (!client) {
                 this.user = new User(data.user);
             } else {
                 this.user = client.users.update(data.user, client);
@@ -74,51 +74,51 @@ class Member extends Base {
     }
 
     update(data) {
-        if(data.status !== undefined) {
+        if (data.status !== undefined) {
             this.status = data.status;
         }
-        if(data.joined_at !== undefined) {
+        if (data.joined_at !== undefined) {
             this.joinedAt = data.joined_at ?  Date.parse(data.joined_at) : null;
         }
-        if(data.client_status !== undefined) {
-            this.clientStatus = Object.assign({web: "offline", desktop: "offline", mobile: "offline"}, data.client_status);
+        if (data.client_status !== undefined) {
+            this.clientStatus = Object.assign({ web: "offline", desktop: "offline", mobile: "offline" }, data.client_status);
         }
-        if(data.activities !== undefined) {
+        if (data.activities !== undefined) {
             this.activities = data.activities;
         }
-        if(data.premium_since !== undefined) {
+        if (data.premium_since !== undefined) {
             this.premiumSince = data.premium_since === null ? null : Date.parse(data.premium_since);
         }
-        if(data.hasOwnProperty("mute") && this.guild) {
+        if (Object.hasOwn(data, "mute") && this.guild) {
             const state = this.guild.voiceStates.get(this.id);
-            if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
+            if (data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
                 this.guild.voiceStates.delete(this.id);
-            } else if(state) {
+            } else if (state) {
                 state.update(data);
-            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
+            } else if (data.channel_id || data.mute || data.deaf || data.suppress) {
                 this.guild.voiceStates.update(data);
             }
         }
-        if(data.nick !== undefined) {
+        if (data.nick !== undefined) {
             this.nick = data.nick;
         }
-        if(data.roles !== undefined) {
+        if (data.roles !== undefined) {
             this.roles = data.roles;
         }
-        if(data.pending !== undefined) {
+        if (data.pending !== undefined) {
             this.pending = data.pending;
         }
-        if(data.avatar !== undefined) {
+        if (data.avatar !== undefined) {
             this.avatar = data.avatar;
         }
-        if(data.communication_disabled_until !== undefined) {
-            if(data.communication_disabled_until !== null) {
+        if (data.communication_disabled_until !== undefined) {
+            if (data.communication_disabled_until !== null) {
                 this.communicationDisabledUntil = Date.parse(data.communication_disabled_until);
             } else {
                 this.communicationDisabledUntil = data.communication_disabled_until;
             }
         }
-        if(data.flags !== undefined) {
+        if (data.flags !== undefined) {
             this.flags = data.flags;
         }
     }
@@ -177,7 +177,7 @@ class Member extends Base {
 
     get voiceState() {
         return this.guild?.voiceStates.get(this.id) || new VoiceState({
-            id: this.id
+            id: this.id,
         });
     }
 
@@ -212,7 +212,7 @@ class Member extends Base {
     * @returns {String}
     */
     dynamicAvatarURL(format, size) {
-        if(!this.avatar) {
+        if (!this.avatar) {
             return this.user.dynamicAvatarURL(format, size);
         }
         return this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size);
@@ -278,7 +278,7 @@ class Member extends Base {
             "status",
             "user",
             "voiceState",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -2,7 +2,7 @@
 
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
-const {SystemJoinMessages, MessageTypes, MessageFlags} = require("../Constants");
+const { SystemJoinMessages, MessageTypes, MessageFlags } = require("../Constants");
 const User = require("./User");
 const Attachment = require("./Attachment");
 const Collection = require("../util/Collection");
@@ -63,18 +63,18 @@ class Message extends Base {
         this.attachments = new Collection(Attachment);
         this.timestamp = Date.parse(data.timestamp);
         this.channel = this.#client.getChannel(data.channel_id) || {
-            id: data.channel_id
+            id: data.channel_id,
         };
         this.content = "";
         this.reactions = {};
         this.guildID = data.guild_id;
         this.webhookID = data.webhook_id;
 
-        if(data.message_reference) {
+        if (data.message_reference) {
             this.messageReference = {
                 messageID: data.message_reference.message_id,
                 channelID: data.message_reference.channel_id,
-                guildID: data.message_reference.guild_id
+                guildID: data.message_reference.guild_id,
             };
         } else {
             this.messageReference = null;
@@ -82,8 +82,8 @@ class Message extends Base {
 
         this.flags = data.flags || 0;
 
-        if(data.author) {
-            if(data.author.discriminator !== "0000") {
+        if (data.author) {
+            if (data.author.discriminator !== "0000") {
                 this.author = this.#client.users.update(data.author, client);
             } else {
                 this.author = new User(data.author, client);
@@ -91,9 +91,9 @@ class Message extends Base {
         } else {
             this.#client.emit("error", new Error("MESSAGE_CREATE but no message author:\n" + JSON.stringify(data, null, 2)));
         }
-        if(data.referenced_message) {
+        if (data.referenced_message) {
             const channel = this.#client.getChannel(data.referenced_message.channel_id);
-            if(channel) {
+            if (channel) {
                 this.referencedMessage = channel.messages.update(data.referenced_message, this.#client);
             } else {
                 this.referencedMessage = new Message(data.referenced_message, this.#client);
@@ -102,18 +102,18 @@ class Message extends Base {
             this.referencedMessage = data.referenced_message;
         }
 
-        if(data.interaction) {
+        if (data.interaction) {
             this.interaction = data.interaction;
             let interactionMember;
             const interactionUser = this.#client.users.update(data.interaction.user, client);
-            if(data.interaction.member) {
+            if (data.interaction.member) {
                 data.interaction.member.id = data.interaction.user.id;
-                if(this.channel.guild) {
+                if (this.channel.guild) {
                     interactionMember = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
                 } else {
                     interactionMember = data.interaction.member;
                 }
-            } else if(this.channel.guild?.members.has(data.interaction.user.id)) {
+            } else if (this.channel.guild?.members.has(data.interaction.user.id)) {
                 interactionMember = this.channel.guild.members.get(data.interaction.user.id);
             } else {
                 interactionMember = null;
@@ -124,14 +124,14 @@ class Message extends Base {
             this.interaction = null;
         }
 
-        if(this.channel.guild) {
-            if(data.member) {
+        if (this.channel.guild) {
+            if (data.member) {
                 data.member.id = this.author.id;
-                if(data.author) {
+                if (data.author) {
                     data.member.user = data.author;
                 }
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else if(this.channel.guild.members.has(this.author.id)) {
+            } else if (this.channel.guild.members.has(this.author.id)) {
                 this.member = this.channel.guild.members.get(this.author.id);
             } else {
                 this.member = null;
@@ -139,29 +139,29 @@ class Message extends Base {
 
             this.guildID ??= this.channel.guild.id;
 
-            if(data.thread) {
+            if (data.thread) {
                 this.thread = this.channel.guild.threads.update(data.thread, client);
             }
         } else {
             this.member = null;
         }
 
-        if(data.attachments) {
-            for(const attachment of data.attachments) {
+        if (data.attachments) {
+            for (const attachment of data.attachments) {
                 this.attachments.add(attachment, this);
             }
         }
 
-        if(data.role_subscription_data) {
+        if (data.role_subscription_data) {
             this.roleSubscriptionData = {
                 isRenewal: data.role_subscription_data.is_renewal,
                 roleSubscriptionListingID: data.role_subscription_data.role_subscription_listing_id,
                 tierName: data.role_subscription_data.tier_name,
-                totalMonthsSubscribed: data.role_subscription_data.total_months_subscribed
+                totalMonthsSubscribed: data.role_subscription_data.total_months_subscribed,
             };
         }
 
-        switch(this.type) {
+        switch (this.type) {
             case MessageTypes.DEFAULT: {
                 break;
             }
@@ -170,7 +170,7 @@ class Message extends Base {
                 break;
             }
             case MessageTypes.RECIPIENT_REMOVE: {
-                if(this.author.id === data.mentions[0].id) {
+                if (this.author.id === data.mentions[0].id) {
                     data.content = `@${this.author.username} left the group.`;
                 } else {
                     data.content = `${this.author.mention} removed @${data.mentions[0].username}.`;
@@ -277,13 +277,13 @@ class Message extends Base {
     }
 
     update(data, client) {
-        if(data.content !== undefined) {
+        if (data.content !== undefined) {
             this.content = data.content || "";
             this.mentionEveryone = !!data.mention_everyone;
 
             this.mentions = data.mentions.map((mention) => {
                 const user = this.#client.users.add(mention, client);
-                if(mention.member && this.channel.guild) {
+                if (mention.member && this.channel.guild) {
                     mention.member.id = mention.id;
                     this.channel.guild.members.update(mention.member, this.channel.guild);
                 }
@@ -293,53 +293,53 @@ class Message extends Base {
             this.roleMentions = data.mention_roles;
         }
 
-        if(data.pinned !== undefined) {
+        if (data.pinned !== undefined) {
             this.pinned = !!data.pinned;
         }
-        if(data.edited_timestamp != undefined) {
+        if (data.edited_timestamp !== undefined) {
             this.editedTimestamp = Date.parse(data.edited_timestamp);
         }
-        if(data.tts !== undefined) {
+        if (data.tts !== undefined) {
             this.tts = data.tts;
         }
-        if(data.attachments) {
-            for(const id of this.attachments.keys()) {
-                if(!data.attachments.some((attachment) => attachment.id === id)) {
+        if (data.attachments) {
+            for (const id of this.attachments.keys()) {
+                if (!data.attachments.some((attachment) => attachment.id === id)) {
                     this.attachments.delete(id);
                 }
             }
-            for(const attachment of data.attachments) {
+            for (const attachment of data.attachments) {
                 this.attachments.update(attachment, this);
             }
         }
-        if(data.embeds !== undefined) {
+        if (data.embeds !== undefined) {
             this.embeds = data.embeds;
         }
-        if(data.flags !== undefined) {
+        if (data.flags !== undefined) {
             this.flags = data.flags;
         }
-        if(data.activity !== undefined) {
+        if (data.activity !== undefined) {
             this.activity = data.activity;
         }
-        if(data.application !== undefined) {
+        if (data.application !== undefined) {
             this.application = data.application;
         }
-        if(data.application_id !== undefined) {
+        if (data.application_id !== undefined) {
             this.applicationID = data.application_id;
         }
 
-        if(data.reactions) {
+        if (data.reactions) {
             data.reactions.forEach((reaction) => {
                 this.reactions[reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` : reaction.emoji.name] = {
                     count: reaction.count,
-                    me: reaction.me
+                    me: reaction.me,
                 };
             });
         }
 
-        if(data.sticker_items !== undefined) {
+        if (data.sticker_items !== undefined) {
             this.stickerItems = data.sticker_items.map((sticker) => {
-                if(sticker.user) {
+                if (sticker.user) {
                     sticker.user = this.#client.users.update(sticker.user, client);
                 }
 
@@ -347,20 +347,20 @@ class Message extends Base {
             });
         }
 
-        if(data.components !== undefined) {
+        if (data.components !== undefined) {
             this.components = data.components;
         }
 
-        if(data.mention_channels !== undefined) {
+        if (data.mention_channels !== undefined) {
             this.crosspostedChannelMentions = data.mention_channels.map((channel) => ({
                 guildID: channel.guild_id,
                 id: channel.id,
                 name: channel.name,
-                type: channel.type
+                type: channel.type,
             }));
         }
 
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
     }
@@ -374,21 +374,21 @@ class Message extends Base {
 
         let authorName = this.author.username;
         const member = this.channel.guild?.members.get(this.author.id);
-        if(member?.nick) {
+        if (member?.nick) {
             authorName = member.nick;
         }
         cleanContent = cleanContent.replace(new RegExp(`<@!?${this.author.id}>`, "g"), "@\u200b" + authorName);
 
         this.mentions?.forEach((mention) => {
             const member = this.channel.guild?.members.get(mention.id);
-            if(member?.nick) {
+            if (member?.nick) {
                 cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@\u200b" + member.nick);
             }
             cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@\u200b" + mention.username);
         });
 
-        if(this.channel.guild && this.roleMentions) {
-            for(const roleID of this.roleMentions) {
+        if (this.channel.guild && this.roleMentions) {
+            for (const roleID of this.roleMentions) {
                 const role = this.channel.guild.roles.get(roleID);
                 const roleName = role?.name ?? "deleted-role";
                 cleanContent = cleanContent.replace(new RegExp(`<@&${roleID}>`, "g"), "@\u200b" + roleName);
@@ -397,7 +397,7 @@ class Message extends Base {
 
         this.channelMentions.forEach((id) => {
             const channel = this.#client.getChannel(id);
-            if(channel?.name && channel?.mention) {
+            if (channel?.name && channel?.mention) {
                 cleanContent = cleanContent.replace(channel.mention, "#" + channel.name);
             }
         });
@@ -415,7 +415,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     addReaction(reaction) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot have reactions");
         }
         return this.#client.addMessageReaction.call(this.#client, this.channel.id, this.id, reaction);
@@ -437,7 +437,7 @@ class Message extends Base {
      * @returns {Promise<Message>}
      */
     crosspost() {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be crossposted");
         }
         return this.#client.crosspostMessage.call(this.#client, this.channel.id, this.id);
@@ -449,7 +449,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     delete(reason) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be deleted");
         }
         return this.#client.deleteMessage.call(this.#client, this.channel.id, this.id, reason);
@@ -461,10 +461,10 @@ class Message extends Base {
     * @returns {Promise}
     */
     deleteWebhook(token) {
-        if(!this.webhookID) {
+        if (!this.webhookID) {
             throw new Error("Message is not a webhook");
         }
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be deleted");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.webhookID, token, this.id);
@@ -489,7 +489,7 @@ class Message extends Base {
     * @returns {Promise<Message>}
     */
     edit(content) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be edited via this method");
         }
         return this.#client.editMessage.call(this.#client, this.channel.id, this.id, content);
@@ -515,7 +515,7 @@ class Message extends Base {
     * @returns {Promise<Message>}
     */
     editWebhook(token, options) {
-        if(!this.webhookID) {
+        if (!this.webhookID) {
             throw new Error("Message is not a webhook");
         }
         return this.#client.editWebhookMessage.call(this.#client, this.webhookID, token, this.id, options);
@@ -530,7 +530,7 @@ class Message extends Base {
     * @returns {Promise<Array<User>>}
     */
     getReaction(reaction, options) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot have reactions");
         }
         return this.#client.getMessageReaction.call(this.#client, this.channel.id, this.id, reaction, options);
@@ -541,7 +541,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     pin() {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be pinned");
         }
         return this.#client.pinMessage.call(this.#client, this.channel.id, this.id);
@@ -554,7 +554,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     removeReaction(reaction, userID) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot have reactions");
         }
         return this.#client.removeMessageReaction.call(this.#client, this.channel.id, this.id, reaction, userID);
@@ -566,7 +566,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     removeReactionEmoji(reaction) {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot have reactions");
         }
         return this.#client.removeMessageReactionEmoji.call(this.#client, this.channel.id, this.id, reaction);
@@ -577,7 +577,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     removeReactions() {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot have reactions");
         }
         return this.#client.removeMessageReactions.call(this.#client, this.channel.id, this.id);
@@ -588,7 +588,7 @@ class Message extends Base {
     * @returns {Promise}
     */
     unpin() {
-        if(this.flags & MessageFlags.EPHEMERAL) {
+        if (this.flags & MessageFlags.EPHEMERAL) {
             throw new Error("Ephemeral messages cannot be pinned");
         }
         return this.#client.unpinMessage.call(this.#client, this.channel.id, this.id);
@@ -619,7 +619,7 @@ class Message extends Base {
             "tts",
             "type",
             "webhookID",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -2,7 +2,7 @@
 
 const Interaction = require("./Interaction");
 
-const {InteractionResponseTypes} = require("../Constants");
+const { InteractionResponseTypes } = require("../Constants");
 
 /**
 * Represents a modal submit interaction. See Interaction for more properties
@@ -49,19 +49,19 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise<Message?>}
     */
     async createFollowup(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("createFollowup cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
-        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({wait: true}, content));
+        return this.#client.executeWebhook.call(this.#client, this.applicationID, this.token, Object.assign({ wait: true }, content));
     }
 
     /**
@@ -83,28 +83,28 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async createMessage(content) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             return this.createFollowup(content);
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const { files, attachments } = this.#client._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
+            data: content,
         }, files).then(() => this.update());
     }
 
@@ -115,14 +115,14 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async defer(flags) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
             data: {
-                flags: flags || 0
-            }
+                flags: flags || 0,
+            },
         }).then(() => this.update());
     }
 
@@ -132,11 +132,11 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async deferUpdate() {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.DEFERRED_UPDATE_MESSAGE
+            type: InteractionResponseTypes.DEFERRED_UPDATE_MESSAGE,
         }).then(() => this.update());
     }
 
@@ -146,7 +146,7 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async deleteMessage(messageID) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, messageID);
@@ -158,7 +158,7 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async deleteOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("deleteOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.deleteWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");
@@ -184,15 +184,15 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     async editMessage(messageID, content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -218,15 +218,15 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     async editOriginalMessage(content) {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("editOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
         }
@@ -255,28 +255,28 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise}
     */
     async editParent(content) {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             return this.editOriginalMessage(content);
         }
-        if(content !== undefined) {
-            if(typeof content !== "object" || content === null) {
+        if (content !== undefined) {
+            if (typeof content !== "object" || content === null) {
                 content = {
-                    content: "" + content
+                    content: "" + content,
                 };
-            } else if(content.content !== undefined && typeof content.content !== "string") {
+            } else if (content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            if(content.content !== undefined || content.embeds || content.allowedMentions) {
+            if (content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const { files, attachments } = this.#client._processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.UPDATE_MESSAGE,
-            data: content
+            data: content,
         }, files).then(() => this.update());
     }
 
@@ -286,7 +286,7 @@ class ModalSubmitInteraction extends Interaction {
     * @returns {Promise<Message>}
     */
     async getOriginalMessage() {
-        if(this.acknowledged === false) {
+        if (this.acknowledged === false) {
             throw new Error("getOriginalMessage cannot be used to acknowledge an interaction, please use acknowledge, createMessage, defer, deferUpdate, or editParent first.");
         }
         return this.#client.getWebhookMessage.call(this.#client, this.applicationID, this.token, "@original");

--- a/lib/structures/Permission.js
+++ b/lib/structures/Permission.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Base = require("./Base");
-const {Permissions} = require("../Constants");
+const { Permissions } = require("../Constants");
 
 /**
 * Represents a calculated permissions number
@@ -29,13 +29,13 @@ class Permission extends Base {
     }
 
     get json() {
-        if(!this.#json) {
+        if (!this.#json) {
             this.#json = {};
-            for(const perm of Object.keys(Permissions)) {
-                if(!perm.startsWith("all")) {
-                    if(this.allow & Permissions[perm]) {
+            for (const perm of Object.keys(Permissions)) {
+                if (!perm.startsWith("all")) {
+                    if (this.allow & Permissions[perm]) {
                         this.#json[perm] = true;
-                    } else if(this.deny & Permissions[perm]) {
+                    } else if (this.deny & Permissions[perm]) {
                         this.#json[perm] = false;
                     }
                 }
@@ -50,7 +50,7 @@ class Permission extends Base {
     * @returns {Boolean} Whether the permission allows the specified permission
     */
     has(permission) {
-        if(typeof permission === "bigint") {
+        if (typeof permission === "bigint") {
             return (this.allow & permission) === permission;
         }
         return !!(this.allow & Permissions[permission]);
@@ -64,7 +64,7 @@ class Permission extends Base {
         return super.toJSON([
             "allow",
             "deny",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -18,7 +18,7 @@ class PermissionOverwrite extends Permission {
     toJSON(props = []) {
         return super.toJSON([
             "type",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/PingInteraction.js
+++ b/lib/structures/PingInteraction.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Interaction = require("./Interaction");
-const {InteractionResponseTypes} = require("../Constants");
+const { InteractionResponseTypes } = require("../Constants");
 
 /**
 * Represents a ping interaction. See Interaction for more properties.
@@ -29,11 +29,11 @@ class PingInteraction extends Interaction {
     * @returns {Promise}
     */
     pong() {
-        if(this.acknowledged === true) {
+        if (this.acknowledged === true) {
             throw new Error("You have already acknowledged this interaction.");
         }
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.PONG
+            type: InteractionResponseTypes.PONG,
         }).then(() => this.update());
     }
 

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -3,7 +3,7 @@
 const Channel = require("./Channel");
 const Collection = require("../util/Collection");
 const Message = require("./Message");
-const {ChannelTypes} = require("../Constants");
+const { ChannelTypes } = require("../Constants");
 const User = require("./User");
 
 /**
@@ -18,7 +18,7 @@ class PrivateChannel extends Channel {
         super(data, client);
         this.lastMessageID = data.last_message_id;
         this.rateLimitPerUser = data.rate_limit_per_user;
-        if(this.type === ChannelTypes.DM || this.type === undefined) {
+        if (this.type === ChannelTypes.DM || this.type === undefined) {
             this.recipient = new User(data.recipients[0], client);
         }
         this.messages = new Collection(Message, client.options.messageLimit);
@@ -196,7 +196,7 @@ class PrivateChannel extends Channel {
             "lastMessageID",
             "messages",
             "recipient",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/PrivateThreadChannel.js
+++ b/lib/structures/PrivateThreadChannel.js
@@ -20,14 +20,14 @@ class PrivateThreadChannel extends ThreadChannel {
 
     update(data) {
         super.update(data);
-        if(data.thread_metadata !== undefined) {
+        if (data.thread_metadata !== undefined) {
             this.threadMetadata = {
                 archiveTimestamp: Date.parse(data.thread_metadata.archive_timestamp),
                 archived: data.thread_metadata.archived,
                 autoArchiveDuration: data.thread_metadata.auto_archive_duration,
                 createTimestamp: !data.thread_metadata.create_timestamp ? null : Date.parse(data.thread_metadata.create_timestamp),
                 invitable: data.thread_metadata.invitable,
-                locked: data.thread_metadata.locked
+                locked: data.thread_metadata.locked,
             };
         }
     }

--- a/lib/structures/PublicThreadChannel.js
+++ b/lib/structures/PublicThreadChannel.js
@@ -15,7 +15,7 @@ class PublicThreadChannel extends ThreadChannel {
 
     update(data) {
         super.update(data);
-        if(data.applied_tags !== undefined) {
+        if (data.applied_tags !== undefined) {
             this.appliedTags = data.applied_tags;
         }
     }

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -34,43 +34,43 @@ class Role extends Base {
     }
 
     update(data) {
-        if(data.name !== undefined) {
+        if (data.name !== undefined) {
             this.name = data.name;
         }
-        if(data.mentionable !== undefined) {
+        if (data.mentionable !== undefined) {
             this.mentionable = data.mentionable;
         }
-        if(data.managed !== undefined) {
+        if (data.managed !== undefined) {
             this.managed = data.managed;
         }
-        if(data.hoist !== undefined) {
+        if (data.hoist !== undefined) {
             this.hoist = data.hoist;
         }
-        if(data.color !== undefined) {
+        if (data.color !== undefined) {
             this.color = data.color;
         }
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
-        if(data.permissions !== undefined) {
+        if (data.permissions !== undefined) {
             this.permissions = new Permission(data.permissions);
         }
-        if(data.tags !== undefined) {
+        if (data.tags !== undefined) {
             this.tags = data.tags;
-            if(this.tags.guild_connections === null) {
+            if (this.tags.guild_connections === null) {
                 this.tags.guild_connections = true;
             }
-            if(this.tags.premium_subscriber === null) {
+            if (this.tags.premium_subscriber === null) {
                 this.tags.premium_subscriber = true;
             }
-            if(this.tags.available_for_purchase === null) {
+            if (this.tags.available_for_purchase === null) {
                 this.tags.available_for_purchase = true;
             }
         }
-        if(data.icon !== undefined) {
+        if (data.icon !== undefined) {
             this.icon = data.icon;
         }
-        if(data.unicode_emoji !== undefined) {
+        if (data.unicode_emoji !== undefined) {
             this.unicodeEmoji = data.unicode_emoji;
         }
     }
@@ -134,7 +134,7 @@ class Role extends Base {
             "position",
             "tags",
             "unicodeEmoji",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/StageChannel.js
+++ b/lib/structures/StageChannel.js
@@ -9,7 +9,7 @@ const TextVoiceChannel = require("./TextVoiceChannel");
 class StageChannel extends TextVoiceChannel {
     update(data) {
         super.update(data);
-        if(data.topic !== undefined) {
+        if (data.topic !== undefined) {
             this.topic = data.topic;
         }
     }

--- a/lib/structures/StageInstance.js
+++ b/lib/structures/StageInstance.js
@@ -17,20 +17,20 @@ class StageInstance extends Base {
     constructor(data, client) {
         super(data.id);
         this.#client = client;
-        this.channel = client.getChannel(data.channel_id) || {id: data.channel_id};
-        this.guild = client.guilds.get(data.guild_id) || {id: data.guild_id};
-        this.guildScheduledEvent = this.guild.events?.get(data.guild_scheduled_event_id) || {id: data.guild_scheduled_event_id};
+        this.channel = client.getChannel(data.channel_id) || { id: data.channel_id };
+        this.guild = client.guilds.get(data.guild_id) || { id: data.guild_id };
+        this.guildScheduledEvent = this.guild.events?.get(data.guild_scheduled_event_id) || { id: data.guild_scheduled_event_id };
         this.update(data);
     }
 
     update(data) {
-        if(data.discoverable_disabled !== undefined) {
+        if (data.discoverable_disabled !== undefined) {
             this.discoverableDisabled = data.discoverable_disabled;
         }
-        if(data.privacy_level !== undefined) {
+        if (data.privacy_level !== undefined) {
             this.privacyLevel = data.privacy_level;
         }
-        if(data.topic !== undefined) {
+        if (data.topic !== undefined) {
             this.topic = data.topic;
         }
     }

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -30,22 +30,22 @@ class TextChannel extends GuildChannel {
 
     update(data) {
         super.update(data);
-        if(data.rate_limit_per_user !== undefined) {
+        if (data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
-        if(data.topic !== undefined) {
+        if (data.topic !== undefined) {
             this.topic = data.topic;
         }
-        if(data.default_auto_archive_duration !== undefined) {
+        if (data.default_auto_archive_duration !== undefined) {
             this.defaultAutoArchiveDuration = data.default_auto_archive_duration;
         }
-        if(data.permission_overwrites) {
+        if (data.permission_overwrites) {
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
     }
@@ -357,7 +357,7 @@ class TextChannel extends GuildChannel {
             "position",
             "rateLimitPerUser",
             "topic",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -26,13 +26,13 @@ class TextVoiceChannel extends VoiceChannel {
     update(data) {
         super.update(data);
         // "not yet, possibly TBD"
-        if(data.rate_limit_per_user !== undefined) {
+        if (data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
-        if(data.user_limit !== undefined) {
+        if (data.user_limit !== undefined) {
             this.userLimit = data.user_limit;
         }
-        if(data.video_quality_mode !== undefined) {
+        if (data.video_quality_mode !== undefined) {
             this.videoQualityMode = data.video_quality_mode;
         }
     }
@@ -236,7 +236,7 @@ class TextVoiceChannel extends VoiceChannel {
             "rateLimitPerUser",
             "userLimit",
             "videoQualityMode",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -39,28 +39,28 @@ class ThreadChannel extends GuildChannel {
 
     update(data) {
         super.update(data);
-        if(data.member_count !== undefined) {
+        if (data.member_count !== undefined) {
             this.memberCount = data.member_count;
         }
-        if(data.message_count !== undefined) {
+        if (data.message_count !== undefined) {
             this.messageCount = data.message_count;
         }
-        if(data.rate_limit_per_user !== undefined) {
+        if (data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
-        if(data.thread_metadata !== undefined) {
+        if (data.thread_metadata !== undefined) {
             this.threadMetadata = {
                 archiveTimestamp: Date.parse(data.thread_metadata.archive_timestamp),
                 archived: data.thread_metadata.archived,
                 autoArchiveDuration: data.thread_metadata.auto_archive_duration,
                 createTimestamp: !data.thread_metadata.create_timestamp ? null : Date.parse(data.thread_metadata.create_timestamp),
-                locked: data.thread_metadata.locked
+                locked: data.thread_metadata.locked,
             };
         }
-        if(data.member !== undefined) {
+        if (data.member !== undefined) {
             this.member = new ThreadMember(data.member, this.client);
         }
-        if(data.total_message_sent !== undefined) {
+        if (data.total_message_sent !== undefined) {
             this.totalMessageSent = data.total_message_sent;
         }
     }
@@ -321,7 +321,7 @@ class ThreadChannel extends GuildChannel {
             "threadMetadata",
             "member",
             "totalMessageSent",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -20,14 +20,14 @@ class ThreadMember extends Base {
         this.threadID = data.thread_id || data.id; // Thanks Discord
         this.joinTimestamp = Date.parse(data.join_timestamp);
 
-        if(data.member !== undefined) {
-            if(data.member.id === undefined) {
+        if (data.member !== undefined) {
+            if (data.member.id === undefined) {
                 data.member.id = this.id;
             }
 
             const guild = this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
             this.guildMember = guild ? guild.members.update(data.member, guild) : new Member(data.member, guild, client);
-            if(data.presence !== undefined) {
+            if (data.presence !== undefined) {
                 this.guildMember.update(data.presence);
             }
         }
@@ -36,7 +36,7 @@ class ThreadMember extends Base {
     }
 
     update(data) {
-        if(data.flags !== undefined) {
+        if (data.flags !== undefined) {
             this.flags = data.flags;
         }
     }
@@ -53,7 +53,7 @@ class ThreadMember extends Base {
         return super.toJSON([
             "threadID",
             "joinTimestamp",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -18,7 +18,7 @@ class UnavailableGuild extends Base {
     toJSON(props = []) {
         return super.toJSON([
             "unavailable",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -27,7 +27,7 @@ class User extends Base {
     #missingClientError;
     constructor(data, client) {
         super(data.id);
-        if(!client) {
+        if (!client) {
             this.#missingClientError = new Error("Missing client in constructor"); // Preserve constructor callstack
         }
         this.#client = client;
@@ -37,38 +37,38 @@ class User extends Base {
     }
 
     update(data) {
-        if(data.avatar !== undefined) {
+        if (data.avatar !== undefined) {
             this.avatar = data.avatar;
         }
-        if(data.username !== undefined) {
+        if (data.username !== undefined) {
             this.username = data.username;
         }
-        if(data.discriminator !== undefined) {
+        if (data.discriminator !== undefined) {
             this.discriminator = data.discriminator;
         }
-        if(data.public_flags !== undefined) {
+        if (data.public_flags !== undefined) {
             this.publicFlags = data.public_flags;
         }
-        if(data.banner !== undefined) {
+        if (data.banner !== undefined) {
             this.banner = data.banner;
         }
-        if(data.accent_color !== undefined) {
+        if (data.accent_color !== undefined) {
             this.accentColor = data.accent_color;
         }
     }
 
     get avatarURL() {
-        if(this.#missingClientError) {
+        if (this.#missingClientError) {
             throw this.#missingClientError;
         }
         return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar)) : this.defaultAvatarURL;
     }
 
     get bannerURL() {
-        if(!this.banner) {
+        if (!this.banner) {
             return null;
         }
-        if(this.#missingClientError) {
+        if (this.#missingClientError) {
             throw this.#missingClientError;
         }
         return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner));
@@ -87,7 +87,7 @@ class User extends Base {
     }
 
     get staticAvatarURL() {
-        if(this.#missingClientError) {
+        if (this.#missingClientError) {
             throw this.#missingClientError;
         }
         return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "jpg") : this.defaultAvatarURL;
@@ -100,10 +100,10 @@ class User extends Base {
     * @returns {String}
     */
     dynamicAvatarURL(format, size) {
-        if(!this.avatar) {
+        if (!this.avatar) {
             return this.defaultAvatarURL;
         }
-        if(this.#missingClientError) {
+        if (this.#missingClientError) {
             throw this.#missingClientError;
         }
         return this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size);
@@ -116,10 +116,10 @@ class User extends Base {
     * @returns {String?}
     */
     dynamicBannerURL(format, size) {
-        if(!this.banner) {
+        if (!this.banner) {
             return null;
         }
-        if(this.#missingClientError) {
+        if (this.#missingClientError) {
             throw this.#missingClientError;
         }
         return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size);
@@ -143,7 +143,7 @@ class User extends Base {
             "publicFlags",
             "system",
             "username",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -24,19 +24,19 @@ class VoiceChannel extends GuildChannel {
     update(data) {
         super.update(data);
 
-        if(data.bitrate !== undefined) {
+        if (data.bitrate !== undefined) {
             this.bitrate = data.bitrate;
         }
-        if(data.rtc_region !== undefined) {
+        if (data.rtc_region !== undefined) {
             this.rtcRegion = data.rtc_region;
         }
-        if(data.permission_overwrites) {
+        if (data.permission_overwrites) {
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
-        if(data.position !== undefined) {
+        if (data.position !== undefined) {
             this.position = data.position;
         }
     }
@@ -90,7 +90,7 @@ class VoiceChannel extends GuildChannel {
             "position",
             "rtcRegion",
             "voiceMembers",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -31,34 +31,34 @@ class VoiceState extends Base {
     }
 
     update(data) {
-        if(data.channel_id !== undefined) {
+        if (data.channel_id !== undefined) {
             this.channelID = data.channel_id;
             this.sessionID = data.channel_id === null ? null : data.session_id;
-        } else if(this.channelID === undefined) {
+        } else if (this.channelID === undefined) {
             this.channelID = this.sessionID = null;
         }
-        if(data.mute !== undefined) {
+        if (data.mute !== undefined) {
             this.mute = data.mute;
         }
-        if(data.deaf !== undefined) {
+        if (data.deaf !== undefined) {
             this.deaf = data.deaf;
         }
-        if(data.request_to_speak_timestamp !== undefined) {
+        if (data.request_to_speak_timestamp !== undefined) {
             this.requestToSpeakTimestamp = Date.parse(data.request_to_speak_timestamp);
         }
-        if(data.self_mute !== undefined) {
+        if (data.self_mute !== undefined) {
             this.selfMute = data.self_mute;
         }
-        if(data.self_deaf !== undefined) {
+        if (data.self_deaf !== undefined) {
             this.selfDeaf = data.self_deaf;
         }
-        if(data.self_video !== undefined) {
+        if (data.self_video !== undefined) {
             this.selfVideo = data.self_video;
         }
-        if(data.self_stream !== undefined) {
+        if (data.self_stream !== undefined) {
             this.selfStream = data.self_stream;
         }
-        if(data.suppress !== undefined) { // Bots ignore this
+        if (data.suppress !== undefined) { // Bots ignore this
             this.suppress = data.suppress;
         }
     }
@@ -75,7 +75,7 @@ class VoiceState extends Base {
             "selfVideo",
             "sessionID",
             "suppress",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/util/BrowserWebSocket.js
+++ b/lib/util/BrowserWebSocket.js
@@ -1,10 +1,12 @@
+"use strict";
+
 const util = require("node:util");
 const Base = require("../structures/Base");
 
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 
@@ -25,7 +27,7 @@ class BrowserWebSocket extends EventEmitter {
     constructor(url) {
         super();
 
-        if(typeof window === "undefined") {
+        if (typeof window === "undefined") {
             throw new Error("BrowserWebSocket cannot be used outside of a browser environment");
         }
 
@@ -57,7 +59,7 @@ class BrowserWebSocket extends EventEmitter {
     }
 
     async #onMessage(event) {
-        if(event.data instanceof window.Blob) {
+        if (event.data instanceof window.Blob) {
             this.emit("message", await event.data.arrayBuffer());
         } else {
             this.emit("message", event.data);

--- a/lib/util/Bucket.js
+++ b/lib/util/Bucket.js
@@ -12,10 +12,11 @@ const Base = require("../structures/Base");
 * @prop {Number} tokens How many tokens the bucket has consumed in this interval
 */
 class Bucket {
-    #queue = [];
     lastReset = 0;
     lastSend = 0;
     tokens = 0;
+    #queue = [];
+
     /**
     * Construct a Bucket
     * @arg {Number} tokenLimit The max number of tokens the bucket can consume per interval
@@ -28,15 +29,15 @@ class Bucket {
     constructor(tokenLimit, interval, options = {}) {
         this.tokenLimit = tokenLimit;
         this.interval = interval;
-        this.latencyRef = options.latencyRef || {latency: 0};
+        this.latencyRef = options.latencyRef || { latency: 0 };
         this.reservedTokens = options.reservedTokens || 0;
     }
 
     check() {
-        if(this.timeout || this.#queue.length === 0) {
+        if (this.timeout || this.#queue.length === 0) {
             return;
         }
-        if(this.lastReset + this.interval + this.tokenLimit * this.latencyRef.latency < Date.now()) {
+        if (this.lastReset + this.interval + this.tokenLimit * this.latencyRef.latency < Date.now()) {
             this.lastReset = Date.now();
             this.tokens = Math.max(0, this.tokens - this.tokenLimit);
         }
@@ -44,13 +45,13 @@ class Bucket {
         let val;
         let tokensAvailable = this.tokens < this.tokenLimit;
         let unreservedTokensAvailable = this.tokens < (this.tokenLimit - this.reservedTokens);
-        while(this.#queue.length > 0 && (unreservedTokensAvailable || (tokensAvailable && this.#queue[0].priority))) {
+        while (this.#queue.length > 0 && (unreservedTokensAvailable || (tokensAvailable && this.#queue[0].priority))) {
             this.tokens++;
             tokensAvailable = this.tokens < this.tokenLimit;
             unreservedTokensAvailable = this.tokens < (this.tokenLimit - this.reservedTokens);
             const item = this.#queue.shift();
             val = this.latencyRef.latency - Date.now() + this.lastSend;
-            if(this.latencyRef.latency === 0 || val <= 0) {
+            if (this.latencyRef.latency === 0 || val <= 0) {
                 item.func();
                 this.lastSend = Date.now();
             } else {
@@ -61,7 +62,7 @@ class Bucket {
             }
         }
 
-        if(this.#queue.length > 0 && !this.timeout) {
+        if (this.#queue.length > 0 && !this.timeout) {
             this.timeout = setTimeout(() => {
                 this.timeout = null;
                 this.check();
@@ -75,10 +76,10 @@ class Bucket {
     * @arg {Boolean} [priority=false] Whether or not the callback should use reserved tokens
     */
     queue(func, priority=false) {
-        if(priority) {
-            this.#queue.unshift({func, priority});
+        if (priority) {
+            this.#queue.unshift({ func, priority });
         } else {
-            this.#queue.push({func, priority});
+            this.#queue.push({ func, priority });
         }
         this.check();
     }

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -27,11 +27,11 @@ class Collection extends Map {
     * @returns {Class} The updated object
     */
     update(obj, extra, replace) {
-        if(!obj.id && obj.id !== 0) {
+        if (!obj.id && obj.id !== 0) {
             throw new Error("Missing object id");
         }
         const item = this.get(obj.id);
-        if(!item) {
+        if (!item) {
             return this.add(obj, extra, replace);
         }
         item.update(obj, extra);
@@ -47,25 +47,25 @@ class Collection extends Map {
     * @returns {Class} The existing or newly created object
     */
     add(obj, extra, replace) {
-        if(this.limit === 0) {
+        if (this.limit === 0) {
             return (obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name) ? obj : new this.baseObject(obj, extra);
         }
-        if(obj.id == null) {
+        if (obj.id == null) {
             throw new Error("Missing object id");
         }
         const existing = this.get(obj.id);
-        if(existing && !replace) {
+        if (existing && !replace) {
             return existing;
         }
-        if(!(obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name)) {
+        if (!(obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name)) {
             obj = new this.baseObject(obj, extra);
         }
 
         this.set(obj.id, obj);
 
-        if(this.limit && this.size > this.limit) {
+        if (this.limit && this.size > this.limit) {
             const iter = this.keys();
-            while(this.size > this.limit) {
+            while (this.size > this.limit) {
                 this.delete(iter.next().value);
             }
         }
@@ -78,8 +78,8 @@ class Collection extends Map {
      * @returns {Boolean} Whether or not all elements satisfied the condition
      */
     every(func) {
-        for(const item of this.values()) {
-            if(!func(item)) {
+        for (const item of this.values()) {
+            if (!func(item)) {
                 return false;
             }
         }
@@ -93,8 +93,8 @@ class Collection extends Map {
     */
     filter(func) {
         const arr = [];
-        for(const item of this.values()) {
-            if(func(item)) {
+        for (const item of this.values()) {
+            if (func(item)) {
                 arr.push(item);
             }
         }
@@ -107,8 +107,8 @@ class Collection extends Map {
     * @returns {Class?} The first matching object, or undefined if no match
     */
     find(func) {
-        for(const item of this.values()) {
-            if(func(item)) {
+        for (const item of this.values()) {
+            if (func(item)) {
                 return item;
             }
         }
@@ -122,7 +122,7 @@ class Collection extends Map {
     */
     map(func) {
         const arr = [];
-        for(const item of this.values()) {
+        for (const item of this.values()) {
             arr.push(func(item));
         }
         return arr;
@@ -135,7 +135,7 @@ class Collection extends Map {
     random() {
         const index = Math.floor(Math.random() * this.size);
         const iter = this.values();
-        for(let i = 0; i < index; ++i) {
+        for (let i = 0; i < index; ++i) {
             iter.next();
         }
         return iter.next().value;
@@ -151,7 +151,7 @@ class Collection extends Map {
         const iter = this.values();
         let val;
         let result = initialValue === undefined ? iter.next().value : initialValue;
-        while((val = iter.next().value) !== undefined) {
+        while ((val = iter.next().value) !== undefined) {
             result = func(result, val);
         }
         return result;
@@ -165,7 +165,7 @@ class Collection extends Map {
     */
     remove(obj) {
         const item = this.get(obj.id);
-        if(!item) {
+        if (!item) {
             return null;
         }
         this.delete(obj.id);
@@ -178,8 +178,8 @@ class Collection extends Map {
      * @returns {Boolean} Whether or not at least one element satisfied the condition
      */
     some(func) {
-        for(const item of this.values()) {
-            if(func(item)) {
+        for (const item of this.values()) {
+            if (func(item)) {
                 return true;
             }
         }
@@ -192,7 +192,7 @@ class Collection extends Map {
 
     toJSON() {
         const json = {};
-        for(const item of this.values()) {
+        for (const item of this.values()) {
             json[item.id] = item;
         }
         return json;

--- a/lib/util/MultipartData.js
+++ b/lib/util/MultipartData.js
@@ -5,17 +5,17 @@ class MultipartData {
     bufs = [];
 
     attach(fieldName, data, filename) {
-        if(data === undefined) {
+        if (data === undefined) {
             return;
         }
         let str = "\r\n--" + this.boundary + "\r\nContent-Disposition: form-data; name=\"" + fieldName + "\"";
         let contentType;
-        if(filename) {
+        if (filename) {
             str += "; filename=\"" + filename + "\"";
             const extension = filename.match(/\.(png|apng|gif|jpg|jpeg|webp|svg|json)$/i);
-            if(extension) {
+            if (extension) {
                 let ext = extension[1].toLowerCase();
-                switch(ext) {
+                switch (ext) {
                     case "png":
                     case "apng":
                     case "gif":
@@ -23,7 +23,7 @@ class MultipartData {
                     case "jpeg":
                     case "webp":
                     case "svg": {
-                        if(ext === "svg") {
+                        if (ext === "svg") {
                             ext = "svg+xml";
                         }
                         contentType = "image/";
@@ -38,14 +38,14 @@ class MultipartData {
             }
         }
 
-        if(contentType) {
+        if (contentType) {
             str += `\r\nContent-Type: ${contentType}`;
-        } else if(ArrayBuffer.isView(data)) {
+        } else if (ArrayBuffer.isView(data)) {
             str +="\r\nContent-Type: application/octet-stream";
-            if(!(data instanceof Uint8Array)) {
+            if (!(data instanceof Uint8Array)) {
                 data = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
             }
-        } else if(typeof data === "object") {
+        } else if (typeof data === "object") {
             str +="\r\nContent-Type: application/json";
             data = Buffer.from(JSON.stringify(data));
         } else {

--- a/lib/util/Opus.js
+++ b/lib/util/Opus.js
@@ -4,29 +4,29 @@ let NativeOpus;
 let OpusScript;
 
 module.exports.createOpus = function createOpus(samplingRate, channels, bitrate) {
-    if(!NativeOpus && !OpusScript) {
+    if (!NativeOpus && !OpusScript) {
         try {
             NativeOpus = require("@discordjs/opus");
-        } catch{
+        } catch {
             try {
                 OpusScript = require("opusscript");
-            } catch{ // eslint-disable no-empty
+            } catch { // eslint-disable no-empty
             }
         }
     }
 
     let opus;
-    if(NativeOpus) {
+    if (NativeOpus) {
         opus = new NativeOpus.OpusEncoder(samplingRate, channels);
-    } else if(OpusScript) {
+    } else if (OpusScript) {
         opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
     } else {
         throw new Error("No opus encoder found, playing non-opus audio will not work.");
     }
 
-    if(opus.setBitrate) {
+    if (opus.setBitrate) {
         opus.setBitrate(bitrate);
-    } else if(opus.encoderCTL) {
+    } else if (opus.encoderCTL) {
         opus.encoderCTL(4002, bitrate);
     }
 

--- a/lib/util/SequentialBucket.js
+++ b/lib/util/SequentialBucket.js
@@ -12,39 +12,40 @@ const Base = require("../structures/Base");
 * @prop {Number} reset Timestamp of next reset
 */
 class SequentialBucket {
-    #queue = [];
     processing = false;
     reset = 0;
+    #queue = [];
+
     /**
     * Construct a SequentialBucket
     * @arg {Number} limit The max number of tokens the bucket can consume per interval
     * @arg {Object} [latencyRef] An object
     * @arg {Number} latencyRef.latency Interval between consuming tokens
     */
-    constructor(limit, latencyRef = {latency: 0}) {
+    constructor(limit, latencyRef = { latency: 0 }) {
         this.limit = this.remaining = limit;
         this.latencyRef = latencyRef;
     }
 
     check(override) {
-        if(this.#queue.length === 0) {
-            if(this.processing) {
+        if (this.#queue.length === 0) {
+            if (this.processing) {
                 clearTimeout(this.processing);
                 this.processing = false;
             }
             return;
         }
-        if(this.processing && !override) {
+        if (this.processing && !override) {
             return;
         }
         const now = Date.now();
         const offset = this.latencyRef.latency;
-        if(!this.reset || this.reset < now - offset) {
+        if (!this.reset || this.reset < now - offset) {
             this.reset = now - offset;
             this.remaining = this.limit;
         }
         this.last = now;
-        if(this.remaining <= 0) {
+        if (this.remaining <= 0) {
             this.processing = setTimeout(() => {
                 this.processing = false;
                 this.check(true);
@@ -54,7 +55,7 @@ class SequentialBucket {
         --this.remaining;
         this.processing = true;
         this.#queue.shift()(() => {
-            if(this.#queue.length > 0) {
+            if (this.#queue.length > 0) {
                 this.check(true);
             } else {
                 this.processing = false;
@@ -67,7 +68,7 @@ class SequentialBucket {
     * @arg {Function} func A function to call when a token can be consumed. The function will be passed a callback argument, which must be called to allow the bucket to continue to work
     */
     queue(func, short) {
-        if(short) {
+        if (short) {
             this.#queue.unshift(func);
         } else {
             this.#queue.push(func);

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const warningMessages = {
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
@@ -5,7 +7,7 @@ const unknownCodeMessage = "You have triggered a deprecated behavior whose warni
 const emittedCodes = [];
 
 module.exports = function emitDeprecation(code) {
-    if(emittedCodes.includes(code) ) {
+    if (emittedCodes.includes(code) ) {
         return;
     }
     emittedCodes.push(code);

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -18,7 +18,7 @@ const WebmOpusTransformer = require("./streams/WebmOpusTransformer");
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 
@@ -29,10 +29,10 @@ function resolveHTTPType(link) {
 function webGetter(link, depth = 8) {
     return new Promise((resolve, reject) => {
         resolveHTTPType(link).get(link, (res) => {
-            const {statusCode, headers} = res.hasOwnProperty("statusCode") ? res : res.res;
+            const { statusCode, headers } = Object.hasOwn(res, "statusCode") ? res : res.res;
 
-            if(statusCode === 301 || statusCode === 302 || statusCode === 307 || statusCode === 308) {
-                if(depth <= 0) {
+            if (statusCode === 301 || statusCode === 302 || statusCode === 307 || statusCode === 308) {
+                if (depth <= 0) {
                     reject(new Error("too many redirects"));
                 } else {
                     resolve(webGetter(headers.location, depth - 1));
@@ -45,15 +45,15 @@ function webGetter(link, depth = 8) {
 }
 
 class Piper extends EventEmitter {
+    encoding = false;
+    libopus = true;
+    opus = null;
+    volumeLevel = 1;
     #dataPacketMax = 30;
     #dataPacketMin = 15;
     #dataPackets = [];
     #endStream;
     #retransformer = [];
-    encoding = false;
-    libopus = true;
-    opus = null;
-    volumeLevel = 1;
 
     constructor(converterCommand, opusFactory) {
         super();
@@ -71,12 +71,12 @@ class Piper extends EventEmitter {
     }
 
     addDataPacket(packet) {
-        if(!this.encoding) {
+        if (!this.encoding) {
             return;
         }
-        if(this.#dataPackets.push(packet) < this.#dataPacketMax && this.#endStream?.manualCB) {
+        if (this.#dataPackets.push(packet) < this.#dataPacketMax && this.#endStream?.manualCB) {
             process.nextTick(() => {
-                if(this.#endStream?.manualCB) {
+                if (this.#endStream?.manualCB) {
                     this.#endStream.transformCB();
                 }
             });
@@ -84,22 +84,22 @@ class Piper extends EventEmitter {
     }
 
     encode(source, options) {
-        if(this.encoding || this.streams.length) {
+        if (this.encoding || this.streams.length) {
             this.emit("error", new Error("Already encoding"));
             return false;
         }
 
-        if(typeof source === "string") {
-            if(options.format === "dca" || options.format === "ogg" || options.format === "webm" || options.format === "pcm") {
-                if(source.startsWith("http://") || source.startsWith("https://")) {
+        if (typeof source === "string") {
+            if (options.format === "dca" || options.format === "ogg" || options.format === "webm" || options.format === "pcm") {
+                if (source.startsWith("http://") || source.startsWith("https://")) {
                     const passThrough = new PassThroughStream();
                     webGetter(source).then((res) => res.pipe(passThrough)).catch((e) => this.stop(e));
                     source = passThrough;
                 } else {
                     try {
                         FS.statSync(source);
-                    } catch(err) {
-                        if(err.code === "ENOENT") {
+                    } catch (err) {
+                        if (err.code === "ENOENT") {
                             this.emit("error", new Error("That file does not exist."));
                         } else {
                             this.emit("error", new Error("An error occured trying to access that file."));
@@ -110,7 +110,7 @@ class Piper extends EventEmitter {
                     source = FS.createReadStream(source);
                 }
             }
-        } else if(!(source instanceof Stream) || !source.pipe) {
+        } else if (!(source instanceof Stream) || !source.pipe) {
             this.emit("error", new Error("Invalid source type"));
             return false;
         }
@@ -118,37 +118,37 @@ class Piper extends EventEmitter {
         this.#dataPacketMax = 30;
         this.#dataPacketMin = 15;
 
-        if(typeof source !== "string") {
+        if (typeof source !== "string") {
             this.streams.push(source.once("error", (e) => this.stop(e)));
         }
 
-        if(options.format === "opusPackets") { // eslint-disable no-empty
-        } else if(options.format === "dca") {
+        if (options.format === "opusPackets") { // eslint-disable no-empty
+        } else if (options.format === "dca") {
             this.streams.push(source.pipe(new DCAOpusTransformer()).once("error", (e) => this.stop(e)));
-        } else if(options.format === "ogg") {
+        } else if (options.format === "ogg") {
             this.streams.push(source.pipe(new OggOpusTransformer()).once("error", (e) => this.stop(e)));
-        } else if(options.format === "webm") {
+        } else if (options.format === "webm") {
             this.streams.push(source.pipe(new WebmOpusTransformer()).once("error", (e) => this.stop(e)));
-        } else if(!options.format || options.format === "pcm") {
-            if(options.inlineVolume) {
-                if(!options.format) {
-                    if(!this.converterCommand) {
+        } else if (!options.format || options.format === "pcm") {
+            if (options.inlineVolume) {
+                if (!options.format) {
+                    if (!this.converterCommand) {
                         this.emit("error", new Error("FFmpeg/avconv was not found on this system. Playback of this audio format is impossible"));
                         this.reset();
                         return false;
                     }
-                    if(typeof source === "string") {
+                    if (typeof source === "string") {
                         this.streams.push(source = new FFmpegPCMTransformer({
                             command: this.converterCommand,
                             input: source,
                             encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs
+                            inputArgs: options.inputArgs,
                         }).once("error", (e) => this.stop(e)));
                     } else {
                         this.streams.push(source = source.pipe(new FFmpegPCMTransformer({
                             command: this.converterCommand,
                             encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs
+                            inputArgs: options.inputArgs,
                         })).once("error", (e) => this.stop(e)));
                     }
                 }
@@ -157,20 +157,20 @@ class Piper extends EventEmitter {
                 this.streams.push(this.volume.pipe(new PCMOpusTransformer({
                     opusFactory: this.opusFactory,
                     frameSize: options.frameSize,
-                    pcmSize: options.pcmSize
+                    pcmSize: options.pcmSize,
                 })).once("error", (e) => this.stop(e)));
                 this.#dataPacketMax = 1; // Live volume updating
                 this.#dataPacketMin = 4;
             } else {
-                if(this.libopus) {
-                    if(typeof source === "string") {
+                if (this.libopus) {
+                    if (typeof source === "string") {
                         this.streams.push(source = new FFmpegOggTransformer({
                             command: this.converterCommand,
                             input: source,
                             encoderArgs: options.encoderArgs,
                             inputArgs: options.inputArgs,
                             format: options.format,
-                            frameDuration: options.frameDuration
+                            frameDuration: options.frameDuration,
                         }).once("error", (e) => this.stop(e)));
                     } else {
                         this.streams.push(source = source.pipe(new FFmpegOggTransformer({
@@ -178,29 +178,29 @@ class Piper extends EventEmitter {
                             encoderArgs: options.encoderArgs,
                             inputArgs: options.inputArgs,
                             format: options.format,
-                            frameDuration: options.frameDuration
+                            frameDuration: options.frameDuration,
                         })).once("error", (e) => this.stop(e)));
                     }
                     this.streams.push(source.pipe(new OggOpusTransformer()).once("error", (e) => this.stop(e)));
                 } else {
-                    if(typeof source === "string") {
+                    if (typeof source === "string") {
                         this.streams.push(source = new FFmpegPCMTransformer({
                             command: this.converterCommand,
                             input: source,
                             encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs
+                            inputArgs: options.inputArgs,
                         }).once("error", (e) => this.stop(e)));
                     } else {
                         this.streams.push(source = source.pipe(new FFmpegPCMTransformer({
                             command: this.converterCommand,
                             encoderArgs: options.encoderArgs,
-                            inputArgs: options.inputArgs
+                            inputArgs: options.inputArgs,
                         })).once("error", (e) => this.stop(e)));
                     }
                     this.streams.push(source.pipe(new PCMOpusTransformer({
                         opusFactory: this.opusFactory,
                         frameSize: options.frameSize,
-                        pcmSize: options.pcmSize
+                        pcmSize: options.pcmSize,
                     })).once("error", (e) => this.stop(e)));
                 }
             }
@@ -211,7 +211,7 @@ class Piper extends EventEmitter {
         }
 
         this.#endStream = this.streams[this.streams.length - 1];
-        if(this.#endStream.hasOwnProperty("manualCB")) {
+        if (Object.hasOwn(this.#endStream, "manualCB")) {
             this.#endStream.manualCB = true;
         }
 
@@ -224,17 +224,17 @@ class Piper extends EventEmitter {
     }
 
     getDataPacket() {
-        if(this.#dataPackets.length < this.#dataPacketMin && this.#endStream?.manualCB) {
+        if (this.#dataPackets.length < this.#dataPacketMin && this.#endStream?.manualCB) {
             this.#endStream.transformCB();
         }
-        if(this.#retransformer.length === 0) {
+        if (this.#retransformer.length === 0) {
             return this.#dataPackets.shift();
         } else {
             // If we don't have an opus instance yet, create one.
             this.opus ??= this.opusFactory();
 
             const packet = this.opus.decode(this.#dataPackets.shift());
-            for(let i = 0, num; i < packet.length - 1; i += 2) {
+            for (let i = 0, num; i < packet.length - 1; i += 2) {
                 num = ~~(this.#retransformer.shift() * packet.readInt16LE(i));
                 packet.writeInt16LE(num >= 32767 ? 32767 : num <= -32767 ? -32767 : num, i);
             }
@@ -243,9 +243,9 @@ class Piper extends EventEmitter {
     }
 
     reset() {
-        if(this.streams) {
-            for(const stream of this.streams) {
-                if(typeof stream.destroy === "function") {
+        if (this.streams) {
+            for (const stream of this.streams) {
+                if (typeof stream.destroy === "function") {
                     stream.destroy();
                 } else {
                     stream.unpipe();
@@ -260,7 +260,7 @@ class Piper extends EventEmitter {
 
     resetPackets() {
         // We no longer need this to convert inline volume, so... let it go.
-        if(this.opus) {
+        if (this.opus) {
             this.opus.delete?.();
             this.opus = null;
         }
@@ -269,34 +269,34 @@ class Piper extends EventEmitter {
 
     setVolume(volume) {
         this.volumeLevel = volume;
-        if(!this.volume) {
+        if (!this.volume) {
             return;
         }
         this.volume.setVolume(volume);
     }
 
     stop(e, source) {
-        if(source && !this.streams.includes(source)) {
+        if (source && !this.streams.includes(source)) {
             return;
         }
 
-        if(e) {
+        if (e) {
             this.emit("error", e);
         }
 
-        if(this.throttleTimeout) {
+        if (this.throttleTimeout) {
             clearTimeout(this.throttleTimeout);
             this.throttleTimeout = null;
         }
 
-        if(this.streams.length === 0) {
+        if (this.streams.length === 0) {
             return;
         }
 
         this.#endStream?.removeAllListeners("data");
 
         this.reset();
-        if(this.encoding) {
+        if (this.encoding) {
             this.encoding = false;
             this.emit("stop");
         }

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -5,12 +5,12 @@ const Base = require("../structures/Base");
 const Piper = require("./Piper");
 const VoiceConnection = require("./VoiceConnection");
 const Collection = require("../util/Collection");
-const {createOpus} = require("../util/Opus");
+const { createOpus } = require("../util/Opus");
 
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 
@@ -24,7 +24,6 @@ try {
 * @prop {Number} volume The current volume level of the connection
 */
 class SharedStream extends EventEmitter {
-    #send;
     bitrate = 64_000;
     channels = 2;
     ended = true;
@@ -33,11 +32,12 @@ class SharedStream extends EventEmitter {
     samplingRate = 48_000;
     speaking = false;
     voiceConnections = new Collection(VoiceConnection);
+    #send;
 
     constructor() {
         super();
 
-        if(!VoiceConnection._converterCommand.cmd) {
+        if (!VoiceConnection._converterCommand.cmd) {
             VoiceConnection._converterCommand.pickCommand();
         }
 
@@ -48,7 +48,7 @@ class SharedStream extends EventEmitter {
         * @prop {Error} e The error
         */
         this.piper.on("error", (e) => this.emit("error", e));
-        if(!VoiceConnection._converterCommand.libopus) {
+        if (!VoiceConnection._converterCommand.libopus) {
             this.piper.libopus = false;
         }
 
@@ -65,7 +65,7 @@ class SharedStream extends EventEmitter {
     */
     add(connection) {
         const _connection = this.voiceConnections.add(connection);
-        if(_connection.ready) {
+        if (_connection.ready) {
             _connection.setSpeaking(this.speaking);
         } else {
             _connection.once("ready", () => {
@@ -100,7 +100,7 @@ class SharedStream extends EventEmitter {
         options.frameSize = options.frameSize || options.samplingRate * options.frameDuration / 1000;
         options.pcmSize = options.pcmSize || options.frameSize * 2 * this.channels;
 
-        if(!this.piper.encode(source, options)) {
+        if (!this.piper.encode(source, options)) {
             this.emit("error", new Error("Unable to encode source"));
             return;
         }
@@ -114,7 +114,7 @@ class SharedStream extends EventEmitter {
             bufferingTicks: 0,
             options: options,
             timeout: null,
-            buffer: null
+            buffer: null,
         };
 
         this.playing = true;
@@ -137,9 +137,9 @@ class SharedStream extends EventEmitter {
     }
 
     setSpeaking(value) {
-        if((value = !!value) != this.speaking) {
+        if ((value = !!value) !== this.speaking) {
             this.speaking = value;
-            for(const vc of this.voiceConnections.values()) {
+            for (const vc of this.voiceConnections.values()) {
                 vc.setSpeaking(value);
             }
         }
@@ -157,11 +157,11 @@ class SharedStream extends EventEmitter {
     * Stop the bot from sending audio
     */
     stopPlaying() {
-        if(this.ended) {
+        if (this.ended) {
             return;
         }
         this.ended = true;
-        if(this.current?.timeout) {
+        if (this.current?.timeout) {
             clearTimeout(this.current.timeout);
             this.current.timeout = null;
         }
@@ -179,19 +179,19 @@ class SharedStream extends EventEmitter {
     }
 
     #incrementSequences() {
-        for(const vc of this.voiceConnections.values()) {
+        for (const vc of this.voiceConnections.values()) {
             vc.sequence = (vc.sequence + 1) & 0xFFFF;
         }
     }
 
     #incrementTimestamps(val) {
-        for(const vc of this.voiceConnections.values()) {
+        for (const vc of this.voiceConnections.values()) {
             vc.timestamp = (vc.timestamp + val) >>> 0;
         }
     }
 
     #sendUnbound() {
-        if(!this.piper.encoding && this.piper.dataPacketCount === 0) {
+        if (!this.piper.encoding && this.piper.dataPacketCount === 0) {
             return this.stopPlaying();
         }
 
@@ -199,16 +199,16 @@ class SharedStream extends EventEmitter {
 
         this.#incrementSequences();
 
-        if((this.current.buffer = this.piper.getDataPacket())) {
-            if(this.current.startTime === 0) {
+        if ((this.current.buffer = this.piper.getDataPacket())) {
+            if (this.current.startTime === 0) {
                 this.current.startTime = Date.now();
             }
-            if(this.current.bufferingTicks > 0) {
+            if (this.current.bufferingTicks > 0) {
                 this.current.bufferingTicks = 0;
                 this.setSpeaking(true);
             }
-        } else if(this.current.options.voiceDataTimeout === -1 || this.current.bufferingTicks < this.current.options.voiceDataTimeout / (4 * this.current.options.frameDuration)) { // wait for data
-            if(++this.current.bufferingTicks === 1) {
+        } else if (this.current.options.voiceDataTimeout === -1 || this.current.bufferingTicks < this.current.options.voiceDataTimeout / (4 * this.current.options.frameDuration)) { // wait for data
+            if (++this.current.bufferingTicks === 1) {
                 this.setSpeaking(false);
             } else {
                 this.current.pausedTime += 4 * this.current.options.frameDuration;
@@ -221,7 +221,7 @@ class SharedStream extends EventEmitter {
         }
 
         this.voiceConnections.forEach((connection) => {
-            if(connection.ready && this.current.buffer) {
+            if (connection.ready && this.current.buffer) {
                 connection._sendAudioFrame(this.current.buffer);
             }
         });

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -3,19 +3,19 @@
 const util = require("node:util");
 const Base = require("../structures/Base");
 const ChildProcess = require("node:child_process");
-const {VoiceOPCodes, GatewayOPCodes} = require("../Constants");
+const { VoiceOPCodes, GatewayOPCodes } = require("../Constants");
 const Dgram = require("node:dgram");
 const Net = require("node:net");
 const Piper = require("./Piper");
 const VoiceDataStream = require("./VoiceDataStream");
-const {createOpus} = require("../util/Opus");
+const { createOpus } = require("../util/Opus");
 
 const WebSocket = typeof window !== "undefined" ? require("../util/BrowserWebSocket") : require("ws");
 
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 
@@ -28,15 +28,15 @@ const SILENCE_FRAME = Buffer.from([0xF8, 0xFF, 0xFE]);
 
 const converterCommand = {
     cmd: null,
-    libopus: false
+    libopus: false,
 };
 
 converterCommand.pickCommand = function pickCommand() {
     let tenative;
-    for(const command of ["./ffmpeg", "./avconv", "ffmpeg", "avconv"]) {
+    for (const command of ["./ffmpeg", "./avconv", "ffmpeg", "avconv"]) {
         const res = ChildProcess.spawnSync(command, ["-encoders"]);
-        if(!res.error) {
-            if(!res.stdout.toString().includes("libopus")) {
+        if (!res.error) {
+            if (!res.stdout.toString().includes("libopus")) {
                 tenative = command;
                 continue;
             }
@@ -45,7 +45,7 @@ converterCommand.pickCommand = function pickCommand() {
             return;
         }
     }
-    if(tenative) {
+    if (tenative) {
         converterCommand.cmd = tenative;
         return;
     }
@@ -77,7 +77,6 @@ converterCommand.pickCommand = function pickCommand() {
 * @prop {Number} volume The current volume level of the connection
 */
 class VoiceConnection extends EventEmitter {
-    #send;
     bitrate = 64_000;
     channelID = null;
     channels = 2;
@@ -90,12 +89,11 @@ class VoiceConnection extends EventEmitter {
     samplingRate = 48_000;
     sendBuffer = Buffer.allocUnsafe(16 + 32 + MAX_FRAME_SIZE);
     sendNonce = Buffer.alloc(24);
-
     sequence = 0;
     speaking = false;
     ssrcUserMap = {};
     timestamp = 0;
-
+    #send;
     // frameSize and pcmSize must come after the properties they reference to get initialized correctly
     /* eslint-disable sort-class-members/sort-class-members */
     frameSize = this.samplingRate * this.frameDuration / 1_000;
@@ -105,17 +103,17 @@ class VoiceConnection extends EventEmitter {
     constructor(id, options = {}) {
         super();
 
-        if(typeof window !== "undefined") {
+        if (typeof window !== "undefined") {
             throw new Error("Voice is not supported in browsers at this time");
         }
 
-        if(!Sodium && !NaCl) {
+        if (!Sodium && !NaCl) {
             try {
                 Sodium = require("sodium-native");
-            } catch{
+            } catch {
                 try {
                     NaCl = require("tweetnacl");
-                } catch{ // eslint-disable no-empty
+                } catch { // eslint-disable no-empty
                     throw new Error("Error loading tweetnacl/libsodium, voice not available");
                 }
             }
@@ -126,15 +124,15 @@ class VoiceConnection extends EventEmitter {
         this.shard = options.shard || {};
         this.opusOnly = !!options.opusOnly;
 
-        if(!this.opusOnly && !this.shared) {
+        if (!this.opusOnly && !this.shared) {
             this.opus = {};
         }
 
         this.sendNonce[0] = 0x80;
         this.sendNonce[1] = 0x78;
 
-        if(!options.shared) {
-            if(!converterCommand.cmd) {
+        if (!options.shared) {
+            if (!converterCommand.cmd) {
                 converterCommand.pickCommand();
             }
 
@@ -145,7 +143,7 @@ class VoiceConnection extends EventEmitter {
             * @prop {Error} err The error object
             */
             this.piper.on("error", (e) => this.emit("error", e));
-            if(!converterCommand.libopus) {
+            if (!converterCommand.libopus) {
                 this.piper.libopus = false;
             }
         }
@@ -159,10 +157,10 @@ class VoiceConnection extends EventEmitter {
 
     connect(data) {
         this.connecting = true;
-        if(this.ws && this.ws.readyState !== WebSocket.CLOSED) {
+        if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
             this.disconnect(undefined, true);
             setTimeout(() => {
-                if(!this.connecting && !this.ready) {
+                if (!this.connecting && !this.ready) {
                     this.connect(data);
                 }
             }, 500).unref();
@@ -170,21 +168,21 @@ class VoiceConnection extends EventEmitter {
         }
         clearTimeout(this.connectionTimeout);
         this.connectionTimeout = setTimeout(() => {
-            if(this.connecting) {
+            if (this.connecting) {
                 this.disconnect(new Error("Voice connection timeout"));
             }
             this.connectionTimeout = null;
         }, this.shard.client ? this.shard.client.shards.options.connectionTimeout : 30000).unref();
-        if(!data.endpoint) {
+        if (!data.endpoint) {
             return; // Endpoint null, wait next update.
         }
-        if(!data.token || !data.session_id || !data.user_id) {
+        if (!data.token || !data.session_id || !data.user_id) {
             this.disconnect(new Error("Malformed voice server update: " + JSON.stringify(data)));
             return;
         }
         this.channelID = data.channel_id;
         this.endpoint = new URL(`wss://${data.endpoint}`);
-        if(this.endpoint.port === "80") {
+        if (this.endpoint.port === "80") {
             this.endpoint.port = "";
         }
         this.endpoint.searchParams.set("v", 4);
@@ -201,7 +199,7 @@ class VoiceConnection extends EventEmitter {
             * @event VoiceConnection#connect
             */
             this.emit("connect");
-            if(this.connectionTimeout) {
+            if (this.connectionTimeout) {
                 clearTimeout(this.connectionTimeout);
                 this.connectionTimeout = null;
             }
@@ -209,19 +207,19 @@ class VoiceConnection extends EventEmitter {
                 server_id: this.id,
                 user_id: data.user_id,
                 session_id: data.session_id,
-                token: data.token
+                token: data.token,
             });
         });
         this.ws.on("message", (m) => {
             const packet = JSON.parse(m);
-            if(this.listeners("debug").length > 0) {
+            if (this.listeners("debug").length > 0) {
                 this.emit("debug", "Rec: " + JSON.stringify(packet));
             }
-            switch(packet.op) {
+            switch (packet.op) {
                 case VoiceOPCodes.READY: {
                     this.ssrc = packet.d.ssrc;
                     this.sendNonce.writeUInt32BE(this.ssrc, 8);
-                    if(!packet.d.modes.includes(ENCRYPTION_MODE)) {
+                    if (!packet.d.modes.includes(ENCRYPTION_MODE)) {
                         throw new Error("No supported voice mode found");
                     }
 
@@ -235,16 +233,16 @@ class VoiceConnection extends EventEmitter {
                     this.udpSocket = Dgram.createSocket(Net.isIPv6(this.udpIP) ? "udp6" : "udp4");
                     this.udpSocket.on("error", (err, msg) => {
                         this.emit("error", err);
-                        if(msg) {
+                        if (msg) {
                             this.emit("debug", "Voice UDP error: " + msg);
                         }
-                        if(this.ready || this.connecting) {
+                        if (this.ready || this.connecting) {
                             this.disconnect(err);
                         }
                     });
                     this.udpSocket.once("message", (packet) => {
                         let i = 8;
-                        while(packet[i] !== 0) {
+                        while (packet[i] !== 0) {
                             i++;
                         }
                         const localIP = packet.toString("ascii", 8, i);
@@ -256,15 +254,15 @@ class VoiceConnection extends EventEmitter {
                             data: {
                                 address: localIP,
                                 port: localPort,
-                                mode: ENCRYPTION_MODE
-                            }
+                                mode: ENCRYPTION_MODE,
+                            },
                         });
                     });
                     this.udpSocket.on("close", (err) => {
-                        if(err) {
+                        if (err) {
                             this.emit("warn", "Voice UDP close: " + err);
                         }
-                        if(this.ready || this.connecting) {
+                        if (this.ready || this.connecting) {
                             this.disconnect(err);
                         }
                     });
@@ -289,7 +287,7 @@ class VoiceConnection extends EventEmitter {
                     */
                     this.emit("ready");
                     this.resume();
-                    if(this.receiveStreamOpus || this.receiveStreamPCM) {
+                    if (this.receiveStreamOpus || this.receiveStreamPCM) {
                         this.registerReceiveEventHandler();
                     }
                     break;
@@ -319,7 +317,7 @@ class VoiceConnection extends EventEmitter {
                     break;
                 }
                 case VoiceOPCodes.HELLO: {
-                    if(this.heartbeatInterval) {
+                    if (this.heartbeatInterval) {
                         clearInterval(this.heartbeatInterval);
                     }
                     this.heartbeatInterval = setInterval(() => {
@@ -330,7 +328,7 @@ class VoiceConnection extends EventEmitter {
                     break;
                 }
                 case VoiceOPCodes.CLIENT_DISCONNECT: {
-                    if(this.opus) {
+                    if (this.opus) {
                         // opusscript requires manual cleanup
                         this.opus[packet.d.user_id]?.delete?.();
 
@@ -357,25 +355,25 @@ class VoiceConnection extends EventEmitter {
         this.ws.on("close", (code, reason) => {
             let err = !code || code === 1000 ? null : new Error(code + ": " + reason);
             this.emit("warn", `Voice WS close ${code}: ${reason}`);
-            if(this.connecting || this.ready) {
+            if (this.connecting || this.ready) {
                 let reconnecting = true;
-                if(code === 4006) {
+                if (code === 4006) {
                     reconnecting = false;
-                } else if(code === 4014) {
-                    if(this.channelID) {
+                } else if (code === 4014) {
+                    if (this.channelID) {
                         data.endpoint = null;
                         reconnecting = true;
                         err = null;
                     } else {
                         reconnecting = false;
                     }
-                } else if(code === 1000) {
+                } else if (code === 1000) {
                     reconnecting = false;
                 }
                 this.disconnect(err, reconnecting);
-                if(reconnecting) {
+                if (reconnecting) {
                     setTimeout(() => {
-                        if(!this.connecting && !this.ready) {
+                        if (!this.connecting && !this.ready) {
                             this.connect(data);
                         }
                     }, 500).unref();
@@ -392,38 +390,38 @@ class VoiceConnection extends EventEmitter {
         this.timestamp = 0;
         this.sequence = 0;
 
-        if(this.connectionTimeout) {
+        if (this.connectionTimeout) {
             clearTimeout(this.connectionTimeout);
             this.connectionTimeout = null;
         }
 
         try {
-            if(reconnecting) {
+            if (reconnecting) {
                 this.pause();
             } else {
                 this.stopPlaying();
             }
-        } catch(err) {
+        } catch (err) {
             this.emit("error", err);
         }
-        if(this.heartbeatInterval) {
+        if (this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
         }
-        if(this.udpSocket) {
+        if (this.udpSocket) {
             try {
                 this.udpSocket.close();
-            } catch(err) {
-                if(err.message !== "Not running") {
+            } catch (err) {
+                if (err.message !== "Not running") {
                     this.emit("error", err);
                 }
             }
             this.udpSocket = null;
         }
-        if(this.ws) {
+        if (this.ws) {
             try {
-                if(reconnecting) {
-                    if(this.ws.readyState === WebSocket.OPEN) {
+                if (reconnecting) {
+                    if (this.ws.readyState === WebSocket.OPEN) {
                         this.ws.close(4901, "Dysnomia: reconnect");
                     } else {
                         this.emit("debug", `Terminating websocket (state: ${this.ws.readyState})`);
@@ -432,13 +430,13 @@ class VoiceConnection extends EventEmitter {
                 } else {
                     this.ws.close(1000, "Dysnomia: normal");
                 }
-            } catch(err) {
+            } catch (err) {
                 this.emit("error", err);
             }
             this.ws = null;
         }
-        if(reconnecting) {
-            if(error) {
+        if (reconnecting) {
+            if (error) {
                 this.emit("error", error);
             }
         } else {
@@ -455,7 +453,7 @@ class VoiceConnection extends EventEmitter {
 
     heartbeat() {
         this.sendWS(VoiceOPCodes.HEARTBEAT, Date.now());
-        if(this.udpSocket) {
+        if (this.udpSocket) {
             // NAT/connection table keep-alive
             const udpMessage = Buffer.from([0x80, 0xC8, 0x0, 0x0]);
             this.sendUDPPacket(udpMessage);
@@ -468,11 +466,11 @@ class VoiceConnection extends EventEmitter {
     pause() {
         this.paused = true;
         this.setSpeaking(0);
-        if(this.current) {
-            if(!this.current.pausedTimestamp) {
+        if (this.current) {
+            if (!this.current.pausedTimestamp) {
                 this.current.pausedTimestamp = Date.now();
             }
-            if(this.current.timeout) {
+            if (this.current.timeout) {
                 clearTimeout(this.current.timeout);
                 this.current.timeout = null;
             }
@@ -494,10 +492,10 @@ class VoiceConnection extends EventEmitter {
     * @arg {Number} [options.voiceDataTimeout=2000] Timeout when waiting for voice data (-1 for no timeout)
     */
     play(source, options = {}) {
-        if(this.shared) {
+        if (this.shared) {
             throw new Error("Cannot play stream on shared voice connection");
         }
-        if(!this.ready) {
+        if (!this.ready) {
             throw new Error("Not ready yet");
         }
 
@@ -512,7 +510,7 @@ class VoiceConnection extends EventEmitter {
         options.frameSize = options.frameSize || options.samplingRate * options.frameDuration / 1000;
         options.pcmSize = options.pcmSize || options.frameSize * 2 * this.channels;
 
-        if(!this.piper.encode(source, options)) {
+        if (!this.piper.encode(source, options)) {
             this.emit("error", new Error("Unable to encode source"));
             return;
         }
@@ -526,7 +524,7 @@ class VoiceConnection extends EventEmitter {
             bufferingTicks: 0,
             options: options,
             timeout: null,
-            buffer: null
+            buffer: null,
         };
 
         this.playing = true;
@@ -546,17 +544,17 @@ class VoiceConnection extends EventEmitter {
     * @returns {VoiceDataStream}
     */
     receive(type) {
-        if(type === "pcm") {
-            if(!this.receiveStreamPCM) {
+        if (type === "pcm") {
+            if (!this.receiveStreamPCM) {
                 this.receiveStreamPCM = new VoiceDataStream(type);
-                if(!this.receiveStreamOpus) {
+                if (!this.receiveStreamOpus) {
                     this.registerReceiveEventHandler();
                 }
             }
-        } else if(type === "opus") {
-            if(!this.receiveStreamOpus) {
+        } else if (type === "opus") {
+            if (!this.receiveStreamOpus) {
                 this.receiveStreamOpus = new VoiceDataStream(type);
-                if(!this.receiveStreamPCM) {
+                if (!this.receiveStreamPCM) {
                     this.registerReceiveEventHandler();
                 }
             }
@@ -568,18 +566,18 @@ class VoiceConnection extends EventEmitter {
 
     registerReceiveEventHandler() {
         this.udpSocket.on("message", (msg) => {
-            if(msg[1] !== 0x78) { // unknown payload type, ignore
+            if (msg[1] !== 0x78) { // unknown payload type, ignore
                 return;
             }
 
             const nonce = Buffer.alloc(24);
             msg.copy(nonce, 0, 0, 12);
             let data;
-            if(Sodium) {
+            if (Sodium) {
                 data = Buffer.alloc(msg.length - 12 - Sodium.crypto_secretbox_MACBYTES);
                 Sodium.crypto_secretbox_open_easy(data, msg.subarray(12), nonce, this.secret);
             } else {
-                if(!(data = NaCl.secretbox.open(msg.subarray(12), nonce, this.secret))) {
+                if (!(data = NaCl.secretbox.open(msg.subarray(12), nonce, this.secret))) {
                     /**
                     * Fired to warn of something weird but non-breaking happening
                     * @event VoiceConnection#warn
@@ -591,15 +589,15 @@ class VoiceConnection extends EventEmitter {
             }
             const hasExtension = !!(msg[0] & 0b10000);
             const cc = msg[0] & 0b1111;
-            if(cc > 0) {
+            if (cc > 0) {
                 data = data.subarray(cc * 4);
             }
             // Not a RFC5285 One Byte Header Extension (not negotiated)
-            if(hasExtension) { // RFC3550 5.3.1: RTP Header Extension
+            if (hasExtension) { // RFC3550 5.3.1: RTP Header Extension
                 const l = data[2] << 8 | data[3];
                 data = data.subarray(4 + l * 4);
             }
-            if(this.receiveStreamOpus) {
+            if (this.receiveStreamOpus) {
                 /**
                 * Fired when a voice data packet is received
                 * @event VoiceDataStream#data
@@ -610,12 +608,12 @@ class VoiceConnection extends EventEmitter {
                 */
                 this.receiveStreamOpus.emit("data", data, this.ssrcUserMap[nonce.readUIntBE(8, 4)], nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
-            if(this.receiveStreamPCM) {
+            if (this.receiveStreamPCM) {
                 const userID = this.ssrcUserMap[nonce.readUIntBE(8, 4)];
                 this.opus[userID] ??= createOpus(this.samplingRate, this.channels, this.bitrate);
 
                 data = this.opus[userID].decode(data, this.frameSize);
-                if(!data) {
+                if (!data) {
                     return this.emit("warn", "Failed to decode received packet");
                 }
                 this.receiveStreamPCM.emit("data", data, userID, nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
@@ -628,9 +626,9 @@ class VoiceConnection extends EventEmitter {
     */
     resume() {
         this.paused = false;
-        if(this.current) {
+        if (this.current) {
             this.setSpeaking(1);
-            if(this.current.pausedTimestamp) {
+            if (this.current.pausedTimestamp) {
                 this.current.pausedTime += Date.now() - this.current.pausedTimestamp;
                 this.current.pausedTimestamp = 0;
             }
@@ -657,18 +655,18 @@ class VoiceConnection extends EventEmitter {
     * @arg {Buffer} packet The packet data
     */
     sendUDPPacket(packet) {
-        if(this.udpSocket) {
+        if (this.udpSocket) {
             try {
                 this.udpSocket.send(packet, 0, packet.length, this.udpPort, this.udpIP);
-            } catch(e) {
+            } catch (e) {
                 this.emit("error", e);
             }
         }
     }
 
     sendWS(op, data) {
-        if(this.ws?.readyState === WebSocket.OPEN) {
-            data = JSON.stringify({op: op, d: data});
+        if (this.ws?.readyState === WebSocket.OPEN) {
+            data = JSON.stringify({ op: op, d: data });
             this.ws.send(data);
             this.emit("debug", data);
         }
@@ -679,7 +677,7 @@ class VoiceConnection extends EventEmitter {
         this.sendWS(VoiceOPCodes.SPEAKING, {
             speaking: value,
             delay: delay,
-            ssrc: this.ssrc
+            ssrc: this.ssrc,
         });
     }
 
@@ -695,22 +693,22 @@ class VoiceConnection extends EventEmitter {
     * Stop the bot from sending audio
     */
     stopPlaying() {
-        if(this.ended) {
+        if (this.ended) {
             return;
         }
         this.ended = true;
-        if(this.current?.timeout) {
+        if (this.current?.timeout) {
             clearTimeout(this.current.timeout);
             this.current.timeout = null;
         }
         this.current = null;
-        if(this.piper) {
+        if (this.piper) {
             this.piper.stop();
             this.piper.resetPackets();
         }
 
-        if(this.secret) {
-            for(let i = 0; i < 5; i++) {
+        if (this.secret) {
+            for (let i = 0; i < 5; i++) {
                 this.sendAudioFrame(SILENCE_FRAME, this.frameSize);
             }
         }
@@ -729,13 +727,13 @@ class VoiceConnection extends EventEmitter {
     * @arg {String} channelID The ID of the voice channel
     */
     switchChannel(channelID, reactive) {
-        if(this.channelID === channelID) {
+        if (this.channelID === channelID) {
             return;
         }
 
         this.channelID = channelID;
-        if(reactive) {
-            if(this.reconnecting && !channelID) {
+        if (reactive) {
+            if (this.reconnecting && !channelID) {
                 this.disconnect();
             }
         } else {
@@ -753,63 +751,33 @@ class VoiceConnection extends EventEmitter {
             guild_id: this.id,
             channel_id: this.channelID || null,
             self_mute: !!selfMute,
-            self_deaf: !!selfDeaf
+            self_deaf: !!selfDeaf,
         });
     }
 
     _destroy() {
-        if(this.opus) {
-            for(const key in this.opus) {
+        if (this.opus) {
+            for (const key in this.opus) {
                 this.opus[key].delete?.();
                 delete this.opus[key];
             }
         }
         delete this.piper;
-        if(this.receiveStreamOpus) {
+        if (this.receiveStreamOpus) {
             this.receiveStreamOpus.removeAllListeners();
             this.receiveStreamOpus = null;
         }
-        if(this.receiveStreamPCM) {
+        if (this.receiveStreamPCM) {
             this.receiveStreamPCM.removeAllListeners();
             this.receiveStreamPCM = null;
         }
-    }
-
-    #sendUnbound() {
-        if(!this.piper.encoding && this.piper.dataPacketCount === 0) {
-            return this.stopPlaying();
-        }
-
-        if((this.current.buffer = this.piper.getDataPacket())) {
-            if(this.current.startTime === 0) {
-                this.current.startTime = Date.now();
-            }
-            if(this.current.bufferingTicks > 0) {
-                this.current.bufferingTicks = 0;
-                this.setSpeaking(1);
-            }
-        } else if(this.current.options.voiceDataTimeout === -1 || this.current.bufferingTicks < this.current.options.voiceDataTimeout / (4 * this.current.options.frameDuration)) { // wait for data
-            if(++this.current.bufferingTicks === 1) {
-                this.setSpeaking(0);
-            }
-            this.current.pausedTime += 4 * this.current.options.frameDuration;
-            this.timestamp = (this.timestamp + 3 * this.current.options.frameSize) >>> 0;
-            this.current.timeout = setTimeout(this.#send, 4 * this.current.options.frameDuration);
-            return;
-        } else {
-            return this.stopPlaying();
-        }
-
-        this.sendAudioFrame(this.current.buffer, this.current.options.frameSize);
-        this.current.playTime += this.current.options.frameDuration;
-        this.current.timeout = setTimeout(this.#send, this.current.startTime + this.current.pausedTime + this.current.playTime - Date.now());
     }
 
     #sendAudioFrame(frame) {
         this.sendNonce.writeUInt16BE(this.sequence, 2);
         this.sendNonce.writeUInt32BE(this.timestamp, 4);
 
-        if(Sodium) {
+        if (Sodium) {
             const MACBYTES = Sodium.crypto_secretbox_MACBYTES;
             const length = frame.length + MACBYTES;
             this.sendBuffer.fill(0, 12, 12 + MACBYTES);
@@ -828,6 +796,37 @@ class VoiceConnection extends EventEmitter {
             return this.sendUDPPacket(this.sendBuffer.subarray(BOXZEROBYTES - 12, BOXZEROBYTES + length));
         }
     }
+    #sendUnbound() {
+        if (!this.piper.encoding && this.piper.dataPacketCount === 0) {
+            return this.stopPlaying();
+        }
+
+        if ((this.current.buffer = this.piper.getDataPacket())) {
+            if (this.current.startTime === 0) {
+                this.current.startTime = Date.now();
+            }
+            if (this.current.bufferingTicks > 0) {
+                this.current.bufferingTicks = 0;
+                this.setSpeaking(1);
+            }
+        } else if (this.current.options.voiceDataTimeout === -1 || this.current.bufferingTicks < this.current.options.voiceDataTimeout / (4 * this.current.options.frameDuration)) { // wait for data
+            if (++this.current.bufferingTicks === 1) {
+                this.setSpeaking(0);
+            }
+            this.current.pausedTime += 4 * this.current.options.frameDuration;
+            this.timestamp = (this.timestamp + 3 * this.current.options.frameSize) >>> 0;
+            this.current.timeout = setTimeout(this.#send, 4 * this.current.options.frameDuration);
+            return;
+        } else {
+            return this.stopPlaying();
+        }
+
+        this.sendAudioFrame(this.current.buffer, this.current.options.frameSize);
+        this.current.playTime += this.current.options.frameDuration;
+        this.current.timeout = setTimeout(this.#send, this.current.startTime + this.current.pausedTime + this.current.playTime - Date.now());
+    }
+
+
 
 
     [util.inspect.custom]() {
@@ -848,7 +847,7 @@ class VoiceConnection extends EventEmitter {
             "playing",
             "ready",
             "volume",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -11,9 +11,9 @@ class VoiceConnectionManager extends Collection {
 
     join(guildID, channelID, options) {
         const connection = this.get(guildID);
-        if(connection?.ws) {
+        if (connection?.ws) {
             connection.switchChannel(channelID);
-            if(connection.ready) {
+            if (connection.ready) {
                 return Promise.resolve(connection);
             } else {
                 return new Promise((res, rej) => {
@@ -46,14 +46,14 @@ class VoiceConnectionManager extends Collection {
                 timeout: setTimeout(() => {
                     delete this.pendingGuilds[guildID];
                     rej(new Error("Voice connection timeout"));
-                }, 10000)
+                }, 10000),
             };
         });
     }
 
     leave(guildID) {
         const connection = this.get(guildID);
-        if(!connection) {
+        if (!connection) {
             return;
         }
         connection.disconnect();
@@ -67,19 +67,19 @@ class VoiceConnectionManager extends Collection {
     }
 
     voiceServerUpdate(data) {
-        if(this.pendingGuilds[data.guild_id]?.timeout) {
+        if (this.pendingGuilds[data.guild_id]?.timeout) {
             clearTimeout(this.pendingGuilds[data.guild_id].timeout);
             this.pendingGuilds[data.guild_id].timeout = null;
         }
         let connection = this.get(data.guild_id);
-        if(!connection) {
-            if(!this.pendingGuilds[data.guild_id]) {
+        if (!connection) {
+            if (!this.pendingGuilds[data.guild_id]) {
                 return;
             }
             connection = this.add(new this.baseObject(data.guild_id, {
                 shard: data.shard,
                 opusOnly: this.pendingGuilds[data.guild_id].options.opusOnly,
-                shared: this.pendingGuilds[data.guild_id].options.shared
+                shared: this.pendingGuilds[data.guild_id].options.shared,
             }));
         }
         connection.connect({
@@ -87,42 +87,42 @@ class VoiceConnectionManager extends Collection {
             endpoint: data.endpoint,
             token: data.token,
             session_id: data.session_id,
-            user_id: data.user_id
+            user_id: data.user_id,
         });
-        if(!this.pendingGuilds[data.guild_id] || this.pendingGuilds[data.guild_id].waiting) {
+        if (!this.pendingGuilds[data.guild_id] || this.pendingGuilds[data.guild_id].waiting) {
             return;
         }
         this.pendingGuilds[data.guild_id].waiting = true;
         const disconnectHandler = () => {
             connection = this.get(data.guild_id);
-            if(connection) {
+            if (connection) {
                 connection.removeListener("ready", readyHandler);
                 connection.removeListener("error", errorHandler);
             }
-            if(this.pendingGuilds[data.guild_id]) {
+            if (this.pendingGuilds[data.guild_id]) {
                 this.pendingGuilds[data.guild_id].rej(new Error("Disconnected"));
                 delete this.pendingGuilds[data.guild_id];
             }
         };
         const readyHandler = () => {
             connection = this.get(data.guild_id);
-            if(connection) {
+            if (connection) {
                 connection.removeListener("disconnect", disconnectHandler);
                 connection.removeListener("error", errorHandler);
             }
-            if(this.pendingGuilds[data.guild_id]) {
+            if (this.pendingGuilds[data.guild_id]) {
                 this.pendingGuilds[data.guild_id].res(connection);
                 delete this.pendingGuilds[data.guild_id];
             }
         };
         const errorHandler = (err) => {
             connection = this.get(data.guild_id);
-            if(connection) {
+            if (connection) {
                 connection.removeListener("disconnect", disconnectHandler);
                 connection.removeListener("ready", readyHandler);
                 connection.disconnect();
             }
-            if(this.pendingGuilds[data.guild_id]) {
+            if (this.pendingGuilds[data.guild_id]) {
                 this.pendingGuilds[data.guild_id].rej(err);
                 delete this.pendingGuilds[data.guild_id];
             }
@@ -137,7 +137,7 @@ class VoiceConnectionManager extends Collection {
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "pendingGuilds",
-            ...props
+            ...props,
         ]);
     }
 }

--- a/lib/voice/VoiceDataStream.js
+++ b/lib/voice/VoiceDataStream.js
@@ -3,7 +3,7 @@
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch{
+} catch {
     EventEmitter = require("node:events").EventEmitter;
 }
 

--- a/lib/voice/streams/BaseTransformer.js
+++ b/lib/voice/streams/BaseTransformer.js
@@ -5,8 +5,9 @@ const Base = require("../../structures/Base");
 const TransformStream = require("node:stream").Transform;
 
 class BaseTransformer extends TransformStream {
-    #transformCB;
     manualCB = false;
+    #transformCB;
+
     constructor(options = {}) {
         options.allowHalfOpen ??= true;
         options.highWaterMark ??= 0;
@@ -14,7 +15,7 @@ class BaseTransformer extends TransformStream {
     }
 
     setTransformCB(cb) {
-        if(this.manualCB) {
+        if (this.manualCB) {
             this.transformCB();
             this.#transformCB = cb;
         } else {
@@ -23,7 +24,7 @@ class BaseTransformer extends TransformStream {
     }
 
     transformCB() {
-        if(this.#transformCB) {
+        if (this.#transformCB) {
             this.#transformCB();
             this.#transformCB = null;
         }

--- a/lib/voice/streams/DCAOpusTransformer.js
+++ b/lib/voice/streams/DCAOpusTransformer.js
@@ -6,14 +6,14 @@ class DCAOpusTransformer extends BaseTransformer {
     #remainder = null;
 
     process(buffer) {
-        if(buffer.length - buffer._index < 2) {
+        if (buffer.length - buffer._index < 2) {
             return true;
         }
 
         const opusLen = buffer.readInt16LE(buffer._index);
         buffer._index += 2;
 
-        if(buffer.length - buffer._index < opusLen) {
+        if (buffer.length - buffer._index < opusLen) {
             return true;
         }
 
@@ -22,26 +22,26 @@ class DCAOpusTransformer extends BaseTransformer {
     }
 
     _transform(chunk, enc, cb) {
-        if(this.#remainder)  {
+        if (this.#remainder)  {
             chunk = Buffer.concat([this.#remainder, chunk]);
             this.#remainder = null;
         }
 
-        if(!this.head) {
-            if(chunk.length < 4) {
+        if (!this.head) {
+            if (chunk.length < 4) {
                 this.#remainder = chunk;
                 return cb();
             } else {
                 const dcaVersion = chunk.subarray(0, 4);
-                if(dcaVersion[0] !== 68 || dcaVersion[1] !== 67 || dcaVersion[2] !== 65) { // DCA0 or invalid
+                if (dcaVersion[0] !== 68 || dcaVersion[1] !== 67 || dcaVersion[2] !== 65) { // DCA0 or invalid
                     this.head = true; // Attempt to play as if it were a DCA0 file
-                } else if(dcaVersion[3] === 49) { // DCA1
-                    if(chunk.length < 8) {
+                } else if (dcaVersion[3] === 49) { // DCA1
+                    if (chunk.length < 8) {
                         this.#remainder = chunk;
                         return cb();
                     }
                     const jsonLength = chunk.subarray(4, 8).readInt32LE(0);
-                    if(chunk.length < 8 + jsonLength) {
+                    if (chunk.length < 8 + jsonLength) {
                         this.#remainder = chunk;
                         return cb();
                     }
@@ -57,10 +57,10 @@ class DCAOpusTransformer extends BaseTransformer {
 
         chunk._index = 0;
 
-        while(chunk._index < chunk.length) {
+        while (chunk._index < chunk.length) {
             const offset = chunk._index;
             const ret = this.process(chunk);
-            if(ret) {
+            if (ret) {
                 this.#remainder = chunk.subarray(offset);
                 cb();
                 return;

--- a/lib/voice/streams/FFmpegDuplex.js
+++ b/lib/voice/streams/FFmpegDuplex.js
@@ -10,7 +10,7 @@ const delegateEvents = {
     data: "_reader",
     end: "_reader",
     drain: "_writer",
-    finish: "_writer"
+    finish: "_writer",
 };
 
 class FFmpegDuplex extends DuplexStream {
@@ -40,7 +40,7 @@ class FFmpegDuplex extends DuplexStream {
 
             this[method] = function(ev, fn) {
                 const substream = delegateEvents[ev];
-                if(substream) {
+                if (substream) {
                     return this[substream][method](ev, fn);
                 } else {
                     return og.call(this, ev, fn);
@@ -79,7 +79,7 @@ class FFmpegDuplex extends DuplexStream {
         let stderr = [];
 
         const onStdoutEnd = () => {
-            if(exited && !ended) {
+            if (exited && !ended) {
                 ended = true;
                 this._reader.end();
                 setImmediate(this.emit.bind(this, "close"));
@@ -104,17 +104,17 @@ class FFmpegDuplex extends DuplexStream {
         };
 
         const onExit = (code, signal) => {
-            if(exited) {
+            if (exited) {
                 return;
             }
             exited = true;
 
-            if(killed) {
-                if(ex) {
+            if (killed) {
+                if (ex) {
                     this.emit("error", ex);
                 }
                 this.emit("close");
-            } else if(code === 0 && signal == null) {
+            } else if (code === 0 && signal == null) {
                 // All is well
                 onStdoutEnd();
             } else {
@@ -138,7 +138,7 @@ class FFmpegDuplex extends DuplexStream {
         };
 
         const kill = () => {
-            if(killed) {
+            if (killed) {
                 return;
             }
             this.#stdout.destroy();
@@ -149,7 +149,7 @@ class FFmpegDuplex extends DuplexStream {
             try {
                 this.#process.kill(options.killSignal || "SIGTERM");
                 setTimeout(() => this.#process && this.#process.kill("SIGKILL"), 2000);
-            } catch(e) {
+            } catch (e) {
                 ex = e;
                 onExit();
             }
@@ -161,7 +161,7 @@ class FFmpegDuplex extends DuplexStream {
         this.#stderr = this.#process.stderr;
         this._writer.pipe(this.#stdin);
         this.#stdout.pipe(this._reader, {
-            end: false
+            end: false,
         });
         this.kill = this.destroy = kill;
 

--- a/lib/voice/streams/FFmpegOggTransformer.js
+++ b/lib/voice/streams/FFmpegOggTransformer.js
@@ -3,31 +3,31 @@
 const FFmpegDuplex = require("./FFmpegDuplex");
 
 module.exports = function(options = {}) {
-    if(!options.command) {
+    if (!options.command) {
         throw new Error("Invalid converter command");
     }
     options.frameDuration ??= 60;
     let inputArgs = [
         "-analyzeduration", "0",
-        "-loglevel", "24"
+        "-loglevel", "24",
     ].concat(options.inputArgs || []);
-    if(options.format === "pcm") {
+    if (options.format === "pcm") {
         inputArgs = inputArgs.concat(
             "-f", "s16le",
             "-ar", "48000",
-            "-ac", "2"
+            "-ac", "2",
         );
     }
     inputArgs = inputArgs.concat(
         "-i", options.input || "-",
-        "-vn"
+        "-vn",
     );
     const outputArgs = [
         "-c:a", "libopus",
         "-vbr", "on",
         "-frame_duration", "" + options.frameDuration,
         "-f", "ogg",
-        "-"
+        "-",
     ];
     return FFmpegDuplex.spawn(options.command, inputArgs.concat(options.encoderArgs || [], outputArgs));
 };

--- a/lib/voice/streams/FFmpegPCMTransformer.js
+++ b/lib/voice/streams/FFmpegPCMTransformer.js
@@ -3,22 +3,22 @@
 const FFmpegDuplex = require("./FFmpegDuplex");
 
 module.exports = function(options = {}) {
-    if(!options.command) {
+    if (!options.command) {
         throw new Error("Invalid converter command");
     }
     options.samplingRate ??= 48_000;
     const inputArgs = [
         "-analyzeduration", "0",
-        "-loglevel", "24"
+        "-loglevel", "24",
     ].concat(options.inputArgs || [],
         "-i", options.input || "-",
-        "-vn"
+        "-vn",
     );
     const outputArgs = [
         "-f", "s16le",
         "-ar", "" + options.samplingRate,
         "-ac", "2",
-        "-"
+        "-",
     ];
     return FFmpegDuplex.spawn(options.command, inputArgs.concat(options.encoderArgs || [], outputArgs));
 };

--- a/lib/voice/streams/OggOpusTransformer.js
+++ b/lib/voice/streams/OggOpusTransformer.js
@@ -7,16 +7,16 @@ class OggOpusTransformer extends BaseTransformer {
     #remainder = null;
 
     process(buffer) {
-        if(buffer.length - buffer._index <= 26) {
+        if (buffer.length - buffer._index <= 26) {
             return true;
         }
 
-        if(buffer.toString("utf8", buffer._index, buffer._index + 4) !== "OggS") {
+        if (buffer.toString("utf8", buffer._index, buffer._index + 4) !== "OggS") {
             return new Error("Invalid OGG magic string: " + buffer.toString("utf8", buffer._index, buffer._index + 4));
         }
 
         const typeFlag = buffer.readUInt8(buffer._index + 5);
-        if(typeFlag === 1) {
+        if (typeFlag === 1) {
             return new Error("OGG continued page not supported");
         }
 
@@ -25,7 +25,7 @@ class OggOpusTransformer extends BaseTransformer {
         buffer._index += 26;
 
         const segmentCount = buffer.readUInt8(buffer._index);
-        if(buffer.length - buffer._index - 1 < segmentCount) {
+        if (buffer.length - buffer._index - 1 < segmentCount) {
             return true;
         }
 
@@ -34,9 +34,9 @@ class OggOpusTransformer extends BaseTransformer {
         let byte = 0;
         let total = 0;
         let i = 0;
-        for(; i < segmentCount; i++) {
+        for (; i < segmentCount; i++) {
             byte = buffer.readUInt8(++buffer._index);
-            if(byte < 255) {
+            if (byte < 255) {
                 segments.push(size + byte);
                 size = 0;
             } else {
@@ -47,20 +47,20 @@ class OggOpusTransformer extends BaseTransformer {
 
         ++buffer._index;
 
-        if(buffer.length - buffer._index < total) {
+        if (buffer.length - buffer._index < total) {
             return true;
         }
 
-        for(let segment of segments) {
+        for (let segment of segments) {
             buffer._index += segment;
             byte = (segment = buffer.subarray(buffer._index - segment, buffer._index)).toString("utf8", 0, 8);
-            if(this.head) {
-                if(byte === "OpusTags") {
+            if (this.head) {
+                if (byte === "OpusTags") {
                     this.emit("debug", segment.toString());
-                } else if(bitstream === this.#bitstream) {
+                } else if (bitstream === this.#bitstream) {
                     this.push(segment);
                 }
-            } else if(byte === "OpusHead") {
+            } else if (byte === "OpusHead") {
                 this.#bitstream = bitstream;
                 this.emit("debug", (this.head = segment.toString()));
             } else {
@@ -70,25 +70,25 @@ class OggOpusTransformer extends BaseTransformer {
     }
 
     _final() {
-        if(!this.#bitstream) {
+        if (!this.#bitstream) {
             this.emit("error", new Error("No Opus stream was found"));
         }
     }
 
     _transform(chunk, enc, cb) {
-        if(this.#remainder)  {
+        if (this.#remainder)  {
             chunk = Buffer.concat([this.#remainder, chunk]);
             this.#remainder = null;
         }
 
         chunk._index = 0;
 
-        while(chunk._index < chunk.length) {
+        while (chunk._index < chunk.length) {
             const offset = chunk._index;
             const ret = this.process(chunk);
-            if(ret) {
+            if (ret) {
                 this.#remainder = chunk.subarray(offset);
-                if(ret instanceof Error) {
+                if (ret instanceof Error) {
                     this.emit("error", ret);
                 }
                 cb();

--- a/lib/voice/streams/PCMOpusTransformer.js
+++ b/lib/voice/streams/PCMOpusTransformer.js
@@ -19,7 +19,7 @@ class PCMOpusTransformer extends BaseTransformer {
     }
 
     _flush(cb) {
-        if(this.#remainder) {
+        if (this.#remainder) {
             const buf = Buffer.allocUnsafe(this.pcmSize);
             this.#remainder.copy(buf);
             buf.fill(0, this.#remainder.length);
@@ -30,24 +30,24 @@ class PCMOpusTransformer extends BaseTransformer {
     }
 
     _transform(chunk, enc, cb) {
-        if(this.#remainder) {
+        if (this.#remainder) {
             chunk = Buffer.concat([this.#remainder, chunk]);
             this.#remainder = null;
         }
 
-        if(chunk.length < this.pcmSize) {
+        if (chunk.length < this.pcmSize) {
             this.#remainder = chunk;
             return cb();
         }
 
         chunk._index = 0;
 
-        while(chunk._index + this.pcmSize < chunk.length) {
+        while (chunk._index + this.pcmSize < chunk.length) {
             chunk._index += this.pcmSize;
             this.push(this.opus.encode(chunk.subarray(chunk._index - this.pcmSize, chunk._index), this.frameSize));
         }
 
-        if(chunk._index < chunk.length) {
+        if (chunk._index < chunk.length) {
             this.#remainder = chunk.subarray(chunk._index);
         }
 

--- a/lib/voice/streams/VolumeTransformer.js
+++ b/lib/voice/streams/VolumeTransformer.js
@@ -11,7 +11,7 @@ class VolumeTransformer extends BaseTransformer {
     }
 
     setVolume(volume) {
-        if(isNaN(volume) || (volume = +volume) < 0) {
+        if (isNaN(volume) || (volume = +volume) < 0) {
             throw new Error("Invalid volume level: " + volume);
         }
         this.volume = volume;
@@ -19,24 +19,24 @@ class VolumeTransformer extends BaseTransformer {
     }
 
     _transform(chunk, enc, cb) {
-        if(this.#remainder)  {
+        if (this.#remainder)  {
             chunk = Buffer.concat([this.#remainder, chunk]);
             this.#remainder = null;
         }
 
-        if(chunk.length < 2) {
+        if (chunk.length < 2) {
             return cb();
         }
 
         let buf;
-        if(chunk.length & 1) {
+        if (chunk.length & 1) {
             this.#remainder = chunk.subarray(chunk.length - 1);
             buf = Buffer.allocUnsafe(chunk.length - 1);
         } else {
             buf = Buffer.allocUnsafe(chunk.length);
         }
 
-        for(let i = 0, num; i < buf.length - 1; i += 2) {
+        for (let i = 0, num; i < buf.length - 1; i += 2) {
             // Bind transformed chunk to to 16 bit
             num = ~~(this.db * chunk.readInt16LE(i));
             buf.writeInt16LE(num >= 32767 ? 32767 : num <= -32767 ? -32767 : num, i);

--- a/lib/voice/streams/WebmOpusTransformer.js
+++ b/lib/voice/streams/WebmOpusTransformer.js
@@ -23,30 +23,30 @@ class WebmOpusTransformer extends BaseTransformer {
 
     getVIntLength(buffer, index) {
         let length = 1;
-        for(; length <= 8; ++length) {
-            if(buffer[index] & (1 << (8 - length))) {
+        for (; length <= 8; ++length) {
+            if (buffer[index] & (1 << (8 - length))) {
                 break;
             }
         }
-        if(length > 8) {
+        if (length > 8) {
             this.emit("debug", new Error(`VInt length ${length} | ${buffer.toString("hex", index, index + length)}`));
             return null;
         }
-        if(index + length > buffer.length) {
+        if (index + length > buffer.length) {
             return null;
         }
         return length;
     }
 
     process(type, info) {
-        if(type === TAG_TYPE_TAG) {
-            if(info.name === "SimpleBlock" && (info.data.readUInt8(0) & 0xF) === this.firstAudioTrack.TrackNumber) {
+        if (type === TAG_TYPE_TAG) {
+            if (info.name === "SimpleBlock" && (info.data.readUInt8(0) & 0xF) === this.firstAudioTrack.TrackNumber) {
                 this.push(info.data.subarray(4));
                 return;
             }
-            if(info.name === "CodecPrivate") {
+            if (info.name === "CodecPrivate") {
                 const head = info.data.toString("utf8", 0, 8);
-                if(head !== "OpusHead") {
+                if (head !== "OpusHead") {
                     this.emit("error", new Error("Invalid codec: " + head));
                     return;
                 }
@@ -57,35 +57,35 @@ class WebmOpusTransformer extends BaseTransformer {
                     preSkip: info.data.readUInt16LE(10),
                     inputSampleRate: info.data.readUInt32LE(12),
                     outputGain: info.data.readUInt16LE(16),
-                    mappingFamily: info.data.readUInt8(18)
+                    mappingFamily: info.data.readUInt8(18),
                 };
                 return;
             }
         }
 
-        if(!this.firstAudioTrack) {
-            if(info.name === "TrackEntry") {
-                if(type === TAG_TYPE_START) {
+        if (!this.firstAudioTrack) {
+            if (info.name === "TrackEntry") {
+                if (type === TAG_TYPE_START) {
                     this.parsingTrack = {};
-                } else if(type === TAG_TYPE_END) {
-                    if(this.parsingTrack.TrackNumber && this.parsingTrack.TrackType === TRACKTYPE_AUDIO) {
+                } else if (type === TAG_TYPE_END) {
+                    if (this.parsingTrack.TrackNumber && this.parsingTrack.TrackType === TRACKTYPE_AUDIO) {
                         this.firstAudioTrack = this.parsingTrack;
                     }
                     delete this.parsingTrack;
                 }
                 return;
             }
-            if(this.parsingTrack) {
-                if(info.name === "TrackNumber") {
+            if (this.parsingTrack) {
+                if (info.name === "TrackNumber") {
                     this.parsingTrack.TrackNumber = info.data[0];
                     return;
                 }
-                if(info.name === "TrackType") {
+                if (info.name === "TrackType") {
                     this.parsingTrack.TrackType = info.data[0];
                     return;
                 }
             }
-            if(type === TAG_TYPE_END && info.name === "Tracks") {
+            if (type === TAG_TYPE_END && info.name === "Tracks") {
                 this.emit("error", new Error("No audio track"));
                 return;
             }
@@ -96,13 +96,13 @@ class WebmOpusTransformer extends BaseTransformer {
     readContent(buffer) {
         const tagObj = this.#tag_stack[this.#tag_stack.length - 1];
 
-        if(tagObj.type === "m") {
+        if (tagObj.type === "m") {
             this.process(TAG_TYPE_START, tagObj);
             this.#state = STATE_TAG;
             return true;
         }
 
-        if(buffer.length < buffer._index + tagObj.size) {
+        if (buffer.length < buffer._index + tagObj.size) {
             return false;
         }
 
@@ -115,8 +115,8 @@ class WebmOpusTransformer extends BaseTransformer {
 
         this.process(TAG_TYPE_TAG, tagObj);
 
-        while(this.#tag_stack.length > 0) {
-            if(this.#total < this.#tag_stack[this.#tag_stack.length - 1].end) {
+        while (this.#tag_stack.length > 0) {
+            if (this.#total < this.#tag_stack[this.#tag_stack.length - 1].end) {
                 break;
             }
             this.process(TAG_TYPE_END, this.#tag_stack.pop());
@@ -127,12 +127,12 @@ class WebmOpusTransformer extends BaseTransformer {
 
     readTag(buffer) {
         const tagSize = this.getVIntLength(buffer, buffer._index);
-        if(tagSize === null) {
+        if (tagSize === null) {
             return false;
         }
 
         const size = this.getVIntLength(buffer, buffer._index + tagSize);
-        if(size === null) {
+        if (size === null) {
             return false;
         }
 
@@ -141,9 +141,9 @@ class WebmOpusTransformer extends BaseTransformer {
         const tagObj = {
             type: "unknown",
             name: "unknown",
-            end: this.#total + tagSize
+            end: this.#total + tagSize,
         };
-        if(schema[tagStr]) {
+        if (schema[tagStr]) {
             tagObj.type = schema[tagStr].type;
             tagObj.name = schema[tagStr].name;
         }
@@ -151,14 +151,14 @@ class WebmOpusTransformer extends BaseTransformer {
         buffer._index += tagSize;
 
         let value = buffer[buffer._index] & (1 << (8 - size)) - 1;
-        for(let i = 1; i < size; ++i) {
-            if(i === 7 && value >= MAX_SHIFTED_VINT && buffer[buffer._index + 7] > 0) {
+        for (let i = 1; i < size; ++i) {
+            if (i === 7 && value >= MAX_SHIFTED_VINT && buffer[buffer._index + 7] > 0) {
                 tagObj.end = -1; // Special livestreaming int 0x1FFFFFFFFFFFFFF
                 break;
             }
             value = (value << 8) + buffer[buffer._index + i];
         }
-        if(tagObj.end !== -1) {
+        if (tagObj.end !== -1) {
             tagObj.end += value + size;
         }
         tagObj.size = value;
@@ -173,23 +173,23 @@ class WebmOpusTransformer extends BaseTransformer {
     }
 
     _transform(chunk, enc, cb) {
-        if(this.#remainder)  {
+        if (this.#remainder)  {
             chunk = Buffer.concat([this.#remainder, chunk]);
             this.#remainder = null;
         }
 
         chunk._index = 0;
 
-        while(chunk._index < chunk.length) {
-            if(this.#state === STATE_TAG && !this.readTag(chunk)) {
+        while (chunk._index < chunk.length) {
+            if (this.#state === STATE_TAG && !this.readTag(chunk)) {
                 break;
             }
-            if(this.#state === STATE_CONTENT && !this.readContent(chunk)) {
+            if (this.#state === STATE_CONTENT && !this.readContent(chunk)) {
                 break;
             }
         }
 
-        if(chunk._index < chunk.length) {
+        if (chunk._index < chunk.length) {
             this.#remainder = chunk.subarray(chunk._index);
         }
 
@@ -202,54 +202,54 @@ module.exports = WebmOpusTransformer;
 const schema = {
     ae: {
         name: "TrackEntry",
-        type: "m"
+        type: "m",
     },
     d7: {
         name: "TrackNumber",
-        type: "u"
+        type: "u",
     },
     "86": {
         name: "CodecID",
-        type: "s"
+        type: "s",
     },
     "83": {
         name: "TrackType",
-        type: "u"
+        type: "u",
     },
     "1654ae6b": {
         name: "Tracks",
-        type: "m"
+        type: "m",
     },
     "63a2": {
         name: "CodecPrivate",
-        type: "b"
+        type: "b",
     },
     a3: {
         name: "SimpleBlock",
-        type: "b"
+        type: "b",
     },
     "1a45dfa3": {
         name: "EBML",
-        type: "m"
+        type: "m",
     },
     "18538067": {
         name: "Segment",
-        type: "m"
+        type: "m",
     },
     "114d9b74": {
         name: "SeekHead",
-        type: "m"
+        type: "m",
     },
     "1549a966": {
         name: "Info",
-        type: "m"
+        type: "m",
     },
     e1: {
         name: "Audio",
-        type: "m"
+        type: "m",
     },
     "1f43b675": {
         name: "Cluster",
-        type: "m"
-    }
+        type: "m",
+    },
 };


### PR DESCRIPTION
This PR tweaks the linting rules mainly to help readability and enforce consistency across the Dysnomia codebase.

## What's changed as of now

- `strict` is now enforced as an error - this means that strict mode will be consistently required
- `eqeqeq` is also now enforced as an error to help avoid using loose `==` which is slower (`== null` is still allowed)
- spacing between keywords is now enforced - this is mainly to combat these `} catch{` constructs introduced in #46, secondly because I like it more
- anything else? open to comments and suggestions on what rules to enable/disable/fine-tune