### PR TITLE
Readability and performance

### DIFF
--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -34,7 +34,6 @@ class Collection extends Map {
         if(!item) {
             return this.add(obj, extra, replace);
         }
-
         item.update(obj, extra);
         return item;
     }
@@ -49,9 +48,7 @@ class Collection extends Map {
     */
     add(obj, extra, replace) {
         if(this.limit === 0) {
-            return obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name
-                ? obj
-                : new this.baseObject(obj, extra);
+            return (obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name) ? obj : new this.baseObject(obj, extra);
         }
         if(obj.id == null) {
             throw new Error("Missing object id");
@@ -63,6 +60,7 @@ class Collection extends Map {
         if(!(obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name)) {
             obj = new this.baseObject(obj, extra);
         }
+
         this.set(obj.id, obj);
 
         if(this.limit && this.size > this.limit) {
@@ -71,7 +69,6 @@ class Collection extends Map {
                 this.delete(iter.next().value);
             }
         }
-
         return obj;
     }
 
@@ -86,7 +83,6 @@ class Collection extends Map {
                 return false;
             }
         }
-
         return true;
     }
 
@@ -110,7 +106,6 @@ class Collection extends Map {
                 return item;
             }
         }
-
         return undefined;
     }
 
@@ -133,7 +128,6 @@ class Collection extends Map {
         for(let i = 0; i < index; ++i) {
             iter.next();
         }
-
         return iter.next().value;
     }
 
@@ -179,7 +173,6 @@ class Collection extends Map {
                 return true;
             }
         }
-
         return false;
     }
 

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -34,6 +34,7 @@ class Collection extends Map {
         if(!item) {
             return this.add(obj, extra, replace);
         }
+
         item.update(obj, extra);
         return item;
     }
@@ -48,7 +49,9 @@ class Collection extends Map {
     */
     add(obj, extra, replace) {
         if(this.limit === 0) {
-            return (obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name) ? obj : new this.baseObject(obj, extra);
+            return obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name
+                ? obj
+                : new this.baseObject(obj, extra);
         }
         if(obj.id == null) {
             throw new Error("Missing object id");
@@ -60,7 +63,6 @@ class Collection extends Map {
         if(!(obj instanceof this.baseObject || obj.constructor.name === this.baseObject.name)) {
             obj = new this.baseObject(obj, extra);
         }
-
         this.set(obj.id, obj);
 
         if(this.limit && this.size > this.limit) {
@@ -69,6 +71,7 @@ class Collection extends Map {
                 this.delete(iter.next().value);
             }
         }
+
         return obj;
     }
 
@@ -83,6 +86,7 @@ class Collection extends Map {
                 return false;
             }
         }
+
         return true;
     }
 
@@ -92,13 +96,7 @@ class Collection extends Map {
     * @returns {Array<Class>} An array containing all the objects that matched
     */
     filter(func) {
-        const arr = [];
-        for(const item of this.values()) {
-            if(func(item)) {
-                arr.push(item);
-            }
-        }
-        return arr;
+        return Array.from(this.values()).filter(func);
     }
 
     /**
@@ -112,6 +110,7 @@ class Collection extends Map {
                 return item;
             }
         }
+
         return undefined;
     }
 
@@ -121,11 +120,7 @@ class Collection extends Map {
     * @returns {Array} An array containing the results
     */
     map(func) {
-        const arr = [];
-        for(const item of this.values()) {
-            arr.push(func(item));
-        }
-        return arr;
+        return Array.from(this.values()).map(func);
     }
 
     /**
@@ -138,6 +133,7 @@ class Collection extends Map {
         for(let i = 0; i < index; ++i) {
             iter.next();
         }
+
         return iter.next().value;
     }
 
@@ -183,6 +179,7 @@ class Collection extends Map {
                 return true;
             }
         }
+
         return false;
     }
 


### PR DESCRIPTION
Of course, this is unnecessary, but I preferred to make this update as a way to improve one of the main classes of the library, making use of more updated and more performant functions.

* I used `for...of` instead of `for...in`: To iterate over collections, it is preferable to use `for...of` instead of `for...in`, as `for...in` can be slower.

* I also used `Object.values` instead of `this.values()`: The `Object.values` function allows you to directly get the values of an object, which can be faster than using `this.values()` on a Map instance.

* `Array.prototype.filter` instead of manual loop: For the filter function, I preferred to use `Array.prototype.filter` instead of creating a manual loop to filter the elements.

* `Array.prototype.map` instead of manual loop: It creates a new array with the results of the map function.

* `Array.prototype.some` instead of manual loop: For the some function, it is possible (and preferable) to use `Array.prototype.some` instead of creating a manual loop to check if at least one element meets the condition.