### PR TITLE
feat: add headers to REST options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -479,7 +479,7 @@ declare namespace Dysnomia {
     disableLatencyCompensation?: boolean;
     domain?: string;
     port?: string;
-    headers?: {[key: string]: any}
+    headers?: {[key: string]: any};
     https?: boolean;
     latencyThreshold?: number;
     ratelimiterOffset?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -479,7 +479,7 @@ declare namespace Dysnomia {
     disableLatencyCompensation?: boolean;
     domain?: string;
     port?: string;
-    headers?: {[key: string]: any};
+    headers?: Record<string, number | string | string[]>;
     https?: boolean;
     latencyThreshold?: number;
     ratelimiterOffset?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -479,6 +479,7 @@ declare namespace Dysnomia {
     disableLatencyCompensation?: boolean;
     domain?: string;
     port?: string;
+    headers?: {[key: string]: any}
     https?: boolean;
     latencyThreshold?: number;
     ratelimiterOffset?: number;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -125,6 +125,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.rest.https=true] Whether to make requests to the Discord API over HTTPS (true) or HTTP (false)
     * @arg {Number} [options.rest.latencyThreshold=30000] The average request latency at which Dysnomia will start emitting latency errors
     * @arg {Number} [options.rest.port] The port to use for API requests. Defaults to 443 (HTTPS) or 80 (HTTP)
+    * @arg {Object} [options.rest.headers] Headers to be appended in REST requests.
     * @arg {Number} [options.rest.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
     * @arg {Number} [options.rest.requestTimeout=15000] A number of milliseconds before REST requests are considered timed out
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. Even with this option enabled, it is recommended that you check the cache first before using REST

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -125,7 +125,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.rest.https=true] Whether to make requests to the Discord API over HTTPS (true) or HTTP (false)
     * @arg {Number} [options.rest.latencyThreshold=30000] The average request latency at which Dysnomia will start emitting latency errors
     * @arg {Number} [options.rest.port] The port to use for API requests. Defaults to 443 (HTTPS) or 80 (HTTP)
-    * @arg {Object} [options.rest.headers] Headers to be appended in REST requests.
+    * @arg {Object} [options.rest.headers] Headers to be appended in REST requests
     * @arg {Number} [options.rest.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
     * @arg {Number} [options.rest.requestTimeout=15000] A number of milliseconds before REST requests are considered timed out
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. Even with this option enabled, it is recommended that you check the cache first before using REST

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -86,6 +86,9 @@ class RequestHandler {
                     if(auth) {
                         headers.Authorization = this.#client._token;
                     }
+                    if(this.options.headers) {
+                        Object.assign(headers, this.options.headers);
+                    }
                     if(body?.reason) { // Audit log reason sniping
                         headers["X-Audit-Log-Reason"] = encodeURIComponent(body.reason);
                         delete body.reason;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -83,11 +83,11 @@ class RequestHandler {
                 let finalURL = url;
 
                 try {
-                    if(auth) {
-                        headers.Authorization = this.#client._token;
-                    }
                     if(this.options.headers) {
                         Object.assign(headers, this.options.headers);
+                    }
+                    if(auth) {
+                        headers.Authorization = this.#client._token;
                     }
                     if(body?.reason) { // Audit log reason sniping
                         headers["X-Audit-Log-Reason"] = encodeURIComponent(body.reason);


### PR DESCRIPTION
Additional headers can be appended with `headers` option in REST options. 
- It's useful to put REST proxy authentication key.
- It is also flexible for other header usages.