### PR TITLE
refactor: don't call update() multiple times in the prototype chain

### DIFF
--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -14,7 +14,6 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 class CategoryChannel extends GuildChannel {
     constructor(data, client) {
         super(data, client);
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/ExtendedUser.js
+++ b/lib/structures/ExtendedUser.js
@@ -13,7 +13,6 @@ const User = require("./User");
 class ExtendedUser extends User {
     constructor(data, client) {
         super(data, client);
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/ForumChannel.js
+++ b/lib/structures/ForumChannel.js
@@ -27,7 +27,6 @@ class ForumChannel extends GuildChannel {
         this.defaultThreadRateLimitPerUser = data.default_thread_rate_limit_per_user == null ? null : data.default_thread_rate_limit_per_user;
         this.lastThreadID = data.last_message_id || null;
         this.rateLimitPerUser = data.rate_limit_per_user == null ? null : data.rate_limit_per_user;
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -10,7 +10,6 @@ class NewsChannel extends TextChannel {
     constructor(data, guild, messageLimit) {
         super(data, guild, messageLimit);
         this.rateLimitPerUser = 0;
-        this.update(data);
     }
 
     /**

--- a/lib/structures/PrivateThreadChannel.js
+++ b/lib/structures/PrivateThreadChannel.js
@@ -15,7 +15,6 @@ const ThreadChannel = require("./ThreadChannel");
 class PrivateThreadChannel extends ThreadChannel {
     constructor(data, client, messageLimit) {
         super(data, client, messageLimit);
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/PublicThreadChannel.js
+++ b/lib/structures/PublicThreadChannel.js
@@ -10,7 +10,6 @@ const ThreadChannel = require("./ThreadChannel");
 class PublicThreadChannel extends ThreadChannel {
     constructor(data, client, messageLimit) {
         super(data, client, messageLimit);
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -25,7 +25,6 @@ class TextChannel extends GuildChannel {
         this.lastMessageID = data.last_message_id || null;
         this.rateLimitPerUser = data.rate_limit_per_user == null ? null : data.rate_limit_per_user;
         this.lastPinTimestamp = data.last_pin_timestamp ? Date.parse(data.last_pin_timestamp) : null;
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -20,7 +20,6 @@ class TextVoiceChannel extends VoiceChannel {
         this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
         this.nsfw = data.nsfw;
         this.lastMessageID = data.last_message_id || null;
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -34,7 +34,6 @@ class ThreadChannel extends GuildChannel {
         this.members = new Collection(ThreadMember);
         this.lastMessageID = data.last_message_id || null;
         this.ownerID = data.owner_id;
-        this.update(data);
     }
 
     update(data) {

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -18,7 +18,6 @@ class VoiceChannel extends GuildChannel {
     constructor(data, client) {
         super(data, client);
         this.voiceMembers = new Collection(Member);
-        this.update(data);
     }
 
     update(data) {


### PR DESCRIPTION
The update() method is already called in the base class - according to JS class semantics, when calling a constructor via `super`, `this` still points to the object at the top of the prototype chain, resulting in the update() method being called twice or more down the prototype chain as the super-classes initialize.