### PR TITLE
types(PartialEmoji): make `id` optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -572,7 +572,7 @@ declare namespace Dysnomia {
     roles?: string[];
   }
   interface PartialEmoji {
-    id: string | null;
+    id?: string;
     name: string;
     animated?: boolean;
   }


### PR DESCRIPTION
Changed type definition of `id` field from `string | null` to optional `string` field. 