### PR TITLE
hotfix(Role): include `flags` in toJSON() output (v0.1.x)

### DIFF
--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -131,6 +131,7 @@ class Role extends Base {
             "color",
             "hoist",
             "icon",
+            "flags",
             "managed",
             "mentionable",
             "name",


### PR DESCRIPTION
Backports #103 to 0.1.3 release.
