### PR TITLE
docs(Client): remove missing options.maxShards option

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -114,7 +114,6 @@ class Client extends EventEmitter {
     * @arg {Number | String} [options.gateway.maxShards=1] The total number of shards you want to run. If "auto" Dysnomia will use Discord's recommended shard count.
     * @arg {Function} [options.gateway.reconnectDelay] A function which returns how long the bot should wait until reconnecting to Discord.
     * @arg {Boolean} [options.gateway.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
-    * @arg {Number | String} [options.maxShards=1] The total number of shards you want to run. If "auto" Dysnomia will use Discord's recommended shard count. This option has been moved under `options.gateway`
     * @arg {Number} [options.messageLimit=100] The maximum size of a channel message cache
     * @arg {Boolean} [options.opusOnly=false] Whether to suppress the Opus encoder not found error or not
     * @arg {Object} [options.rest] Options for the REST request handler


### PR DESCRIPTION
I noticed the docs still show an `options.maxShards` option but it appears to not work. The comment correctly notes that `This option has been moved under 'options.gateway'`

I can only speculate but I suspect not marking it `[DEPRECATED]` here may have been a simple oversight in [the original MR](https://github.com/abalabahaha/eris/pull/1426), which does however mark it deprecated in [index.d.ts](https://github.com/abalabahaha/eris/pull/1426/files#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R418).

So I propose removing it to reduce potential confusion. I would also be up for making it work and adding a deprecation warning, but I see it looks like most of those have been ripped out from the `dev` branch.