### PR TITLE
feat: getNitroStickerPacks() -> getStickerPacks()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2718,6 +2718,7 @@ declare namespace Dysnomia {
     getMessage(channelID: string, messageID: string): Promise<Message>;
     getMessageReaction(channelID: string, messageID: string, reaction: string, options?: GetMessageReactionOptions): Promise<User[]>;
     getMessages(channelID: string, options?: GetMessagesOptions): Promise<Message[]>;
+    /** @deprecated */
     getNitroStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getOAuthApplication(): Promise<OAuthApplicationInfo>;
     getPins(channelID: string): Promise<Message[]>;
@@ -2739,6 +2740,7 @@ declare namespace Dysnomia {
     getRoleConnectionMetadata(): Promise<ApplicationRoleConnectionMetadata[]>;
     getSelf(): Promise<ExtendedUser>;
     getStageInstance(channelID: string): Promise<StageInstance>;
+    getStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getThreadMember(channelID: string, memberID: string, options: GetThreadMemberOptions): Promise<ThreadMember>;
     getThreadMembers(channelID: string, options: GetThreadMembersOptions): Promise<ThreadMember[]>;
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2491,7 +2491,7 @@ class Client extends EventEmitter {
 
     /**
      * [DEPRECATED] Get the list of sticker packs available to Nitro subscribers
-     * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
+     * @returns {Promise<Object>} An object which contains a value which contains an array of sticker packs
      */
     getNitroStickerPacks() {
         emitDeprecation("NITRO_STICKER_PACKS");
@@ -2751,7 +2751,7 @@ class Client extends EventEmitter {
 
     /**
      * Get the list of available sticker packs
-     * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
+     * @returns {Promise<Object>} An object which contains a value which contains an array of sticker packs
      */
     getStickerPacks() {
         return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -27,6 +27,7 @@ const UnavailableGuild = require("./structures/UnavailableGuild");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
 const AutoModerationRule = require("./structures/AutoModerationRule");
+const emitDeprecation = require("./util/emitDeprecation");
 
 let EventEmitter;
 try {
@@ -2489,11 +2490,12 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Get the list of sticker packs available to Nitro subscribers
+     * [DEPRECATED] Get the list of sticker packs available to Nitro subscribers
      * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
      */
     getNitroStickerPacks() {
-        return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);
+        emitDeprecation("NITRO_STICKER_PACKS");
+        return this.getStickerPacks();
     }
 
     /**
@@ -2745,6 +2747,14 @@ class Client extends EventEmitter {
     */
     getStageInstance(channelID) {
         return this.requestHandler.request("GET", Endpoints.STAGE_INSTANCE(channelID), true).then((instance) => new StageInstance(instance, this));
+    }
+
+    /**
+     * Get the list of available sticker packs
+     * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
+     */
+    getStickerPacks() {
+        return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);
     }
 
     /**

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -1,5 +1,5 @@
 const warningMessages = {
-    NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated in favor of Client#getStickerPacks."
+    NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated as built-in sticker packs are free for everyone. Please use Client#getStickerPacks instead."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -1,4 +1,5 @@
 const warningMessages = {
+    NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated in favor of Client#getStickerPacks."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 


### PR DESCRIPTION
Sticker packs that used to be Nitro-only are free now - this slipped under the radar.

Ref: https://github.com/discord/discord-api-docs/pull/6265