### PR TITLE
types: correct gateway/REST versions in Constants interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1774,8 +1774,8 @@ declare namespace Dysnomia {
     permissions: string;
   }
   interface Constants {
-    GATEWAY_VERSION: 9;
-    REST_VERSION: 9;
+    GATEWAY_VERSION: 10;
+    REST_VERSION: 10;
     ActivityFlags: {
       INSTANCE:                    1;
       JOIN:                        2;


### PR DESCRIPTION
We're on API v10, as stated in lib/Constants.js.