### PR TITLE
types(Client): make `editChannelOptions()` channel position optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -332,7 +332,7 @@ declare namespace Dysnomia {
   }
   interface ChannelPosition {
     id: string;
-    position: number;
+    position?: number;
     lockPermissions?: boolean;
     parentID?: string;
   }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1315,7 +1315,7 @@ class Client extends EventEmitter {
     * @arg {String} guildID The ID of the guild
     * @arg {Array<Object>} channelPositions An array of [ChannelPosition](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions)
     * @arg {String} channelPositions[].id The ID of the channel
-    * @arg {Number} channelPositions[].position The new position of the channel
+    * @arg {Number} [channelPositions[].position] The new position of the channel
     * @arg {Boolean} [channelPositions[].lockPermissions] Whether to sync the channel's permissions with the new parent, if changing parents
     * @arg {String} [channelPositions[].parentID] The new parent ID (category channel) for the channel that is moved. For each request, only one channel can change parents
     * @returns {Promise}

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -683,7 +683,7 @@ class Guild extends Base {
     * Edit multiple channels' positions. Note that channel position numbers are grouped by type (category, text, voice), then sorted in ascending order (lowest number is on top).
     * @arg {Array<Object>} channelPositions An array of [ChannelPosition](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions)
     * @arg {String} channelPositions[].id The ID of the channel
-    * @arg {Number} channelPositions[].position The new position of the channel
+    * @arg {Number} [channelPositions[].position] The new position of the channel
     * @arg {Boolean} [channelPositions[].lockPermissions] Whether to sync the channel's permissions with the new parent, if changing parents
     * @arg {String} [channelPositions[].parentID] The new parent ID (category channel) for the channel that is moved. For each request, only one channel can change parents
     * @returns {Promise}


### PR DESCRIPTION
Ref: https://github.com/discord/discord-api-docs/commit/a50bf9ba22b5f493a242d748c0e9f51f726bfa17 – although I think this change is a bit weird.