### PR TITLE
Added port option to rest options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -478,6 +478,7 @@ declare namespace Dysnomia {
     baseURL?: string;
     disableLatencyCompensation?: boolean;
     domain?: string;
+    port?: string;
     https?: boolean;
     latencyThreshold?: number;
     ratelimiterOffset?: number;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -124,6 +124,7 @@ class Client extends EventEmitter {
     * @arg {String} [options.rest.domain="discord.com"] The domain to use for API requests
     * @arg {Boolean} [options.rest.https=true] Whether to make requests to the Discord API over HTTPS (true) or HTTP (false)
     * @arg {Number} [options.rest.latencyThreshold=30000] The average request latency at which Dysnomia will start emitting latency errors
+    * @arg {Number} [options.rest.port] The port to use for API requests. Defaults to 443 (HTTPS) or 80 (HTTP)
     * @arg {Number} [options.rest.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
     * @arg {Number} [options.rest.requestTimeout=15000] A number of milliseconds before REST requests are considered timed out
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. Even with this option enabled, it is recommended that you check the cache first before using REST

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -153,6 +153,7 @@ class RequestHandler {
                     req = requester.request({
                         method: method,
                         host: this.options.domain,
+                        port: this.options.port,
                         path: this.options.baseURL + finalURL,
                         headers: headers,
                         agent: this.options.agent


### PR DESCRIPTION
Adding port in to the domain option does not work as intended since Node.js HTTP lib does not allow that. Thus, added `port` option.