### PR TITLE
types(OAuthApplicationInfo): remove guild property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1734,11 +1734,6 @@ declare namespace Dysnomia {
     description: string;
     flags?: number;
     guild_id?: string;
-    // The docs say that there can be a partial guild object attached,
-    // but as of 2023-07-25, there is no guild object attached in either
-    // endpoints, so we cannot determine how partial the guild object really is.
-    // Proceed with caution.
-    guild?: unknown;
     icon: string | null;
     id: string;
     install_params?: OAuthInstallParams;


### PR DESCRIPTION
Per the newly released OpenAPI spec (https://github.com/discord/discord-api-spec), there doesn't even seem to be one... (structure PrivateApplicationResponse)


It should be, however, noted, that the spec isn't considered the source of truth per the same repository.