### PR TITLE
experimental: feat(VoiceConnection): lower browser runtime error to a warning

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -101,7 +101,7 @@ class VoiceConnection extends EventEmitter {
         super();
 
         if(typeof window !== "undefined") {
-            throw new Error("Voice is not supported in browsers at this time");
+            process.emitWarning("Voice is not supported in browser-like runtimes. Proceed at your own caution.", "BrowserLikeRuntimeWarning", "dysnomia:VOICE_BROWSER");
         }
 
         if(!Sodium && !NaCl) {

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -51,6 +51,8 @@ converterCommand.pickCommand = function pickCommand() {
     }
 };
 
+let emittedBrowserLikeRuntimeWarning = false;
+
 /**
 * Represents a voice connection
 * @extends EventEmitter
@@ -100,8 +102,9 @@ class VoiceConnection extends EventEmitter {
     constructor(id, options = {}) {
         super();
 
-        if(typeof window !== "undefined") {
+        if(typeof window !== "undefined" && !emittedBrowserLikeRuntimeWarning) {
             process.emitWarning("Voice is not supported in browser-like runtimes. Proceed at your own caution.", "BrowserLikeRuntimeWarning", "dysnomia:VOICE_BROWSER");
+            emittedBrowserLikeRuntimeWarning = true;
         }
 
         if(!Sodium && !NaCl) {


### PR DESCRIPTION
The base work around "browser" support was done over 7 years ago. Although nothing much has changed when it comes to supporting UDP connections in browsers, over time, browser-like runtimes like Deno, Bun, and others claiming (partial) Node compatibility (including UDP connections) have emerged. Although using Dysnomia with these browser-like environments won't be officially supported, I think that rather than blocking them outright, we should acknowledge that those alternative runtimes exist and allow them to try to use voice at their own risk with a warning that they might possibly end up seeing undefined or weird behavior.
