### PR TITLE
docs: convert inline `@prop` to actual class members

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -46,28 +46,22 @@ const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 /**
 * Represents the main Dysnomia client
 * @extends EventEmitter
-* @prop {Object?} application Object containing the bot application's ID and its public flags
-* @prop {Boolean} bot Whether the user belongs to an OAuth2 application
-* @prop {Object} channelGuildMap Object mapping channel IDs to guild IDs
-* @prop {String} gatewayURL The URL for the discord gateway
-* @prop {Collection<Guild>} guilds Collection of guilds the bot is in
-* @prop {Object} guildShardMap Object mapping guild IDs to shard IDs
-* @prop {Object} options Dysnomia options
-* @prop {Object} privateChannelMap Object mapping user IDs to private channel IDs
-* @prop {Collection<PrivateChannel>} privateChannels Collection of private channels the bot is in
-* @prop {RequestHandler} requestHandler The request handler the client will use
-* @prop {Collection<Shard>} shards Collection of shards Dysnomia is using
-* @prop {Number} startTime Timestamp of bot ready event
-* @prop {Object} threadGuildMap Object mapping thread channel IDs to guild IDs
-* @prop {Collection<UnavailableGuild>} unavailableGuilds Collection of unavailable guilds the bot is in
-* @prop {Number} uptime How long in milliseconds the bot has been up for
-* @prop {ExtendedUser} user The bot user
-* @prop {Collection<User>} users Collection of users the bot sees
-* @prop {Collection<VoiceConnection>} voiceConnections Extended collection of active VoiceConnections the bot has
 */
 class Client extends EventEmitter {
+    /**
+     * Object mapping channel IDs to guild IDs
+     * @type {Object<string, string>}
+     */
     channelGuildMap = {};
+    /**
+     * Collection of guilds the bot is in
+     * @type {Collection<Guild>}
+     */
     guilds = new Collection(Guild);
+    /**
+     * Object mapping guild IDs to shard IDs
+     * @type {Object<string, number>}
+     */
     guildShardMap = {};
     lastConnect = 0;
     lastReconnectDelay = 0;
@@ -77,15 +71,53 @@ class Client extends EventEmitter {
         since: null,
         status: "offline"
     };
+    /**
+     * Object mapping user IDs to private channel IDs
+     * @type {Object<string, string>}
+     */
     privateChannelMap = {};
+    /**
+     * Collection of private channels the bot is in
+     * @type {Collection<PrivateChannel>}
+     */
     privateChannels = new Collection(PrivateChannel);
     ready = false;
     reconnectAttempts = 0;
+    /**
+     * Timestamp of bot ready event
+     * @type {Number}
+     */
     startTime = 0;
+    /**
+     * Object mapping thread channel IDs to guild IDs
+     * @type {Object<string, string>}
+     */
     threadGuildMap = {};
+    /**
+     * Collection of unavailable guilds the bot is in
+     * @type {Collection<UnavailableGuild>}
+     */
     unavailableGuilds = new Collection(UnavailableGuild);
+    /**
+     * Collection of users the bot sees
+     * @type {Collection<User>}
+     */
     users = new Collection(User);
+    /**
+     * Extended collection of active VoiceConnections the bot has
+     * @type {Collection<VoiceConnection>}
+     */
     voiceConnections = new VoiceConnectionManager();
+
+    /**
+     * Object containing the bot application's ID and its public flags
+     * @member {Object?} Client#application
+     */
+
+    /**
+     * The bot user
+     * @member {ExtendedUser} Client#user
+     */
 
     /**
     * Create a Client
@@ -134,6 +166,10 @@ class Client extends EventEmitter {
     constructor(token, options) {
         super();
 
+        /**
+         * Dysnomia options
+         * @type {Object}
+         */
         this.options = Object.assign({
             allowedMentions: {
                 users: true,
@@ -169,17 +205,33 @@ class Client extends EventEmitter {
             value: token
         });
 
+        /**
+         * The request handler the client will use
+         * @type {RequestHandler}
+         */
         this.requestHandler = new RequestHandler(this, this.options.rest);
         delete this.options.rest;
 
+        /**
+         * Collection of shards Dysnomia is using
+         * @type {Collection<Shard>}
+         */
         this.shards = new ShardManager(this, this.options.gateway);
         delete this.options.gateway;
 
+        /**
+         * Whether the user belongs to an OAuth2 application
+         * @type {Boolean}
+         */
         this.bot = this._token.startsWith("Bot ");
 
         this.connect = this.connect.bind(this);
     }
 
+    /**
+     * How long in milliseconds the bot has been up for
+     * @type {Number}
+     */
     get uptime() {
         return this.startTime ? Date.now() - this.startTime : 0;
     }
@@ -335,6 +387,10 @@ class Client extends EventEmitter {
             if(!data.url.endsWith("/")) {
                 data.url += "/";
             }
+            /**
+             * The URL for the discord gateway
+             * @type {String}
+             */
             this.gatewayURL = `${data.url}?v=${Constants.GATEWAY_VERSION}&encoding=${Erlpack ? "etf" : "json"}`;
 
             if(this.shards.options.compress) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -47,14 +47,6 @@ try {
 /**
 * Represents a shard
 * @extends EventEmitter
-* @prop {Number} id The ID of the shard
-* @prop {Boolean} connecting Whether the shard is connecting
-* @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
-* @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} latency The current latency between the shard and Discord, in milliseconds
-* @prop {Boolean} ready Whether the shard is ready
-* @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"ready"/"identifying"/"resuming"
 */
 class Shard extends EventEmitter {
     #onWSClose;
@@ -66,7 +58,15 @@ class Shard extends EventEmitter {
     constructor(id, client) {
         super();
 
+        /**
+         * The ID of the shard
+         * @type {Number}
+         */
         this.id = id;
+        /**
+         * The client instance associated with this shard
+         * @type {Client}
+         */
         this.client = client;
 
         this.onPacket = this.onPacket.bind(this);
@@ -81,6 +81,10 @@ class Shard extends EventEmitter {
     checkReady() {
         if(!this.ready) {
             if(Object.keys(this.getAllUsersCount).length === 0) {
+                /**
+                 * Whether the shard is ready
+                 * @type {Boolean}
+                 */
                 this.ready = true;
                 /**
                 * Fired when the shard turns ready
@@ -100,6 +104,11 @@ class Shard extends EventEmitter {
             return;
         }
         ++this.connectAttempts;
+
+        /**
+         * Whether the shard is connecting
+         * @type {Boolean}
+         */
         this.connecting = true;
         return this.initializeWS();
     }
@@ -277,6 +286,10 @@ class Shard extends EventEmitter {
             }
             this.lastHeartbeatAck = false;
         }
+        /**
+         * Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
+         * @type {Number}
+         */
         this.lastHeartbeatSent = Date.now();
         this.sendWS(GatewayOPCodes.HEARTBEAT, this.seq, true);
     }
@@ -292,6 +305,10 @@ class Shard extends EventEmitter {
             this.emit("error", new Error("pako/zlib-sync not found, cannot decompress data"));
             return;
         }
+        /**
+         * The status of the shard. "disconnected"/"connecting"/"handshaking"/"ready"/"identifying"/"resuming"
+         * @type {String}
+         */
         this.status = "identifying";
         const identify = {
             token: this.#token,
@@ -406,6 +423,10 @@ class Shard extends EventEmitter {
                     this.heartbeatInterval = setInterval(() => this.heartbeat(true), packet.d.heartbeat_interval);
                 }
 
+                /**
+                 * Debug trace of Discord servers
+                 * @type {Array<String>?}
+                 */
                 this.discordServerTrace = packet.d._trace;
                 this.connecting = false;
                 if(this.connectTimeout) {
@@ -431,7 +452,15 @@ class Shard extends EventEmitter {
             }
             case GatewayOPCodes.HEARTBEAT_ACK: {
                 this.lastHeartbeatAck = true;
+                /**
+                 * Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
+                 * @type {Number}
+                 */
                 this.lastHeartbeatReceived = Date.now();
+                /**
+                 * The current latency between the shard and Discord, in milliseconds
+                 * @type {Number}
+                 */
                 this.latency = this.lastHeartbeatReceived - this.lastHeartbeatSent;
                 break;
             }

--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -2,62 +2,106 @@ const Base = require("./Base");
 
 /**
  * Represents an application command
- * @prop {String} applicationID The ID of the application that this command belongs to
- * @prop {String?} defaultMemberPermissions The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
- * @prop {String} description The description of the command (empty for user & message commands)
- * @prop {Object?} descriptionLocalizations A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
- * @prop {Boolean?} dmPermission If this command can be used in direct messages (global commands only)
- * @prop {String?} guildID The ID of the guild associated with this command (guild commands only)
- * @prop {String} id The ID of the application command
- * @prop {String} name The name of the command
- * @prop {Object?} nameLocalizations A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
- * @prop {Boolean} nsfw Whether this command is age-restricted or not
- * @prop {Object[]?} options The [options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure) associated with this command
- * @prop {Number} type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
- * @prop {String} version The id of the version of this command
+ * @extends Base
  */
 class ApplicationCommand extends Base {
+    /**
+     * The ID of the application command
+     * @override
+     * @member {Number} ApplicationCommand#id
+     */
+
     #client;
     constructor(data, client) {
         super(data.id);
         this.#client = client;
+
+
+        /**
+         * The ID of the application that this command belongs to
+         * @type {String}
+         */
         this.applicationID = data.application_id;
+        /**
+         * The name of the command
+         * @type {String}
+         */
         this.name = data.name;
+        /**
+         * The description of the command (empty for user & message commands)
+         * @type {String}
+         */
         this.description = data.description;
+        /**
+         * The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
+         * @type {Number}
+         */
         this.type = data.type;
+        /**
+         * The id of the version of this command
+         * @type {String}
+         */
         this.version = data.version;
 
         if(data.guild_id !== undefined) {
+            /**
+             * The ID of the guild associated with this command (guild commands only)
+             * @type {String?}
+             */
             this.guildID = data.guild_id;
         }
 
         if(data.name_localizations !== undefined) {
+            /**
+             * A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
+             * @type {Object<string, string>}
+             */
             this.nameLocalizations = data.name_localizations;
         }
 
         if(data.description_localizations !== undefined) {
+            /**
+             * A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
+             * @type {Object<string, string>}
+             */
             this.descriptionLocalizations = data.description_localizations;
         }
 
         if(data.options !== undefined) {
+            /**
+             * The [options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure) associated with this command
+             * @type {Object[]?}
+             */
             this.options = data.options;
         }
 
         if(data.default_member_permissions !== undefined) {
+            /**
+             * The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
+             * @type {String?}
+             */
             this.defaultMemberPermissions = data.default_member_permissions;
         }
 
         if(data.dm_permission !== undefined) {
+            /**
+             * If this command can be used in direct messages (global commands only)
+             * @type {Boolean?}
+             */
             this.dmPermission = data.dm_permission;
         }
 
         if(data.nsfw !== undefined) {
+            /**
+             * Whether this command is age-restricted or not
+             * @type {Boolean}
+             */
             this.nsfw = data.nsfw;
         }
     }
 
     /**
-     * Delete This command
+     * Delete this command
      * @returns {Promise}
      */
     delete() {
@@ -68,9 +112,9 @@ class ApplicationCommand extends Base {
     * Edit this application command
     * @arg {Object} options The properties to edit
     * @arg {String} [options.name] The command name
-    * @arg {Object} [options.nameLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
+    * @arg {Object<string, string>} [options.nameLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
     * @arg {String} [options.description] The command description (chat input commands only)
-    * @arg {Object} [options.descriptionLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
+    * @arg {Object<string, string>} [options.descriptionLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
     * @arg {Array<Object>} [options.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {String} [options.defaultMemberPermissions] The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
     * @arg {Boolean} [options.dmPermission] If this command can be used in direct messages (global commands only)

--- a/lib/structures/Attachment.js
+++ b/lib/structures/Attachment.js
@@ -4,50 +4,92 @@ const Base = require("./Base");
 
 /**
  * Represents an attachment
- * @prop {String?} contentType The content type of the attachment
- * @prop {String?} description The description of the attachment
- * @prop {Number?} durationSecs The duration of the audio file (voice messages only)
- * @prop {Boolean?} ephemeral Whether the attachment is ephemeral
- * @prop {String} filename The filename of the attachment
- * @prop {Number?} flags Attachment flags. See [Discord's documentation](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-flags) for a list of them
- * @prop {Number?} height The height of the attachment
- * @prop {String} id The attachment ID
- * @prop {String} proxyURL The proxy URL of the attachment
- * @prop {Number} size The size of the attachment
- * @prop {String} url The URL of the attachment
- * @prop {String?} waveform A Base64-encoded byte array representing the sampled waveform of the audio file (voice messages only)
- * @prop {Number?} width The width of the attachment
+ * @extends Base
  */
 class Attachment extends Base {
+    /**
+     * The attachment ID
+     * @override
+     * @member {Number} Attachment#id
+     */
+
     constructor(data) {
         super(data.id);
 
+        /**
+         * The filename of the attachment
+         * @type {String}
+         */
         this.filename = data.filename;
+        /**
+         * The size of the attachment
+         * @type {Number}
+         */
         this.size = data.size;
+        /**
+         * The URL of the attachment
+         * @type {String}
+         */
         this.url = data.url;
+        /**
+         * The proxy URL of the attachment
+         * @type {String}
+         */
         this.proxyURL = data.proxy_url;
+        /**
+         * The duration of the audio file (voice messages only)
+         * @type {Number?}
+         */
         this.durationSecs = data.duration_secs;
+        /**
+         * A Base64-encoded byte array representing the sampled waveform of the audio file (voice messages only)
+         * @type {String?}
+         */
         this.waveform = data.waveform;
         this.update(data);
     }
 
     update(data) {
         if(data.description !== undefined) {
+            /**
+             * The description of the attachment
+             * @type {String?}
+             */
             this.description = data.description;
         }
         if(data.content_type !== undefined) {
+            /**
+             * The content type of the attachment
+             * @type {String?}
+             */
             this.contentType = data.content_type;
         }
         if(data.height !== undefined) {
+            /**
+             * The height of the attachment
+             * @type {Number?}
+             */
             this.height = data.height;
         }
         if(data.width !== undefined) {
+            /**
+             * The width of the attachment
+             * @type {Number?}
+             */
             this.width = data.width;
         }
         if(data.ephemeral !== undefined) {
+            /**
+             * Whether the attachment is ephemeral
+             * @type {Boolean?}
+             */
             this.ephemeral = data.ephemeral;
         }
         if(data.flags !== undefined) {
+            /**
+             * Attachment flags. See [Discord's documentation](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-flags) for a list of them
+             * @type {Number?}
+             */
             this.flags = data.flags;
         }
     }

--- a/lib/structures/AutoModerationRule.js
+++ b/lib/structures/AutoModerationRule.js
@@ -4,37 +4,69 @@ const Base = require("./Base");
 
 /**
  * Represents an auto moderation rule
- * @prop {Array<Object>} actions An array of [auto moderation action objects](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object)
- * @prop {String} creatorID The ID of the user who created this auto moderation rule
- * @prop {Boolean} enabled Whether this auto moderation rule is enabled or not
- * @prop {Number} eventType The rule [event type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types)
- * @prop {Array<String>} exemptRoles An array of role IDs exempt from this rule
- * @prop {Array<String>} exemptChannels An array of channel IDs exempt from this rule
- * @prop {String} guildID The ID of the guild which this rule belongs to
- * @prop {String} id The ID of the auto moderation rule
- * @prop {String} name The name of the rule
- * @prop {Object} triggerMetadata The [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata) tied with this rule
- * @prop {Number} triggerType The rule [trigger type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types)
  */
 class AutoModerationRule extends Base {
+    /**
+     * The ID of the auto moderation rule
+     * @member {String} AutoModerationRule#id
+     */
     #client;
     constructor(data, client) {
         super(data.id);
         this.#client = client;
 
+        /**
+         * An array of [auto moderation action objects](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object)
+         * @type {Array<Object>}
+         */
         this.actions = data.actions.map((action) => ({
             type: action.type,
             metadata: action.metadata
         }));
-
+        /**
+         * The ID of the user who created this auto moderation rule
+         * @type {String}
+         */
         this.creatorID = data.creator_id;
+        /**
+         * Whether this auto moderation rule is enabled or not
+         * @type {Boolean}
+         */
         this.enabled = data.enabled;
+        /**
+         * The rule [event type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types)
+         * @type {Number}
+         */
         this.eventType = data.event_type;
+        /**
+         * An array of role IDs exempt from this rule
+         * @type {Array<String>}
+         */
         this.exemptRoles = data.exempt_roles;
+        /**
+         * An array of channel IDs exempt from this rule
+         * @type {Array<String>}
+         */
         this.exemptChannels = data.exempt_channels;
+        /**
+         * The ID of the guild which this rule belongs to
+         * @type {String}
+         */
         this.guildID = data.guild_id;
+        /**
+         * The name of the rule
+         * @type {String}
+         */
         this.name = data.name;
+        /**
+         * The [metadata](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata) tied with this rule
+         * @type {Object}
+         */
         this.triggerMetadata = data.trigger_metadata;
+        /**
+         * The rule [trigger type](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types)
+         * @type {Number}
+         */
         this.triggerType = data.trigger_type;
     }
 

--- a/lib/structures/AutocompleteInteraction.js
+++ b/lib/structures/AutocompleteInteraction.js
@@ -6,21 +6,17 @@ const {InteractionResponseTypes} = require("../Constants");
 /**
 * Represents an application command autocomplete interaction. See Interaction for more properties.
 * @extends Interaction
-* @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
-* @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached
-* @prop {Object} data The data attached to the interaction
-* @prop {String} data.id The ID of the Application Command
-* @prop {String} data.name The command name
-* @prop {Number} data.type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
-* @prop {String?} data.target_id The id the of user or message targetted by a context menu command
-* @prop {Array<Object>?} data.options The run Application Command options
-* @prop {String} data.options[].name The name of the Application Command option
-* @prop {Number} data.options[].type The [option type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type)
-* @prop {(String | Number | Boolean)?} data.options[].value The option value (Mutually exclusive with options)
-* @prop {Boolean?} data.options[].focused If the option is focused
-* @prop {Array<Object>?} data.options[].options Sub-options (Mutually exclusive with value, subcommand/subcommandgroup)
 */
 class AutocompleteInteraction extends Interaction {
+    /**
+     * @override
+     * @member {!(PrivateChannel | TextChannel | NewsChannel)} AutocompleteInteraction#channel
+     */
+    /**
+     * The data attached to the interaction
+     * @override
+     * @member {AutocompleteInteraction.InteractionData} AutocompleteInteraction#data
+     */
     #client;
     constructor(data, client) {
         super(data, client);
@@ -59,3 +55,23 @@ class AutocompleteInteraction extends Interaction {
 }
 
 module.exports = AutocompleteInteraction;
+
+/**
+ * The data attached to the interaction
+ * @typedef AutocompleteInteraction.InteractionData
+ * @prop {String} id The ID of the Application Command
+ * @prop {String} name The command name
+ * @prop {Number} type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
+ * @prop {String?} target_id The id the of user or message targetted by a context menu command
+ * @prop {Array<AutocompleteInteraction.CommandOptions>?} options The run Application Command options
+ */
+
+/**
+ * The run Application Command options
+ * @typedef AutocompleteInteraction.CommandOptions
+ * @prop {String} name The name of the Application Command option
+ * @prop {Number} type The [option type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type)
+ * @prop {(String | Number | Boolean)?} value The option value (Mutually exclusive with options)
+ * @prop {Boolean?} focused If the option is focused
+ * @prop {Array<Object>?} options Sub-options (Mutually exclusive with value, subcommand/subcommandgroup)
+ */

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -4,16 +4,22 @@ const util = require("node:util");
 
 /**
  * Provides utilities for working with many Discord structures
- * @prop {string} id A Discord snowflake identifying the object
- * @prop {Number} createdAt Timestamp of structure creation
  */
 class Base {
     constructor(id) {
         if(id) {
+            /**
+             * A Discord snowflake identifying the object
+             * @type {String}
+             */
             this.id = id;
         }
     }
 
+    /**
+     * Timestamp of structure creation
+     * @type {Number}
+     */
     get createdAt() {
         return Base.getCreatedAt(this.id);
     }

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -7,9 +7,6 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 /**
 * Represents a guild category channel. See GuildChannel for more properties and methods.
 * @extends GuildChannel
-* @prop {Collection<GuildChannel>} channels A collection of guild channels that are part of this category
-* @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
-* @prop {Number} position The position of the channel
 */
 class CategoryChannel extends GuildChannel {
     constructor(data, client) {
@@ -19,16 +16,28 @@ class CategoryChannel extends GuildChannel {
     update(data, client) {
         super.update(data, client);
         if(data.permission_overwrites) {
+            /**
+             * Collection of PermissionOverwrites in this channel
+             * @type {Collection<PermissionOverwrite>}
+             */
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.position !== undefined) {
+            /**
+             * The position of the channel
+             * @type {Number}
+             */
             this.position = data.position;
         }
     }
 
+    /**
+     * A collection of guild channels that are part of this category
+     * @type {Collection<GuildChannel>}
+     */
     get channels() {
         const channels = new Collection(GuildChannel);
         if(this.guild?.channels) {

--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -6,25 +6,42 @@ const emitDeprecation = require("../util/emitDeprecation");
 
 /**
 * Represents a channel. You also probably want to look at CategoryChannel, NewsChannel, PrivateChannel, TextChannel, and TextVoiceChannel.
-* @prop {Client} client [DEPRECATED] The client that initialized the channel
-* @prop {Number} createdAt Timestamp of the channel's creation
-* @prop {String} id The ID of the channel
-* @prop {String} mention A string that mentions the channel
-* @prop {Number} type The type of the channel
 */
 class Channel extends Base {
+    /**
+     * The ID of the channel
+     * @member {String} Channel#id
+     */
+
+    /**
+     * Timestamp of the channel's creation
+     * @member {Number} Channel#createdAt
+     */
     #client;
     constructor(data, client) {
         super(data.id);
         this.#client = client;
+        /**
+         * The type of the channel
+         * @type {Number}
+         */
         this.type = data.type;
     }
 
+    /**
+     * The client that initialized the channel
+     * @deprecated Accessing the client reference via Channel#client is deprecated and is going to be removed in the next release. Please use your own client reference instead.
+     * @type {Client}
+     */
     get client() {
         emitDeprecation("CHANNEL_CLIENT");
         return this.#client;
     }
 
+    /**
+     * A string that mentions the channel
+     * @type {String}
+     */
     get mention() {
         return `<#${this.id}>`;
     }

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -12,28 +12,19 @@ const Collection = require("../util/Collection");
 const {InteractionResponseTypes} = require("../Constants");
 
 /**
-* Represents an application command interaction. See Interaction for more properties.
+* Represents an application command interaction.
 * @extends Interaction
-* @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
-* @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached
-* @prop {Object} data The data attached to the interaction
-* @prop {String} data.id The ID of the Application Command
-* @prop {String} data.name The command name
-* @prop {Number} data.type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
-* @prop {String?} data.target_id The id the of user or message targetted by a context menu command
-* @prop {Array<Object>?} data.options The run Application Command options
-* @prop {String} data.options[].name The name of the Application Command option
-* @prop {Number} data.options[].type The [option type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type)
-* @prop {(String | Number | Boolean)?} data.options[].value The option value (Mutually exclusive with options)
-* @prop {Array<Object>?} data.options[].options Sub-options (Mutually exclusive with value, subcommand/subcommandgroup)
-* @prop {Object?} data.resolved resolved objects within the interaction (e.x. the user for a user option)
-* @prop {Collection<Channel>?} data.resolved.channels resolved channels
-* @prop {Collection<Member>?} data.resolved.members resolved members
-* @prop {Collection<Message>?} data.resolved.messages resolved messages
-* @prop {Collection<Role>?} data.resolved.roles resolved roles
-* @prop {Collection<User>?} data.resolved.users resolved users
 */
 class CommandInteraction extends Interaction {
+    /**
+     * @override
+     * @member {!(PrivateChannel | TextChannel | NewsChannel)} CommandInteraction#channel
+     */
+    /**
+     * The data attached to the interaction
+     * @override
+     * @member {CommandInteraction.InteractionData} CommandInteraction#data
+     */
     #client;
     constructor(data, client) {
         super(data, client);
@@ -327,3 +318,33 @@ class CommandInteraction extends Interaction {
 }
 
 module.exports = CommandInteraction;
+
+/**
+ * The data attached to the interaction
+ * @typedef CommandInteraction.InteractionData
+ * @prop {String} id The ID of the Application Command
+ * @prop {String} name The command name
+ * @prop {Number} type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
+ * @prop {String?} target_id The id the of user or message targetted by a context menu command
+ * @prop {CommandInteraction.ResolvedData?} resolved Resolved objects within the interaction (e.x. the user for a user option)
+ * @prop {Array<CommandInteraction.CommandOptions>?} options The run Application Command options
+ */
+
+/**
+ * The run Application Command options
+ * @typedef CommandInteraction.CommandOptions
+ * @prop {String} name The name of the Application Command option
+ * @prop {Number} type The [option type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type)
+ * @prop {(String | Number | Boolean)?} value The option value (Mutually exclusive with options)
+ * @prop {Array<Object>?} options Sub-options (Mutually exclusive with value, subcommand/subcommandgroup)
+ */
+
+/**
+ * Resolved objects within the interaction (e.x. the user for a user option)
+ * @typedef CommandInteraction.ResolvedData
+ * @prop {Collection<Channel>?} channels Resolved channels
+ * @prop {Collection<Member>?} members Resolved members
+ * @prop {Collection<Message>?} messages Resolved messages
+ * @prop {Collection<Role>?} roles Resolved roles
+ * @prop {Collection<User>?} users Resolved users
+ */

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -11,25 +11,19 @@ const Collection = require("../util/Collection");
 const {InteractionResponseTypes} = require("../Constants");
 
 /**
-* Represents a message component interaction. See Interaction for more properties
+* Represents a message component interaction.
 * @extends Interaction
-* @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
-* @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached
-* @prop {Object} data The data attached to the interaction
-* @prop {Number} data.component_type The type of Message Component
-* @prop {String} data.custom_id The ID of the Message Component
-* @prop {Object?} data.resolved resolved objects within the interaction (e.x. the user for a user option) (select menus only)
-* @prop {Collection<Channel>?} data.resolved.channels resolved channels
-* @prop {Collection<Member>?} data.resolved.members resolved members
-* @prop {Collection<Role>?} data.resolved.roles resolved roles
-* @prop {Collection<User>?} data.resolved.users resolved users
-* @prop {Array<String>?} data.values The value of the run selected options (Select Menus Only)
-* @prop {String?} guildID The ID of the guild in which the interaction was created
-* @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
-* @prop {Message?} message The message the interaction came from
-* @prop {User?} user The user who triggered the interaction (This is only sent when the interaction is invoked within a dm)
 */
 class ComponentInteraction extends Interaction {
+    /**
+     * @override
+     * @member {!(PrivateChannel | TextChannel | NewsChannel)} ComponentInteraction#channel
+     */
+    /**
+     * The data attached to the interaction
+     * @override
+     * @member {ComponentInteraction.InteractionData} ComponentInteraction#data
+     */
     #client;
     constructor(data, client) {
         super(data, client);
@@ -78,6 +72,10 @@ class ComponentInteraction extends Interaction {
         }
 
         if(data.message !== undefined) {
+            /**
+             * The message the interaction came from
+             * @type {Message?}
+             */
             this.message = new Message(data.message, this.#client);
         }
     }
@@ -371,3 +369,21 @@ class ComponentInteraction extends Interaction {
 }
 
 module.exports = ComponentInteraction;
+
+/**
+ * The data attached to the interaction
+ * @typedef ComponentInteraction.InteractionData
+ * @prop {Number} component_type The type of Message Component
+ * @prop {String} custom_id The ID of the Message Component
+ * @prop {Array<String>?} values The value of the run selected options (Select Menus Only)
+ * @prop {ComponentInteraction.ResolvedData?} resolved Resolved objects within the interaction (e.x. the user for a user option)
+ */
+
+/**
+ * Resolved objects within the interaction (e.x. the user for a user option)
+ * @typedef CommandInteraction.ResolvedData
+ * @prop {Collection<Channel>?} channels Resolved channels
+ * @prop {Collection<Member>?} members Resolved members
+ * @prop {Collection<Role>?} roles Resolved roles
+ * @prop {Collection<User>?} users Resolved users
+ */

--- a/lib/structures/ExtendedUser.js
+++ b/lib/structures/ExtendedUser.js
@@ -5,10 +5,6 @@ const User = require("./User");
 /**
 * Represents an extended user
 * @extends User
-* @prop {String?} email The email of the user
-* @prop {Boolean?} mfaEnabled Whether the user has enabled two-factor authentication
-* @prop {Number?} premiumType The type of Nitro subscription on the user's account
-* @prop {Boolean?} verified Whether the account email has been verified
 */
 class ExtendedUser extends User {
     constructor(data, client) {
@@ -18,15 +14,31 @@ class ExtendedUser extends User {
     update(data) {
         super.update(data);
         if(data.email !== undefined) {
+            /**
+             * The email of the user
+             * @type {String?}
+             */
             this.email = data.email;
         }
         if(data.verified !== undefined) {
+            /**
+             * Whether the account email has been verified
+             * @type {Boolean?}
+             */
             this.verified = data.verified;
         }
         if(data.mfa_enabled !== undefined) {
+            /**
+             * Whether the user has enabled two-factor authentication
+             * @type {Boolean?}
+             */
             this.mfaEnabled = data.mfa_enabled;
         }
         if(data.premium_type !== undefined) {
+            /**
+             * The type of Nitro subscription on the user's account
+             * @type {Number?}
+             */
             this.premiumType = data.premium_type;
         }
     }

--- a/lib/structures/ForumChannel.js
+++ b/lib/structures/ForumChannel.js
@@ -5,35 +5,38 @@ const GuildChannel = require("./GuildChannel");
 const PermissionOverwrite = require("./PermissionOverwrite");
 
 /**
-* Represents a guild forum channel. See GuildChannel for more properties and methods.
+* Represents a guild forum channel.
 * @extends GuildChannel
-* @prop {Array<Object>} availableTags Available tags for this channel
-* @prop {Number} defaultAutoArchiveDuration The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080)
-* @prop {Number} defaultForumLayout The default forum layout view used to display forum posts
-* @prop {Object | null} defaultReactionEmoji The emoji to show as the reaction button
-* @prop {Number | null} defaultSortOrder The default thread sorting order. Defaults to `null`, which indicates no preference.
-* @prop {Number} defaultThreadRateLimitPerUser The initial ratelimit of the channel to use on newly created threads, in seconds. 0 means no ratelimit is enabled
-* @prop {String} lastThreadID The ID of the last thread in this channel
-* @prop {Boolean} nsfw Whether the channel is an NSFW channel or not
-* @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
-* @prop {Number} position The position of the channel
-* @prop {Number} rateLimitPerUser The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
-* @prop {String?} topic The topic of the channel, shown to the user as post guidelines
 */
 class ForumChannel extends GuildChannel {
     #client;
     constructor(data, client) {
         super(data, client);
         this.#client = client;
-        this.availableTags = data.available_tags || [];
+        /**
+         * The initial ratelimit of the channel to use on newly created threads, in seconds. 0 means no ratelimit is enabled
+         * @type {Number}
+         */
         this.defaultThreadRateLimitPerUser = data.default_thread_rate_limit_per_user == null ? null : data.default_thread_rate_limit_per_user;
+        /**
+         * The ID of the last thread in this channel
+         * @type {String?}
+         */
         this.lastThreadID = data.last_message_id || null;
+        /**
+         * The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
+         * @type {Number}
+         */
         this.rateLimitPerUser = data.rate_limit_per_user == null ? null : data.rate_limit_per_user;
     }
 
     update(data, client) {
         super.update(data, client);
         if(data.available_tags !== undefined) {
+            /**
+             * Available tags for this channel
+             * @type {Array<Object>}
+             */
             this.availableTags = data.available_tags.map((tag) => ({
                 id: tag.id,
                 name: tag.name,
@@ -43,39 +46,71 @@ class ForumChannel extends GuildChannel {
             }));
         }
         if(data.default_auto_archive_duration !== undefined) {
+            /**
+             * The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080)
+             * @type {Number}
+             */
             this.defaultAutoArchiveDuration = data.default_auto_archive_duration;
         }
         if(data.default_thread_rate_limit_per_user !== undefined) {
             this.defaultThreadRateLimitPerUser = data.default_thread_rate_limit_per_user;
         }
         if(data.default_forum_layout !== undefined) {
+            /**
+             * The default forum layout view used to display forum posts
+             * @type {Number}
+             */
             this.defaultForumLayout = data.default_forum_layout;
         }
         if(data.default_reaction_emoji !== undefined) {
+            /**
+             * The emoji to show as the reaction button
+             * @type {Object | null}
+             */
             this.defaultReactionEmoji = data.default_reaction_emoji && {
                 emojiID: data.default_reaction_emoji.emoji_id,
                 emojiName: data.default_reaction_emoji.emoji_name
             };
         }
         if(data.default_sort_order !== undefined) {
+            /**
+             * The default thread sorting order. Defaults to `null`, which indicates no preference.
+             * @type {Number | null}
+             */
             this.defaultSortOrder = data.default_sort_order;
         }
         if(data.rate_limit_per_user !== undefined) {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
         if(data.topic !== undefined) {
+            /**
+             * The topic of the channel, shown to the user as post guidelines
+             * @type {String?}
+             */
             this.topic = data.topic;
         }
         if(data.permission_overwrites) {
+            /**
+             * Collection of PermissionOverwrites in this channel
+             * @type {Collection<PermissionOverwrite>}
+             */
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.position !== undefined) {
+            /**
+             * The position of the channel
+             * @type {Number}
+             */
             this.position = data.position;
         }
         if(data.nsfw !== undefined) {
+            /**
+             * Whether the channel is an NSFW channel or not
+             * @type {Boolean}
+             */
             this.nsfw = data.nsfw;
         }
     }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -16,92 +16,112 @@ const ThreadChannel = require("./ThreadChannel");
 
 /**
 * Represents a guild
-* @prop {String?} afkChannelID The ID of the AFK voice channel
-* @prop {Number} afkTimeout The AFK timeout in seconds
-* @prop {String?} applicationID The application ID of the guild creator if it is bot-created
-* @prop {Number?} approximateMemberCount The approximate number of members in the guild (REST only)
-* @prop {Number?} approximatePresenceCount The approximate number of presences in the guild (REST only)
-* @prop {String?} banner The hash of the guild banner image, or null if no banner (VIP only)
-* @prop {String?} bannerURL The URL of the guild's banner image
-* @prop {Collection<GuildChannel>} channels Collection of Channels in the guild
-* @prop {Number} createdAt Timestamp of the guild's creation
-* @prop {Number} defaultNotifications The default notification settings for the guild. 0 is "All Messages", 1 is "Only @mentions"
-* @prop {String?} description The description for the guild (VIP only)
-* @prop {String?} discoverySplash The has of the guild discovery splash image, or null if no discovery splash
-* @prop {String?} discoverySplashURL The URL of the guild's discovery splash image
-* @prop {Array<Object>} emojis An array of guild emoji objects
-* @prop {Number} explicitContentFilter The explicit content filter level for the guild. 0 is off, 1 is on for people without roles, 2 is on for all
-* @prop {Array<String>} features An array of guild feature strings
-* @prop {String?} icon The hash of the guild icon, or null if no icon
-* @prop {String?} iconURL The URL of the guild's icon
-* @prop {String} id The ID of the guild
-* @prop {Number} joinedAt Timestamp of when the bot account joined the guild
-* @prop {Boolean} large Whether the guild is "large" by "some Discord standard"
-* @prop {Number?} maxMembers The maximum amount of members for the guild
-* @prop {Number} maxPresences The maximum number of people that can be online in a guild at once (returned from REST API only)
-* @prop {Number?} maxStageVideoChannelUsers The max number of users allowed in a stage video channel
-* @prop {Number?} maxVideoChannelUsers The max number of users allowed in a video channel
-* @prop {Number} memberCount Number of members in the guild
-* @prop {Number} mfaLevel The admin 2FA level for the guild. 0 is not required, 1 is required
-* @prop {Collection<Member>} members Collection of Members in the guild
-* @prop {String} name The name of the guild
-* @prop {Number} nsfwLevel The guild NSFW level designated by Discord
-* @prop {String} ownerID The ID of the user that is the guild owner
-* @prop {String} preferredLocale Preferred "COMMUNITY" guild language used in server discovery and notices from Discord, and sent in interactions
-* @prop {Boolean} premiumProgressBarEnabled If the boost progress bar is enabled
-* @prop {Number?} premiumSubscriptionCount The total number of users currently boosting this guild
-* @prop {Number} premiumTier Nitro boost level of the guild
-* @prop {String?} publicUpdatesChannelID ID of the guild's updates channel if the guild has "COMMUNITY" features
-* @prop {Collection<Role>} roles Collection of Roles in the guild
-* @prop {String?} rulesChannelID The channel where "COMMUNITY" guilds display rules and/or guidelines
-* @prop {String?} safetyAlertsChannelID The ID of the channel where safety alerts from Discord are received
-* @prop {Shard} shard The Shard that owns the guild
-* @prop {String?} splash The hash of the guild splash image, or null if no splash (VIP only)
-* @prop {String?} splashURL The URL of the guild's splash image
-* @prop {Collection<StageInstance>} stageInstances Collection of stage instances in the guild
-* @prop {Array<Object>?} stickers An array of guild sticker objects
-* @prop {Number} systemChannelFlags The flags for the system channel
-* @prop {String?} systemChannelID The ID of the default channel for system messages (built-in join messages and boost messages)
-* @prop {Collection<ThreadChannel>} threads Collection of threads that the current user has permission to view
-* @prop {Boolean} unavailable Whether the guild is unavailable or not
-* @prop {String?} vanityURL The vanity URL of the guild (VIP only)
-* @prop {Number} verificationLevel The guild verification level
-* @prop {Collection<VoiceState>} voiceStates Collection of voice states in the guild
-* @prop {Object?} welcomeScreen The welcome screen of a Community guild, shown to new members
-* @prop {Object} welcomeScreen.description The description in the welcome screen
-* @prop {Array<Object>} welcomeScreen.welcomeChannels The list of channels in the welcome screens. Each channels have the following properties: `channelID`, `description`, `emojiID`, `emojiName`. `emojiID` and `emojiName` properties can be null.
-* @prop {Number?} widgetChannelID The channel id that the widget will generate an invite to. REST only.
-* @prop {Boolean?} widgetEnabled Whether the guild widget is enabled. REST only.
+* @extends Base
 */
 class Guild extends Base {
     #client;
+    /**
+     * Collection of Channels in the guild
+     * @type {Collection<GuildChannel>}
+     */
+    channels = new Collection(GuildChannel);
+    /**
+     * A collection of scheduled events in the guild
+     * @type {Collection<GuildScheduledEvent>}
+     */
+    events = new Collection(GuildScheduledEvent);
+    /**
+     * Collection of Members in the guild
+     * @type {Collection<Member>}
+     */
+    members = new Collection(Member);
+    /**
+     * Collection of Roles in the guild
+     * @type {Collection<Role>}
+     */
+    roles = new Collection(Role);
+    /**
+     * Collection of stage instances in the guild
+     * @type {Collection<StageInstance>}
+     */
+    stageInstances = new Collection(StageInstance);
+    /**
+     * Collection of threads that the current user has permission to view
+     * @type {Collection<ThreadChannel>}
+     */
+    threads = new Collection(ThreadChannel);
+    /**
+     * Collection of voice states in the guild
+     * @type {Collection<VoiceState>}
+     */
+    voiceStates = new Collection(VoiceState);
+
+    /**
+     * Timestamp of the guild's creation
+     * @member {Number} Guild#createdAt
+     */
+    /**
+     * The ID of the guild
+     * @member {String} Guild#id
+     */
+
     constructor(data, client) {
         super(data.id);
         this.#client = client;
+        /**
+         * The Shard that owns the guild
+         * @type {Shard}
+         */
         this.shard = client.shards.get(client.guildShardMap[this.id] || (Base.getDiscordEpoch(data.id) % client.shards.options.maxShards) || 0);
+        /**
+         * Whether the guild is unavailable or not
+         * @type {Boolean}
+         */
         this.unavailable = !!data.unavailable;
+        /**
+         * Timestamp of when the bot account joined the guild
+         * @type {Number}
+         */
         this.joinedAt = Date.parse(data.joined_at);
-        this.voiceStates = new Collection(VoiceState);
-        this.channels = new Collection(GuildChannel);
-        this.threads = new Collection(ThreadChannel);
-        this.members = new Collection(Member);
-        this.events = new Collection(GuildScheduledEvent);
-        this.stageInstances = new Collection(StageInstance);
+
+        /**
+         * Number of members in the guild
+         * @type {Number}
+         */
         this.memberCount = data.member_count;
-        this.roles = new Collection(Role);
+        /**
+         * The application ID of the guild creator if it is bot-created
+         * @type {String?}
+         */
         this.applicationID = data.application_id;
 
         if(data.widget_enabled !== undefined) {
+            /**
+             * Whether the guild widget is enabled. REST only.
+             * @type {Boolean?}
+             */
             this.widgetEnabled = data.widget_enabled;
         }
         if(data.widget_channel_id !== undefined) {
+            /**
+             * The channel ID that the widget will generate an invite to. REST only.
+             * @type {String?}
+             */
             this.widgetChannelID = data.widget_channel_id;
         }
 
         if(data.approximate_member_count !== undefined) {
+            /**
+             * The approximate number of members in the guild (REST only)
+             * @type {Number?}
+             */
             this.approximateMemberCount = data.approximate_member_count;
         }
         if(data.approximate_presence_count !== undefined) {
+            /**
+             * The approximate number of presences in the guild (REST only)
+             * @type {Number?}
+             */
             this.approximatePresenceCount = data.approximate_presence_count;
         }
 
@@ -190,96 +210,220 @@ class Guild extends Base {
 
     update(data) {
         if(data.name !== undefined) {
+            /**
+             * The name of the guild
+             * @type {String}
+             */
             this.name = data.name;
         }
         if(data.verification_level !== undefined) {
+            /**
+             * The guild verification level
+             * @type {Number}
+             */
             this.verificationLevel = data.verification_level;
         }
         if(data.splash !== undefined) {
+            /**
+             * The hash of the guild splash image, or null if no splash (VIP only)
+             * @type {String?}
+             */
             this.splash = data.splash;
         }
         if(data.discovery_splash !== undefined) {
+            /**
+             * The hash of the guild discovery splash image, or null if no discovery splash
+             * @type {String?}
+             */
             this.discoverySplash = data.discovery_splash;
         }
         if(data.banner !== undefined) {
+            /**
+             * The hash of the guild banner image, or null if no banner (VIP only)
+             * @type {String?}
+             */
             this.banner = data.banner;
         }
         if(data.owner_id !== undefined) {
+            /**
+             * The ID of the user that is the guild owner
+             * @type {String}
+             */
             this.ownerID = data.owner_id;
         }
         if(data.icon !== undefined) {
+            /**
+             * The hash of the guild icon, or null if no icon
+             * @type {String?}
+             */
             this.icon = data.icon;
         }
         if(data.features !== undefined) {
+            /**
+             * An array of guild feature strings
+             * @type {Array<String>}
+             */
             this.features = data.features;
         }
         if(data.emojis !== undefined) {
+            /**
+             * An array of guild emoji objects
+             * @type {Array<Object>}
+             */
             this.emojis = data.emojis;
         }
         if(data.stickers !== undefined) {
+            /**
+             * An array of guild sticker objects
+             * @type {Array<Object>?}
+             */
             this.stickers = data.stickers;
         }
         if(data.afk_channel_id !== undefined) {
+            /**
+             * The ID of the AFK voice channel
+             * @type {String?}
+             */
             this.afkChannelID = data.afk_channel_id;
         }
         if(data.afk_timeout !== undefined) {
+            /**
+             * The AFK timeout in seconds
+             * @type {Number}
+             */
             this.afkTimeout = data.afk_timeout;
         }
         if(data.default_message_notifications !== undefined) {
+            /**
+             * The default notification settings for the guild. 0 is "All Messages", 1 is "Only @mentions"
+             * @type {Number}
+             */
             this.defaultNotifications = data.default_message_notifications;
         }
         if(data.mfa_level !== undefined) {
+            /**
+             * The admin 2FA level for the guild. 0 is not required, 1 is required
+             * @type {Number}
+             */
             this.mfaLevel = data.mfa_level;
         }
         if(data.large !== undefined) {
+            /**
+             * Whether the guild's member count is over the large guild threshold
+             * @type {Boolean}
+             */
             this.large = data.large;
         }
         if(data.max_presences !== undefined) {
+            /**
+             * The maximum number of people that can be online in a guild at once (returned from REST API only)
+             * @type {Number?}
+             */
             this.maxPresences = data.max_presences;
         }
         if(data.explicit_content_filter !== undefined) {
+            /**
+             * The explicit content filter level for the guild. 0 is off, 1 is on for people without roles, 2 is on for all
+             * @type {Number}
+             */
             this.explicitContentFilter = data.explicit_content_filter;
         }
         if(data.system_channel_id !== undefined) {
+            /**
+             * The ID of the default channel for system messages (built-in join messages and boost messages)
+             * @type {String?}
+             */
             this.systemChannelID = data.system_channel_id;
         }
         if(data.system_channel_flags !== undefined) {
+            /**
+             * The flags for the system channel
+             * @type {Number}
+             */
             this.systemChannelFlags = data.system_channel_flags;
         }
         if(data.premium_progress_bar_enabled !== undefined) {
+            /**
+             * If the boost progress bar is enabled
+             * @type {Boolean}
+             */
             this.premiumProgressBarEnabled = data.premium_progress_bar_enabled;
         }
         if(data.premium_tier !== undefined) {
+            /**
+             * Nitro boost level of the guild
+             * @type {Number}
+             */
             this.premiumTier = data.premium_tier;
         }
         if(data.premium_subscription_count !== undefined) {
+            /**
+             * The total number of users currently boosting this guild
+             * @type {Number?}
+             */
             this.premiumSubscriptionCount = data.premium_subscription_count;
         }
         if(data.vanity_url_code !== undefined) {
+            /**
+             * The vanity URL of the guild (VIP only)
+             * @type {String?}
+             */
             this.vanityURL = data.vanity_url_code;
         }
         if(data.preferred_locale !== undefined) {
+            /**
+             * Preferred "COMMUNITY" guild language used in server discovery and notices from Discord, and sent in interactions
+             * @type {String}
+             */
             this.preferredLocale = data.preferred_locale;
         }
         if(data.description !== undefined) {
+            /**
+             * The description for the guild (VIP only)
+             * @type {String?}
+             */
             this.description = data.description;
         }
         if(data.max_members !== undefined) {
+            /**
+             * The maximum amount of members for the guild
+             * @type {Number?}
+             */
             this.maxMembers = data.max_members;
         }
         if(data.public_updates_channel_id !== undefined) {
+            /**
+             * ID of the guild's updates channel if the guild has "COMMUNITY" features
+             * @type {String?}
+             */
             this.publicUpdatesChannelID = data.public_updates_channel_id;
         }
         if(data.rules_channel_id !== undefined) {
+            /**
+             * The channel where "COMMUNITY" guilds display rules and/or guidelines
+             * @type {String?}
+             */
             this.rulesChannelID = data.rules_channel_id;
         }
         if(data.max_video_channel_users !== undefined) {
+            /**
+             * The max number of users allowed in a video channel
+             * @type {Number?}
+             */
             this.maxVideoChannelUsers = data.max_video_channel_users;
         }
         if(data.max_stage_video_channel_users !== undefined) {
+            /**
+             * The max number of users allowed in a stage video channel
+             * @type {Number?}
+             */
             this.maxStageVideoChannelUsers = data.max_stage_video_channel_users;
         }
         if(data.welcome_screen !== undefined) {
+            /**
+             * The welcome screen of a Community guild, shown to new members
+             * @type {Guild.WelcomeScreen?}
+             */
             this.welcomeScreen = {
                 description: data.welcome_screen.description,
                 welcomeChannels: data.welcome_screen.welcome_channels?.map((c) => {
@@ -293,25 +437,49 @@ class Guild extends Base {
             };
         }
         if(data.nsfw_level !== undefined) {
+            /**
+             * The guild NSFW level designated by Discord
+             * @type {Number}
+             */
             this.nsfwLevel = data.nsfw_level;
         }
         if(data.safety_alerts_channel_id !== undefined) {
+            /**
+             * The ID of the channel where safety alerts from Discord are received
+             * @type {String?}
+             */
             this.safetyAlertsChannelID = data.safety_alerts_channel_id;
         }
     }
 
+    /**
+     * The URL of the guild's banner image
+     * @type {String?}
+     */
     get bannerURL() {
         return this.banner ? this.#client._formatImage(Endpoints.BANNER(this.id, this.banner)) : null;
     }
 
+    /**
+     * The URL of the guild's icon
+     * @type {String?}
+     */
     get iconURL() {
         return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon)) : null;
     }
 
+    /**
+     * The URL of the guild's splash image
+     * @type {String?}
+     */
     get splashURL() {
         return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash)) : null;
     }
 
+    /**
+     * The URL of the guild's discovery splash image
+     * @type {String?}
+     */
     get discoverySplashURL() {
         return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash)) : null;
     }
@@ -1346,3 +1514,10 @@ class Guild extends Base {
 }
 
 module.exports = Guild;
+
+/**
+ * The welcome screen of a Community guild, shown to new members
+ * @typedef Guild.WelcomeScreen
+ * @prop {String?} description The description in the welcome screen
+ * @prop {Array<Object>} welcomeChannels The list of channels in the welcome screens. Each channels have the following properties: `channelID`, `description`, `emojiID`, `emojiName`. `emojiID` and `emojiName` properties can be null.
+ */

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -6,56 +6,49 @@ const {AuditLogActions} = require("../Constants");
 
 /**
 * Represents a guild audit log entry describing a moderation action
-* @prop {Number} actionType The action type of the entry. See Constants.AuditLogActions for more details
-* @prop {Object?} after The properties of the targeted object after the action was taken
-* For example, if a channel was renamed from #general to #potato, this would be `{name: "potato"}``
-* @prop {String?} applicationID The ID of the application that was targeted
-* @prop {String?} autoModerationRuleName The name of the auto moderation rule that was triggered
-* @prop {String?} autoModerationTriggerType The trigger type of the auto moderation rule that was triggered
-* @prop {Object?} before The properties of the targeted object before the action was taken
-* For example, if a channel was renamed from #general to #potato, this would be `{name: "general"}``
-* @prop {(CategoryChannel | TextChannel | TextVoiceChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel | StageChannel)?} channel The channel targeted in the entry, action types 26 (MEMBER_MOVE), 72/74/75 (MESSAGE_DELETE/PIN/UNPIN) and 83/84/85 (STAGE_INSTANCE_CREATE/UPDATE/DELETE) only
-* @prop {Number?} count The number of entities targeted
-* For example, for action type 26 (MEMBER_MOVE), this is the number of members that were moved/disconnected from the voice channel
-* @prop {Number?} deleteMemberDays The number of days of inactivity to prune for, action type 21 (MEMBER_PRUNE) only
-* @prop {Guild} guild The guild containing the entry
-* @prop {String} id The ID of the entry
-* @prop {String?} integrationType The type of integration which performed the action, action types 20 (MEMBER\_KICK) and 25 (MEMBER\_ROLE\_UPDATE) only
-* @prop {(Member | Object)?} member The member described by the permission overwrite, action types 13-15 (CHANNEL\_OVERWRITE\_CREATE/UPDATE/DELETE) only. If the member is not cached, this could be {id: String}
-* @prop {Number?} membersRemoved The number of members pruned from the server, action type 21 (MEMBER_PRUNE) only
-* @prop {(Message | Object)?} message The message that was (un)pinned, action types 74/75 (MESSAGE_PIN/UNPIN) only. If the message is not cached, this will be an object with an `id` key. No other property is guaranteed.
-* @prop {String?} reason The reason for the action
-* @prop {(Role | Object)?} role The role described by the permission overwrite, action types 13-15 (CHANNEL\_OVERWRITE\_CREATE/UPDATE/DELETE) only. If the role is not cached, this could be {id: String, name: String}
-* @prop {(CategoryChannel | Guild | Member | Invite | Role | Object | TextChannel | TextVoiceChannel | NewsChannel | StageInstance | ThreadChannel)?} target The object of the action target
-* If the item is not cached, this property will be null
-* If the action targets a guild, this could be a Guild object
-* If the action targets a guild channel, this could be a CategoryChannel, TextChannel, or TextVoiceChannel object
-* If the action targets a member, this could be a Member object
-* If the action targets a role, this could be a Role object
-* If the action targets an invite, this is an Invite object
-* If the action targets a webhook, this is null
-* If the action targets a emoji, this could be an emoji object
-* If the action targets a sticker, this could be a sticker object
-* If the action targets a message, this is a User object
-* If the action targets an application command, this is null
-* If the action targets an auto moderation rule, this is null
-* If the action targets a stage instance, this is a StageInstance object
-* If the action targets a thread, this is a ThreadChannel object
-* If the action is an auto moderation rule execution, this is a User object
-* @prop {String} targetID The ID of the action target
-* @prop {User | Object} user The user that performed the action. If the user is not cached, this will be an object with an `id` key. No other properties are guaranteed
+* @extends Base
 */
 class GuildAuditLogEntry extends Base {
+    /**
+     * The ID of the entry
+     * @member {String} GuildAuditLogEntry#id
+     */
     constructor(data, guild) {
         super(data.id);
+        /**
+         * The guild containing the entry
+         * @prop {Guild}
+         */
         this.guild = guild;
 
+        /**
+         * The action type of the entry. See Constants.AuditLogActions for more details
+         * @type {Number}
+         */
         this.actionType = data.action_type;
+        /**
+         * The reason for the action
+         * @type {String?}
+         */
         this.reason = data.reason || null;
+        /**
+         * The user that performed the action. If the user is not cached, this will be an object with an `id` key. No other properties are guaranteed
+         * @type {User | Object}
+         */
         this.user = guild.shard.client.users.get(data.user_id) || {
             id: data.user_id
         };
+        /**
+         * The properties of the targeted object before the action was taken
+         * For example, if a channel was renamed from #general to #potato, this would be `{name: "general"}`
+         * @type {Object?}
+         */
         this.before = null;
+        /**
+         * The properties of the targeted object after the action was taken
+         * For example, if a channel was renamed from #general to #potato, this would be `{name: "potato"}`
+         * @type {Object?}
+         */
         this.after = null;
         if(data.changes) {
             this.before = {};
@@ -71,38 +64,83 @@ class GuildAuditLogEntry extends Base {
         }
 
         if(data.target_id) {
+            /**
+             * The ID of the action target
+             * @type {String?}
+             */
             this.targetID = data.target_id;
         }
         if(data.options) {
             if(data.options.application_id) {
+                /**
+                 * The ID of the application that was targeted
+                 * @type {String?}
+                 */
                 this.applicationID = data.options.application_id;
             }
             if(data.options.auto_moderation_rule_name) {
+                /**
+                 * The name of the auto moderation rule that was triggered
+                 * @type {String?}
+                 */
                 this.autoModerationRuleName = data.options.auto_moderation_rule_name;
             }
             if(data.options.auto_moderation_rule_trigger_type) {
+                /**
+                 * The trigger type of the auto moderation rule that was triggered
+                 * @type {String?}
+                 */
                 this.autoModerationRuleTriggerType = data.options.auto_moderation_rule_trigger_type;
             }
             if(data.options.count) {
+                /**
+                 * The number of entities targeted
+                 * For example, for action type 26 (MEMBER_MOVE), this is the number of members that were moved/disconnected from the voice channel
+                 * @type {Number?}
+                 */
                 this.count = +data.options.count;
             }
             if(data.options.channel_id) {
+                /**
+                 * The channel targeted in the entry, action types 26 (MEMBER_MOVE), 72/74/75 (MESSAGE_DELETE/PIN/UNPIN) and 83/84/85 (STAGE_INSTANCE_CREATE/UPDATE/DELETE) only
+                 * @type {(CategoryChannel | TextChannel | TextVoiceChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel | StageChannel)?}
+                 */
                 this.channel = guild.threads.get(data.options.channel_id) || guild.channels.get(data.options.channel_id);
 
                 if(data.options.message_id) {
+                    /**
+                     * The message that was (un)pinned, action types 74/75 (MESSAGE_PIN/UNPIN) only. If the message is not cached, this will be an object with an `id` key. No other property is guaranteed.
+                     * @type {(Message | Object)?}
+                     */
                     this.message = this.channel?.messages.get(data.options.message_id) || {id: data.options.message_id};
                 }
             }
             if(data.options.delete_member_days) {
+                /**
+                 * The number of days of inactivity to prune for, action type 21 (MEMBER_PRUNE) only
+                 * @type {Number?}
+                 */
                 this.deleteMemberDays = +data.options.delete_member_days;
+                /**
+                 * The number of members pruned from the server, action type 21 (MEMBER_PRUNE) only
+                 * @type {Number?}
+                 */
                 this.membersRemoved = +data.options.members_removed;
             }
             if(data.options.type) {
                 if(data.options.type === "1") {
+                    /**
+                     * The member described by the permission overwrite, action types 13-15 (CHANNEL\_OVERWRITE\_CREATE/UPDATE/DELETE) only. If the member is not cached, this could be {id: String}
+                     * @type {(Member | Object)?}
+                     */
                     this.member = guild.members.get(data.options.id) || {
                         id: data.options.id
                     };
                 } else if(data.options.type === "0") {
+                    /**
+                     * The role described by the permission overwrite, action types 13-15 (CHANNEL\_OVERWRITE\_CREATE/UPDATE/DELETE) only. If the role is not cached, this could be {id: String, name: String}
+                     * @type {(Role | Object)?}
+                     */
                     this.role = guild.roles.get(data.options.id) || {
                         id: data.options.id,
                         name: data.options.role_name
@@ -110,11 +148,34 @@ class GuildAuditLogEntry extends Base {
                 }
             }
             if(data.options.integration_type) {
+                /**
+                 * The type of integration which performed the action, action types 20 (MEMBER\_KICK) and 25 (MEMBER\_ROLE\_UPDATE) only
+                 * @type {String?}
+                 */
                 this.integrationType = data.options.integration_type;
             }
         }
     }
 
+    /**
+     * The object of the action target
+     * If the item is not cached, this property will be null
+     * If the action targets a guild, this could be a Guild object
+     * If the action targets a guild channel, this could be a CategoryChannel, TextChannel, or TextVoiceChannel object
+     * If the action targets a member, this could be a Member object
+     * If the action targets a role, this could be a Role object
+     * If the action targets an invite, this is an Invite object
+     * If the action targets a webhook, this is null
+     * If the action targets a emoji, this could be an emoji object
+     * If the action targets a sticker, this could be a sticker object
+     * If the action targets a message, this is a User object
+     * If the action targets an application command, this is null
+     * If the action targets an auto moderation rule, this is null
+     * If the action targets a stage instance, this is a StageInstance object
+     * If the action targets a thread, this is a ThreadChannel object
+     * If the action is an auto moderation rule execution, this is a User object
+     * @type {(CategoryChannel | Guild | Member | Invite | Role | Object | TextChannel | TextVoiceChannel | NewsChannel | StageInstance | ThreadChannel)?}
+     */
     get target() { // pay more, get less
         if(this.actionType < 10) { // Guild
             return this.guild;

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -17,7 +17,7 @@ class GuildAuditLogEntry extends Base {
         super(data.id);
         /**
          * The guild containing the entry
-         * @prop {Guild}
+         * @type {Guild}
          */
         this.guild = guild;
 

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -178,5 +178,4 @@ class GuildChannel extends Channel {
 
 module.exports = GuildChannel;
 
-const ThreadChannel = require("./ThreadChannel");const Guild = require("./Guild");
-
+const ThreadChannel = require("./ThreadChannel");

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -5,25 +5,27 @@ const Permission = require("./Permission");
 const {Permissions} = require("../Constants");
 
 /**
-* Represents a guild channel. You also probably want to look at CategoryChannel, NewsChannel, StoreChannel, TextChannel, ThreadChannel, and TextVoiceChannel. See Channel for extra properties.
+* Represents a guild channel. You also probably want to look at CategoryChannel, NewsChannel, StoreChannel, TextChannel, ThreadChannel, and TextVoiceChannel.
 * @extends Channel
-* @prop {Number?} flags The flags of this channel
-* @prop {Guild} guild The guild that owns the channel
-* @prop {String} id The ID of the channel
-* @prop {String} name The name of the channel
-* @prop {String?} parentID The ID of the category this channel belongs to or the channel ID where the thread originated from (thread channels only)
-* @prop {Permission?} permissions The permissions of the bot user in this channel (available only for channels resolved via interactions)
 */
 class GuildChannel extends Channel {
     #client;
     constructor(data, client) {
         super(data, client);
         this.#client = client;
+        /**
+         * The guild that owns the channel
+         * @type {Guild}
+         */
         this.guild = client.guilds.get(data.guild_id) || {
             id: data.guild_id
         };
 
         if(data.permissions !== undefined) {
+            /**
+             * The permissions of the bot user in this channel (available only for channels resolved via interactions)
+             * @type {Permission?}
+             */
             this.permissions = new Permission(data.permissions, 0);
         }
 
@@ -35,12 +37,24 @@ class GuildChannel extends Channel {
             this.type = data.type;
         }
         if(data.name !== undefined) {
+            /**
+             * The name of the channel
+             * @type {String}
+             */
             this.name = data.name;
         }
         if(data.parent_id !== undefined) {
+            /**
+             * The ID of the category this channel belongs to or the channel ID where the thread originated from (thread channels only)
+             * @type {String?}
+             */
             this.parentID = data.parent_id;
         }
         if(data.flags !== undefined) {
+            /**
+             * The flags of this channel
+             * @type {Number?}
+             */
             this.flags = data.flags;
         }
     }
@@ -164,4 +178,5 @@ class GuildChannel extends Channel {
 
 module.exports = GuildChannel;
 
-const ThreadChannel = require("./ThreadChannel");
+const ThreadChannel = require("./ThreadChannel");const Guild = require("./Guild");
+

--- a/lib/structures/GuildIntegration.js
+++ b/lib/structures/GuildIntegration.js
@@ -4,70 +4,123 @@ const Base = require("./Base");
 
 /**
 * Represents a guild integration
-* @prop {Object} account Info on the integration account
-* @prop {String} account.id The ID of the integration account
-* @prop {String} account.name The name of the integration account
-* @prop {Object?} application The bot/OAuth2 application for Discord integrations. See [the Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object)
-* @prop {Number} createdAt Timestamp of the guild integration's creation
-* @prop {Boolean} enabled Whether the integration is enabled or not
-* @prop {Boolean?} enableEmoticons Whether integration emoticons are enabled or not
-* @prop {Number?} expireBehavior behavior of expired subscriptions
-* @prop {Number?} expireGracePeriod grace period for expired subscriptions
-* @prop {String} id The ID of the integration
-* @prop {Guild} guild The guild this integration belongs to
-* @prop {String} name The name of the integration
-* @prop {Boolean?} revoked Whether or not the application was revoked
-* @prop {String?} roleID The ID of the role connected to the integration
-* @prop {Array<String>} scopes The scope the application is authorized for
-* @prop {Number?} subscriberCount The amount of subscribers
-* @prop {Number?} syncedAt Unix timestamp of last integration sync
-* @prop {Boolean?} syncing Whether the integration is syncing or not
-* @prop {String} type The type of the integration
-* @prop {User?} user The user connected to the integration
+* @extends Base
 */
 class GuildIntegration extends Base {
+    /**
+     * The ID of the integration
+     * @member {String} GuildIntegration#id
+     */
+    /**
+     * Timestamp of the guild integration's creation
+     * @member {Number} GuildIntegration#createdAt
+     */
     constructor(data, guild) {
         super(data.id);
+        /**
+         * The guild this integration belongs to
+         * @type {Guild}
+         */
         this.guild = guild;
+        /**
+         * The name of the integration
+         * @type {String}
+         */
         this.name = data.name;
+        /**
+         * The type of the integration
+         * @type {String}
+         */
         this.type = data.type;
         if(data.role_id !== undefined) {
+            /**
+             * The ID of the role connected to the integration
+             * @type {String?}
+             */
             this.roleID = data.role_id;
         }
         if(data.user) {
+            /**
+             * The user connected to the integration
+             * @type {User?}
+             */
             this.user = guild.shard.client.users.add(data.user, guild.shard.client);
         }
+        /**
+         * Info on the integration account
+         * @type {GuildIntegration.AccountData}
+         */
         this.account = data.account; // not worth making a class for
         this.update(data);
     }
 
     update(data) {
+        /**
+         * Whether the integration is enabled or not
+         * @type {Boolean}
+         */
         this.enabled = data.enabled;
         if(data.syncing !== undefined) {
+            /**
+             * Whether the integration is syncing or not
+             * @type {Boolean?}
+             */
             this.syncing = data.syncing;
         }
         if(data.expire_behavior !== undefined) {
+            /**
+             * The behavior of expired subscriptions
+             * @type {Number?}
+             */
             this.expireBehavior = data.expire_behavior;
         }
         if(data.expire_behavior !== undefined) {
+            /**
+             * The grace period for expired subscriptions
+             * @type {Number?}
+             */
             this.expireGracePeriod = data.expire_grace_period;
         }
         if(data.enable_emoticons !== undefined) {
+            /**
+             * Whether integration emoticons are enabled or not
+             * @type {Boolean?}
+             */
             this.enableEmoticons = data.enable_emoticons;
         }
         if(data.subscriber_count !== undefined) {
+            /**
+             * The amount of subscribers
+             * @type {Number?}
+             */
             this.subscriberCount = data.subscriber_count;
         }
         if(data.synced_at !== undefined) {
+            /**
+             * Unix timestamp of last integration sync
+             * @type {Number?}
+             */
             this.syncedAt = data.synced_at;
         }
         if(data.revoked !== undefined) {
+            /**
+             * Whether or not the application was revoked
+             * @type {Boolean?}
+             */
             this.revoked = data.revoked;
         }
         if(data.application !== undefined) {
+            /**
+             * The bot/OAuth2 application for Discord integrations. See [the Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object)
+             * @type {Object?}
+             */
             this.application = data.application;
         }
         if(data.scopes !== undefined) {
+            /**
+             * The scope the application is authorized for
+             * @type {Array<String>?}
+             */
             this.scopes = data.scopes;
         }
     }
@@ -103,3 +156,10 @@ class GuildIntegration extends Base {
 }
 
 module.exports = GuildIntegration;
+
+/**
+ * Info on the integration account
+ * @typedef GuildIntegration.AccountData
+ * @prop {String} id The ID of the integration account
+ * @prop {String} name The name of the integration account
+ */

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -6,47 +6,89 @@ const Endpoints = require("../rest/Endpoints.js");
 /**
 * Represents a GuildPreview structure
 * @extends Base
-* @prop {Number} approximateMemberCount The **approximate** number of members in the guild
-* @prop {Number} approximatePresenceCount The **approximate** number of presences in the guild
-* @prop {String?} description The description for the guild (VIP only)
-* @prop {String?} discoverySplash The hash of the guild discovery splash image, or null if no splash
-* @prop {String?} discoverySplashURL The URL of the guild's discovery splash image
-* @prop {Array<Object>} emojis An array of guild emoji objects
-* @prop {Array<String>} features An array of guild feature strings
-* @prop {String?} icon The hash of the guild icon, or null if no icon
-* @prop {String?} iconURL The URL of the guild's icon
-* @prop {String} id The ID of the guild
-* @prop {String} name The name of the guild
-* @prop {String?} splash The hash of the guild splash image, or null if no splash (VIP only)
-* @prop {String?} splashURL The URL of the guild's splash image
-* @prop {Array<Object>} stickers An array of guild sticker objects
 */
 class GuildPreview extends Base {
     #client;
+    /**
+     * The ID of the guild
+     * @member {String} GuildPreview#id
+     */
     constructor(data, client) {
         super(data.id);
         this.#client = client;
 
+        /**
+         * The name of the guild
+         * @type {String}
+         */
         this.name = data.name;
+        /**
+         * The hash of the guild icon, or null if no icon
+         * @type {String?}
+         */
         this.icon = data.icon;
+        /**
+         * The description for the guild
+         * @type {String?}
+         */
         this.description = data.description;
+        /**
+         * The hash of the guild splash image, or null if no splash (VIP only)
+         * @type {String?}
+         */
         this.splash = data.splash;
+        /**
+         * The hash of the guild discovery splash image, or null if no splash
+         * @type {String?}
+         */
         this.discoverySplash = data.discovery_splash;
+        /**
+         * An array of guild feature strings
+         * @type {Array<String>}
+         */
         this.features = data.features;
+        /**
+         * The **approximate** number of members in the guild
+         * @type {Number}
+         */
         this.approximateMemberCount = data.approximate_member_count;
+        /**
+         * The **approximate** number of presences in the guild
+         * @type {Number}
+         */
         this.approximatePresenceCount = data.approximate_presence_count;
+        /**
+         * An array of guild emoji objects
+         * @type {Array<Object>}
+         */
         this.emojis = data.emojis;
+        /**
+         * An array of guild sticker objects
+         * @type {Array<Object>}
+         */
         this.stickers = data.stickers;
     }
 
+    /**
+     * The URL of the guild's icon
+     * @type {String?}
+     */
     get iconURL() {
         return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon)) : null;
     }
 
+    /**
+     * The URL of the guild's splash image
+     * @type {String?}
+     */
     get splashURL() {
         return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash)) : null;
     }
 
+    /**
+     * The URL of the guild's discovery splash image
+     * @type {String?}
+     */
     get discoverySplashURL() {
         return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash)) : null;
     }

--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -5,38 +5,38 @@ const Endpoints = require("../rest/Endpoints");
 
 /**
 * Represents a guild scheduled event
-* @prop {(VoiceChannel | StageChannel | Object)?} channel The channel where the event will be held. This will be null if the event is external (`entityType` is `3`). Can be partial with only `id` if the channel or guild is not cached
-* @prop {User?} creator The user that created the scheduled event. For events created before October 25 2021, this will be null. Please see the relevant Discord documentation for more details
-* @prop {String?} description The description of the event
-* @prop {String?} entityID The entity ID associated to the event
-* @prop {Object?} entityMetadata Metadata for the event. This will be null if the event is not external (`entityType` is not `3`)
-* @prop {String?} entityMetadata.location Location of the event
-* @prop {Number} entityType The [entity type](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types) of the scheduled event
-* @prop {Guild | Object} guild The guild which the event belongs to. Can be partial with only `id` if not cached
-* @prop {String} id The id of the guild event
-* @prop {String?} image The hash of the event's image, or null if no image
-* @prop {String?} imageURL The URL of the event's image, or null if no image
-* @prop {String} name The name of the event
-* @prop {Number} privacyLevel Event privacy level
-* @prop {Number?} scheduledEndTime The time the event will end, or null if the event does not have a scheduled time to end
-* @prop {Number} scheduledStartTime The time the event will start
-* @prop {Number} status The [status](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status) of the scheduled event
-* @prop {Number?} userCount The number of users subscribed to the event
+* @extends Base
 */
 class GuildScheduledEvent extends Base {
+    /**
+     * The ID of the guild event
+     * @member {String} GuildScheduledEvent#id
+     */
     #client;
     constructor(data, client) {
         super(data.id);
 
         this.#client = client;
         if(data.creator !== undefined) {
+            /**
+             * The user that created the scheduled event. For events created before October 25 2021, this will be null. Please see the relevant Discord documentation for more details
+             * @type {User?}
+             */
             this.creator = client.users.update(data.creator, this.client);
         } else {
             this.creator = null;
         }
+        /**
+         * The guild which the event belongs to. Can be partial with only `id` if not cached
+         * @type {Guild | Object}
+         */
         this.guild = client.guilds.get(data.guild_id) || {
             id: data.guild_id
         };
+        /**
+         * The time the event will end, or null if the event does not have a scheduled time to end
+         * @type {Number?}
+         */
         this.scheduledEndTime = null;
         this.update(data);
     }
@@ -44,46 +44,94 @@ class GuildScheduledEvent extends Base {
     update(data) {
         if(data.channel_id !== undefined) {
             if(data.channel_id !== null) {
+                /**
+                 * The channel where the event will be held. This will be null if the event is external (`entityType` is `3`). Can be partial with only `id` if the channel or guild is not cached
+                 * @type {(VoiceChannel | StageChannel | Object)?}
+                 */
                 this.channel = this.#client.guilds.get(data.guild_id)?.channels.get(data.channel_id) || {id: data.channel_id};
             } else {
                 this.channel = null;
             }
         }
         if(data.name !== undefined) {
+            /**
+             * The name of the event
+             * @type {String}
+             */
             this.name = data.name;
         }
         if(data.description !== undefined) {
+            /**
+             * The description of the event
+             * @type {String?}
+             */
             this.description = data.description;
         }
         if(data.scheduled_start_time !== undefined) {
+            /**
+             * The time the event will start
+             * @type {Number}
+             */
             this.scheduledStartTime = Date.parse(data.scheduled_start_time);
         }
         if(data.scheduled_end_time !== undefined) {
             this.scheduledEndTime = Date.parse(data.scheduled_end_time);
         }
         if(data.privacy_level !== undefined) {
+            /**
+             * Event privacy level
+             * @type {Number}
+             */
             this.privacyLevel = data.privacy_level;
         }
         if(data.status !== undefined) {
+            /**
+             * The [status](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status) of the scheduled event
+             * @type {Number}
+             */
             this.status = data.status;
         }
         if(data.entity_type !== undefined) {
+            /**
+             * The [entity type](https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types) of the scheduled event
+             * @type {Number}
+             */
             this.entityType = data.entity_type;
         }
         if(data.entity_id !== undefined) {
+            /**
+             * The entity ID associated to the event
+             * @type {String?}
+             */
             this.entityID = data.entity_id;
         }
         if(data.entity_metadata !== undefined) {
+            /**
+             * Metadata for the event. This will be null if the event is not external (`entityType` is not `3`)
+             * @type {GuildScheduledEvent.EntityMetadata?}
+             */
             this.entityMetadata = data.entity_metadata;
         }
         if(data.user_count !== undefined) {
+            /**
+             * The number of users subscribed to the event
+             * @type {Number?}
+             */
             this.userCount = data.user_count;
         }
         if(data.image !== undefined) {
+            /**
+             * The hash of the event's image, or null if no image
+             * @type {String?}
+             */
             this.image = data.image;
         }
     }
 
+    /**
+     * The URL of the event's image, or null if no image
+     * @type {String?}
+     */
     get imageURL() {
         return this.image ? this.#client._formatImage(Endpoints.GUILD_SCHEDULED_EVENT_COVER(this.id, this.image)) : null;
     }
@@ -151,3 +199,8 @@ class GuildScheduledEvent extends Base {
 }
 
 module.exports = GuildScheduledEvent;
+
+/**
+ * @typedef GuildScheduledEvent.EntityMetadata
+ * @prop {String?} location Location of the event
+ */

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -3,30 +3,60 @@ const Guild = require("./Guild");
 
 /**
 * Represents a guild template
-* @prop {String} code The template code
-* @prop {Number} createdAt Timestamp of template creation
-* @prop {User} creator User that created the template
-* @prop {String?} description The template description
-* @prop {Boolean?} isDirty Whether the template has unsynced changes
-* @prop {String} name The template name
-* @prop {Guild} serializedSourceGuild The guild snapshot this template contains
-* @prop {Guild | Object} sourceGuild The guild this template is based on. If the guild is not cached, this will be an object with `id` key. No other property is guaranteed
-* @prop {Number} updatedAt Timestamp of template update
-* @prop {Number} usageCount Number of times this template has been used
 */
 class GuildTemplate {
     #client;
     constructor(data, client) {
         this.#client = client;
+        /**
+         * The template code
+         * @type {String}
+         */
         this.code = data.code;
+        /**
+         * Timestamp of template creation
+         * @type {Number}
+         */
         this.createdAt = Date.parse(data.created_at);
+        /**
+         * The user that created the template
+         * @type {User}
+         */
         this.creator = client.users.update(data.creator, client);
+        /**
+         * The template description
+         * @type {String?}
+         */
         this.description = data.description;
+        /**
+         * Whether the template has unsynced changes
+         * @type {Boolean?}
+         */
         this.isDirty = data.is_dirty;
+        /**
+         * The template name
+         * @type {String}
+         */
         this.name = data.name;
+        /**
+         * The guild snapshot this template contains
+         * @type {Guild}
+         */
         this.serializedSourceGuild = new Guild(data.serialized_source_guild, client);
+        /**
+         * The guild this template is based on. If the guild is not cached, this will be an object with `id` key. No other property is guaranteed
+         * @type {Guild | Object}
+         */
         this.sourceGuild = client.guilds.get(data.source_guild_id) || {id: data.source_guild_id};
+        /**
+         * Timestamp of template update
+         * @type {Number}
+         */
         this.updatedAt = Date.parse(data.updated_at);
+        /**
+         * The number of times this template has been used
+         * @type {Number}
+         */
         this.usageCount = data.usage_count;
     }
 

--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -7,48 +7,75 @@ const Permission = require("./Permission");
 
 /**
 * Represents an interaction. You also probably want to look at AutocompleteInteraction, CommandInteraction, ComponentInteraction, and ModalSubmitInteraction.
-* @prop {Boolean} acknowledged Whether or not the interaction has been acknowledged
-* @prop {String} applicationID The ID of the interaction's application
-* @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
-* @prop {(PrivateChannel | TextChannel | NewsChannel)?} channel The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached.
-* @prop {Object} data The data attached to the interaction. See AutocompleteInteraction, CommandInteraction, and ComponentInteraction for specific details
-* @prop {String?} guildID The ID of the guild in which the interaction was created
-* @prop {String?} guildLocale The selected language of the guild the command was invoked from (e.g. "en-US")
-* @prop {String} id The ID of the interaction
-* @prop {String?} locale The selected language of the invoking user (e.g. "en-US")
-* @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
-* @prop {String} token The interaction token (Interaction tokens are valid for 15 minutes after initial response and can be used to send followup messages but you must send an initial response within 3 seconds of receiving the event. If the 3 second deadline is exceeded, the token will be invalidated.)
-* @prop {Number} type The [interaction type](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type)
-* @prop {User} user The user who triggered the interaction
-* @prop {Number} version The interaction version
+* @extends Base
 */
 class Interaction extends Base {
+    /**
+     * The ID of the interaction
+     * @member {String} Interaction#id
+     */
     #client;
     constructor(data, client) {
         super(data.id);
         this.#client = client;
 
+        /**
+         * The ID of the interaction's application
+         * @type {String}
+         */
         this.applicationID = data.application_id;
+        /**
+         * The interaction token (Interaction tokens are valid for 15 minutes after initial response and can be used to send followup messages but you must send an initial response within 3 seconds of receiving the event. If the 3 second deadline is exceeded, the token will be invalidated.)
+         * @type {String}
+         */
         this.token = data.token;
+        /**
+         * The [interaction type](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type)
+         * @type {Number}
+         */
         this.type = data.type;
+        /**
+         * The interaction version
+         * @type {Number}
+         */
         this.version = data.version;
+        /**
+         * Whether or not the interaction has been acknowledged
+         * @type {Boolean}
+         */
         this.acknowledged = false;
 
         if(data.channel !== undefined) {
+            /**
+             * The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached.
+             * @type {(PrivateChannel | TextChannel | NewsChannel)?}
+             */
             this.channel = this.#client.getChannel(data.channel.id) || data.channel;
         }
 
         if(data.data !== undefined) {
+            /**
+             * The data attached to the interaction. See AutocompleteInteraction, CommandInteraction, and ComponentInteraction for specific details
+             * @type {Object}
+             */
             this.data = JSON.parse(JSON.stringify(data.data));
         }
 
         if(data.guild_id !== undefined) {
+            /**
+             * The ID of the guild in which the interaction was created
+             * @type {String?}
+             */
             this.guildID = data.guild_id;
         }
 
         if(data.member !== undefined) {
             if(this.channel.guild) {
                 data.member.id = data.member.user.id;
+                /**
+                 * The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
+                 * @type {Member?}
+                 */
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
             } else {
                 const guild = this.#client.guilds.get(data.guild_id);
@@ -58,18 +85,34 @@ class Interaction extends Base {
         }
 
         if(data.user !== undefined) {
+            /**
+             * The user who triggered the interaction
+             * @type {User}
+             */
             this.user = this.#client.users.update(data.user, client);
         }
 
         if(data.locale !== undefined) {
+            /**
+             * The selected language of the invoking user (e.g. "en-US")
+             * @type {String?}
+             */
             this.locale = data.locale;
         }
 
         if(data.guild_locale !== undefined) {
+            /**
+             * The selected language of the guild the command was invoked from (e.g. "en-US")
+             * @type {String?}
+             */
             this.guildLocale = data.guild_locale;
         }
 
         if(data.app_permissions !== undefined) {
+            /**
+             * The permissions the app or bot has within the channel the interaction was sent from
+             * @type {Permission?}
+             */
             this.appPermissions = new Permission(data.app_permissions);
         }
     }

--- a/lib/structures/Invite.js
+++ b/lib/structures/Invite.js
@@ -6,66 +6,94 @@ const GuildScheduledEvent = require("./GuildScheduledEvent");
 
 /**
 * Represents an invite. Some properties are only available when fetching invites from channels, which requires the Manage Channel permission.
-* @prop {TextChannel | NewsChannel | TextVoiceChannel | StageChannel | Object} channel Info on the invite channel
-* @prop {String} channel.id The ID of the invite's channel
-* @prop {String?} channel.name The name of the invite's channel
-* @prop {Number} channel.type The type of the invite's channel
-* @prop {String?} channel.icon The icon of a channel (group dm)
-* @prop {String} code The invite code
-* @prop {Number?} createdAt Timestamp of invite creation
-* @prop {Number?} expiresAt Timestamp of invite expiration
-* @prop {Guild?} guild Info on the invite guild
-* @prop {GuildScheduledEvent?} guildScheduledEvent The guild scheduled event associated with the invite
-* @prop {User?} inviter The invite creator
-* @prop {Number?} maxAge How long the invite lasts in seconds
-* @prop {Number?} maxUses The max number of invite uses
-* @prop {Number?} memberCount The **approximate** member count for the guild
-* @prop {Number?} presenceCount The **approximate** presence count for the guild
-* @prop {Object?} stageInstance  [DEPRECATED] The active public stage instance data for the stage channel this invite is for
-* @prop {Member[]} stageInstance.members The members in the stage instance
-* @prop {Number} stageInstance.participantCount The number of participants in the stage instance
-* @prop {Number} stageInstance.speakerCount The number of speakers in the stage instance
-* @prop {String} stageInstance.topic The topic of the stage instance
-* @prop {Object?} targetApplication The target application
-* @prop {Number?} targetType The type of the target application
-* @prop {User?} targetUser The user whose stream is displayed for the invite (voice channel only)
-* @prop {Boolean?} temporary Whether the invite grants temporary membership or not
-* @prop {Number?} uses The number of invite uses
+* @extends Base
 */
 class Invite extends Base {
+    /**
+     * Invites don't have an ID.
+     * @private
+     * @override
+     * @member {undefined} Invite#id
+     */
+
     #client;
     #createdAt;
     constructor(data, client) {
         super();
         this.#client = client;
+        /**
+         * The invite code
+         * @type {String}
+         */
         this.code = data.code;
         if(data.guild && client.guilds.has(data.guild.id)) {
+            /**
+             * Info on the invite channel
+             * @type {TextChannel | NewsChannel | TextVoiceChannel | StageChannel | Invite.UncachedInviteChannel}
+             */
             this.channel = client.guilds.get(data.guild.id).channels.update(data.channel, client);
         } else {
             this.channel = data.channel;
         }
         if(data.guild) {
             if(client.guilds.has(data.guild.id)) {
+                /**
+                 * Info on the invite guild
+                 * @type {Guild?}
+                 */
                 this.guild = client.guilds.update(data.guild, client);
             } else {
                 this.guild = new Guild(data.guild, client);
             }
         }
         if(data.inviter) {
+            /**
+             * The invite creator
+             * @type {User?}
+             */
             this.inviter = client.users.add(data.inviter, client);
         }
+        /**
+         * The number of invite uses
+         * @type {Number?}
+         */
         this.uses = data.uses !== undefined ? data.uses : null;
+        /**
+         * The max number of invite uses
+         * @type {Number?}
+         */
         this.maxUses = data.max_uses !== undefined ? data.max_uses : null;
+        /**
+         * How long the invite lasts in seconds
+         * @type {Number?}
+         */
         this.maxAge = data.max_age !== undefined ? data.max_age : null;
+        /**
+         * Whether the invite grants temporary membership or not
+         * @type {Boolean?}
+         */
         this.temporary = data.temporary !== undefined ? data.temporary : null;
         this.#createdAt = data.created_at !== undefined ? data.created_at : null;
+        /**
+         * The **approximate** presence count for the guild
+         * @type {Number?}
+         */
         this.presenceCount = data.approximate_presence_count !== undefined ? data.approximate_presence_count : null;
+        /**
+         * The **approximate** member count for the guild
+         * @type {Number?}
+         */
         this.memberCount = data.approximate_member_count !== undefined ? data.approximate_member_count : null;
         if(data.stage_instance !== undefined) {
             data.stage_instance.members = data.stage_instance.members.map((m) => {
                 m.id = m.user.id;
                 return m;
             });
+            /**
+             * The active public stage instance data for the stage channel this invite is for
+             * @deprecated Deprecated in Discord's API
+             * @type {Invite.StageInstance}
+             */
             this.stageInstance = {
                 members: data.stage_instance.members.map((m) => this.guild.members.update(m, this.guild)),
                 participantCount: data.stage_instance.participant_count,
@@ -76,22 +104,46 @@ class Invite extends Base {
             this.stageInstance = null;
         }
         if(data.target_application !== undefined) {
+            /**
+             * The target application
+             * @type {Object?}
+             */
             this.targetApplication = data.target_application;
         }
         if(data.target_type !== undefined) {
+            /**
+             * The type of the target application
+             * @type {Number?}
+             */
             this.targetType = data.target_type;
         }
         if(data.target_user !== undefined) {
+            /**
+             * The user whose stream is displayed for the invite (voice channel only)
+             * @type {User?}
+             */
             this.targetUser = client.users.update(data.target_user, this.#client);
         }
         if(data.expires_at !== undefined) {
+            /**
+             * Timestamp of invite expiration
+             * @type {Number?}
+             */
             this.expiresAt = Date.parse(data.expires_at);
         }
         if(data.guild_scheduled_event !== undefined) {
+            /**
+             * The guild scheduled event associated with the invite
+             * @type {GuildScheduledEvent?}
+             */
             this.guildScheduledEvent = new GuildScheduledEvent(data.guild_scheduled_event, client);
         }
     }
 
+    /**
+     * Timestamp of invite creation
+     * @type {Number?}
+     */
     get createdAt() {
         return Date.parse(this.#createdAt);
     }
@@ -128,3 +180,22 @@ class Invite extends Base {
 }
 
 module.exports = Invite;
+
+/**
+ * Information about an uncached invite
+ * @typedef Invite.UncachedInviteChannel
+ * @prop {String} id The ID of the invite's channel
+ * @prop {String?} name The name of the invite's channel
+ * @prop {Number} type The type of the invite's channel
+ * @prop {String?} icon The icon of a channel (group dm)
+ */
+
+/**
+ * Information about the active public stage instance
+ * @deprecated Deprecated in Discord's API
+ * @typedef Invite.StageInstance
+ * @prop {Member[]} members The members in the stage instance
+ * @prop {Number} participantCount The number of participants in the stage instance
+ * @prop {Number} speakerCount The number of speakers in the stage instance
+ * @prop {String} topic The topic of the stage instance
+ */

--- a/lib/structures/MediaChannel.js
+++ b/lib/structures/MediaChannel.js
@@ -3,7 +3,7 @@
 const ForumChannel = require("./ForumChannel");
 
 /**
- * Represents a media channel. See ForumChannel for available properties and methods.
+ * Represents a media channel.
  * @extends ForumChannel
  */
 class MediaChannel extends ForumChannel {}

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -7,50 +7,27 @@ const VoiceState = require("./VoiceState");
 
 /**
 * Represents a server member
-* @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
-* @prop {Array<Object>?} activities The member's current activities
-* @prop {String?} avatar The hash of the member's guild avatar, or null if no guild avatar
-* @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
-* @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
-* @prop {String?} bannerURL The URL of the user's banner
-* @prop {Boolean} bot Whether the user is an OAuth bot or not
-* @prop {Object?} clientStatus The member's per-client status
-* @prop {String} clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
-* @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
-* @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
-* @prop {Number?} communicationDisabledUntil Timestamp of timeout expiry. If `null`, the member is not timed out
-* @prop {Number} createdAt Timestamp of user creation
-* @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
-* @prop {String} defaultAvatarURL The URL of the user's default avatar
-* @prop {String} discriminator The discriminator of the user - if a single zero digit ("0"), the user is using the unique username system
-* @prop {Number} flags The guild member flag bit set
-* @prop {Object?} game The active game the member is playing
-* @prop {String} game.name The name of the active game
-* @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
-* @prop {String?} game.url The url of the active game
-* @prop {String?} globalName The globally visible display name of the user
-* @prop {Guild} guild The guild the member is in
-* @prop {String} id The ID of the member
-* @prop {Number?} joinedAt Timestamp of when the member joined the guild
-* @prop {String} mention A string that mentions the member
-* @prop {String?} nick The server nickname of the member
-* @prop {Boolean?} pending Whether the member has passed the guild's Membership Screening requirements
-* @prop {Permission} permissions The guild-wide permissions of the member
-* @prop {Number?} premiumSince Timestamp of when the member boosted the guild
-* @prop {Array<String>} roles An array of role IDs this member is a part of
-* @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
-* @prop {String} status The member's status. Either "online", "idle", "dnd", or "offline"
-* @prop {User} user The user object of the member
-* @prop {String} username The username of the user
-* @prop {VoiceState} voiceState The voice state of the member
+* @extends Base
 */
 class Member extends Base {
+    /**
+     * The ID of the member
+     * @member {String} Member#id
+     */
+    /**
+     * The guild the member is in
+     * @member {Guild} Member#guild
+     */
     constructor(data, guild, client) {
         super(data.id || data.user.id);
         if(!data.id && data.user) {
             data.id = data.user.id;
         }
         if((this.guild = guild)) {
+            /**
+             * The user object of the member
+             * @type {User}
+             */
             this.user = guild.shard.client.users.get(data.id);
             if(!this.user && data.user) {
                 this.user = guild.shard.client.users.add(data.user, guild.shard.client);
@@ -68,26 +45,58 @@ class Member extends Base {
             this.user = null;
         }
 
+        /**
+         * The server nickname of the member
+         * @type {String?}
+         */
         this.nick = null;
+        /**
+         * An array of role IDs this member is a part of
+         * @type {Array<String>}
+         */
         this.roles = [];
+        /**
+         * The guild member flag bit set
+         * @type {Number}
+         */
         this.flags = 0;
         this.update(data);
     }
 
     update(data) {
         if(data.status !== undefined) {
+            /**
+             * The member's status. Either "online", "idle", "dnd", or "offline"
+             * @type {String}
+             */
             this.status = data.status;
         }
         if(data.joined_at !== undefined) {
+            /**
+             * Timestamp of when the member joined the guild
+             * @type {Number?}
+             */
             this.joinedAt = data.joined_at ?  Date.parse(data.joined_at) : null;
         }
         if(data.client_status !== undefined) {
+            /**
+             * The member's per-client status
+             * @type {Member.ClientStatus}
+             */
             this.clientStatus = Object.assign({web: "offline", desktop: "offline", mobile: "offline"}, data.client_status);
         }
         if(data.activities !== undefined) {
+            /**
+             * The member's current activities
+             * @type {Array<Member.Activity>?}
+             */
             this.activities = data.activities;
         }
         if(data.premium_since !== undefined) {
+            /**
+             * Timestamp of when the member boosted the guild
+             * @type {Number?}
+             */
             this.premiumSince = data.premium_since === null ? null : Date.parse(data.premium_since);
         }
         if(data.hasOwnProperty("mute") && this.guild) {
@@ -107,13 +116,25 @@ class Member extends Base {
             this.roles = data.roles;
         }
         if(data.pending !== undefined) {
+            /**
+             * Whether the member has passed the guild's Membership Screening requirements
+             * @type {Boolean?}
+             */
             this.pending = data.pending;
         }
         if(data.avatar !== undefined) {
+            /**
+             * The hash of the member's guild avatar, or null if no guild avatar
+             * @type {String?}
+             */
             this.avatar = data.avatar;
         }
         if(data.communication_disabled_until !== undefined) {
             if(data.communication_disabled_until !== null) {
+                /**
+                 * Timestamp of timeout expiry. If `null`, the member is not timed out
+                 * @type {Number?}
+                 */
                 this.communicationDisabledUntil = Date.parse(data.communication_disabled_until);
             } else {
                 this.communicationDisabledUntil = data.communication_disabled_until;
@@ -124,68 +145,132 @@ class Member extends Base {
         }
     }
 
+    /**
+     * The user's banner color, or null if no banner color (REST only)
+     * @type {Number?}
+     */
     get accentColor() {
         return this.user.accentColor;
     }
 
+    /**
+     * The URL of the user's avatar which can be either a JPG or GIF
+     * @type {String}
+     */
     get avatarURL() {
         return this.avatar ? this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar)) : this.user.avatarURL;
     }
 
+    /**
+     * The hash of the user's banner, or null if no banner (REST only)
+     * @type {String?}
+     */
     get banner() {
         return this.user.banner;
     }
 
+    /**
+     * The URL of the user's banner
+     * @type {String?}
+     */
     get bannerURL() {
         return this.user.bannerURL;
     }
 
+    /**
+     * Whether the user is an OAuth bot or not
+     * @type {Boolean}
+     */
     get bot() {
         return this.user.bot;
     }
 
+    /**
+     * Timestamp of user creation
+     * @type {Number}
+     */
     get createdAt() {
         return this.user.createdAt;
     }
 
+    /**
+     * The hash for the default avatar of a user if there is no avatar set
+     * @type {String}
+     */
     get defaultAvatar() {
         return this.user.defaultAvatar;
     }
 
+    /**
+     * The URL of the user's default avatar
+     * @type {String}
+     */
     get defaultAvatarURL() {
         return this.user.defaultAvatarURL;
     }
 
+    /**
+     * The discriminator of the user - if a single zero digit ("0"), the user is using the unique username system
+     * @type {String}
+     */
     get discriminator() {
         return this.user.discriminator;
     }
 
+    /**
+     * The globally visible display name of the user
+     * @type {String?}
+     */
     get globalName() {
         return this.user.globalName;
     }
 
+    /**
+     * A string that mentions the member
+     * @type {String}
+     */
     get mention() {
         return `<@!${this.id}>`;
     }
 
+    /**
+     * The guild-wide permissions of the member
+     * @type {Permission}
+     */
     get permissions() {
         return this.guild.permissionsOf(this);
     }
 
+    /**
+     * The URL of the user's avatar (always a JPG)
+     * @type {String}
+     */
     get staticAvatarURL(){
         return this.user.staticAvatarURL;
     }
 
+    /**
+     * The username of the user
+     * @type {String}
+     */
     get username() {
         return this.user.username;
     }
 
+    /**
+     * The voice state of the member
+     * @type {VoiceState}
+     */
     get voiceState() {
         return this.guild?.voiceStates.get(this.id) || new VoiceState({
             id: this.id
         });
     }
 
+    /**
+     * The active game the member is playing
+     * @type {Member.Activity?}
+     */
     get game() {
         return this.activities?.length > 0 ? this.activities[0] : null;
     }
@@ -289,3 +374,20 @@ class Member extends Base {
 }
 
 module.exports = Member;
+
+/**
+ * The member's per-client status
+ * @typedef Member.ClientStatus
+ * @prop {String} web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
+ * @prop {String} desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+ * @prop {String} mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+ */
+
+/**
+ * The member's activity. See [Discord's documentation](https://discord.com/developers/docs/topics/gateway-events#activity-object) for more properties
+ * @typedef Member.Activity
+ * @prop {String} game.name The name of the active game
+ * @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
+ * @prop {String?} game.url The url of the active game
+ * @prop {String?} game.state The state of the active game
+ */

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -9,68 +9,70 @@ const Collection = require("../util/Collection");
 
 /**
 * Represents a message
-* @prop {Object?} activity The activity specified in the message
-* @prop {Object?} application The application of the activity in the message
-* @prop {String?} applicationID The ID of the interaction's application
-* @prop {Collection<Attachment>} attachments Array of attachments
-* @prop {User} author The message author
-* @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the message is in. Can be partial with only the id if the channel is not cached.
-* @prop {Array<String>} channelMentions Array of mentions channels' ids
-* @prop {String?} cleanContent Message content with mentions replaced by names. Mentions are currently escaped, but this behavior is [DEPRECATED] and will be removed soon. Use allowed mentions, the official way of avoiding unintended mentions, when creating messages.
-* @prop {Array<Object>} components An array of component objects
-* @prop {String} content Message content
-* @prop {Number} createdAt Timestamp of message creation
-* @prop {Array<Object>?} crosspostedChannelMentions An array of mentioned channels (crossposted messages only)
-* @prop {Number?} editedTimestamp Timestamp of latest message edit
-* @prop {Array<Object>} embeds Array of embeds
-* @prop {Number} flags Message flags. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
-* @prop {String} [guildID] The ID of the guild this message is in (undefined if in DMs)
-* @prop {String} id The ID of the message
-* @prop {Object?} interaction An object containing info about the interaction the message is responding to, if applicable
-* @prop {String} interaction.id The id of the interaction
-* @prop {Number} interaction.type The type of interaction
-* @prop {String} interaction.name The name of the command
-* @prop {User} interaction.user The user who invoked the interaction
-* @prop {Member?} interaction.member The member who invoked the interaction
-* @prop {String} jumpLink The url used by Discord clients to jump to this message
-* @prop {Member?} member The message author with server-specific data
-* @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
-* @prop {Array<User>} mentions Array of mentioned users
-* @prop {Object?} messageReference An object containing the reference to the original message if it is a crossposted message or reply
-* @prop {String?} messageReference.messageID The id of the original message this message was crossposted from
-* @prop {String} messageReference.channelID The id of the channel this message was crossposted from
-* @prop {String?} messageReference.guildID The id of the guild this message was crossposted from
-* @prop {Boolean} pinned Whether the message is pinned or not
-* @prop {Number?} position The approximate position of a message in a thread
-* @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
-* @prop {Message?} referencedMessage The message that was replied to. If undefined, message data was not received. If null, the message was deleted.
-* @prop {Object?} roleSubscriptionData Data about the role subscription that triggered this message
-* @prop {Array<String>} roleMentions Array of mentioned roles' ids
-* @prop {Array<Object>?} stickerItems The stickers sent with the message
-* @prop {ThreadChannel?} thread The thread channel created from this message (messages fetched via REST only)
-* @prop {Number} timestamp Timestamp of message creation
-* @prop {Boolean} tts Whether to play the message using TTS or not
-* @prop {Number} type The type of the message
-* @prop {String?} webhookID ID of the webhook that sent the message
+* @extends Base
 */
 class Message extends Base {
+    /**
+     * Timestamp of message creation
+     * @member {Number} Message#createdAt
+     */
+    /**
+     * The ID of the message
+     * @member {String} Message#id
+     */
     #channelMentions;
     #client;
+    /**
+     * A collection of attachments
+     * @type {Collection<Attachment>}
+     */
+    attachments = new Collection(Attachment);
     constructor(data, client) {
         super(data.id);
         this.#client = client;
+        /**
+         * The type of the message
+         * @type {Number}
+         */
         this.type = data.type || 0;
-        this.attachments = new Collection(Attachment);
+        /**
+         * Timestamp of message creation
+         * @type {Number}
+         */
         this.timestamp = Date.parse(data.timestamp);
+        /**
+         * The channel the message is in. Can be partial with only the id if the channel is not cached.
+         * @type {PrivateChannel | TextChannel | NewsChannel}
+         */
         this.channel = this.#client.getChannel(data.channel_id) || {
             id: data.channel_id
         };
+        /**
+         * Message content
+         * @type {String}
+         */
         this.content = "";
+        /**
+         * An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
+         * @type {Object<string, object>}
+         */
         this.reactions = {};
+        /**
+         * The ID of the guild this message is in (undefined if in DMs)
+         * @type {String?}
+         */
         this.guildID = data.guild_id;
+        /**
+         * ID of the webhook that sent the message
+         * @type {String?}
+         */
         this.webhookID = data.webhook_id;
 
         if(data.message_reference) {
+            /**
+             * An object containing the reference to the original message if it is a crossposted message or reply
+             * @type {Message.MessageReference}
+             */
             this.messageReference = {
                 messageID: data.message_reference.message_id,
                 channelID: data.message_reference.channel_id,
@@ -80,10 +82,18 @@ class Message extends Base {
             this.messageReference = null;
         }
 
+        /**
+         * Message flags. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
+         * @type {Number}
+         */
         this.flags = data.flags || 0;
 
         if(data.author) {
             if(data.author.discriminator !== "0000") {
+                /**
+                 * The message author
+                 * @type {User}
+                 */
                 this.author = this.#client.users.update(data.author, client);
             } else {
                 this.author = new User(data.author, client);
@@ -94,6 +104,10 @@ class Message extends Base {
         if(data.referenced_message) {
             const channel = this.#client.getChannel(data.referenced_message.channel_id);
             if(channel) {
+                /**
+                 * The message that was replied to. If undefined, message data was not received. If null, the message was deleted.
+                 * @type {Message?}
+                 */
                 this.referencedMessage = channel.messages.update(data.referenced_message, this.#client);
             } else {
                 this.referencedMessage = new Message(data.referenced_message, this.#client);
@@ -103,6 +117,10 @@ class Message extends Base {
         }
 
         if(data.interaction) {
+            /**
+             * An object containing info about the interaction the message is responding to, if applicable
+             * @type {Message.InteractionData}
+             */
             this.interaction = data.interaction;
             let interactionMember;
             const interactionUser = this.#client.users.update(data.interaction.user, client);
@@ -130,6 +148,10 @@ class Message extends Base {
                 if(data.author) {
                     data.member.user = data.author;
                 }
+                /**
+                 * The message author with server-specific data
+                 * @type {Member?}
+                 */
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
             } else if(this.channel.guild.members.has(this.author.id)) {
                 this.member = this.channel.guild.members.get(this.author.id);
@@ -140,6 +162,10 @@ class Message extends Base {
             this.guildID ??= this.channel.guild.id;
 
             if(data.thread) {
+                /**
+                 * The thread channel created from this message (messages fetched via REST only)
+                 * @type {ThreadChannel?}
+                 */
                 this.thread = this.channel.guild.threads.update(data.thread, client);
             }
         } else {
@@ -153,6 +179,10 @@ class Message extends Base {
         }
 
         if(data.role_subscription_data) {
+            /**
+             * Data about the role subscription that triggered this message
+             * @type {Object?}
+             */
             this.roleSubscriptionData = {
                 isRenewal: data.role_subscription_data.is_renewal,
                 roleSubscriptionListingID: data.role_subscription_data.role_subscription_listing_id,
@@ -279,8 +309,16 @@ class Message extends Base {
     update(data, client) {
         if(data.content !== undefined) {
             this.content = data.content || "";
+            /**
+             * Whether the message mentions everyone/here or not
+             * @type {Boolean}
+             */
             this.mentionEveryone = !!data.mention_everyone;
 
+            /**
+             * Array of mentioned users
+             * @type {Array<User>}
+             */
             this.mentions = data.mentions.map((mention) => {
                 const user = this.#client.users.add(mention, client);
                 if(mention.member && this.channel.guild) {
@@ -290,16 +328,32 @@ class Message extends Base {
                 return user;
             });
 
+            /**
+             * Array of mentioned roles' ids
+             * @type {Array<String>}
+             */
             this.roleMentions = data.mention_roles;
         }
 
         if(data.pinned !== undefined) {
+            /**
+             * Whether the message is pinned or not
+             * @type {Boolean}
+             */
             this.pinned = !!data.pinned;
         }
         if(data.edited_timestamp != undefined) {
+            /**
+             * Timestamp of latest message edit
+             * @type {Number?}
+             */
             this.editedTimestamp = Date.parse(data.edited_timestamp);
         }
         if(data.tts !== undefined) {
+            /**
+             * Whether to play the message using TTS or not
+             * @type {Boolean}
+             */
             this.tts = data.tts;
         }
         if(data.attachments) {
@@ -313,18 +367,34 @@ class Message extends Base {
             }
         }
         if(data.embeds !== undefined) {
+            /**
+             * Array of embeds
+             * @type {Array<Object>}
+             */
             this.embeds = data.embeds;
         }
         if(data.flags !== undefined) {
             this.flags = data.flags;
         }
         if(data.activity !== undefined) {
+            /**
+             * The activity specified in the message
+             * @type {Object?}
+             */
             this.activity = data.activity;
         }
         if(data.application !== undefined) {
+            /**
+             * The application of the activity in the message
+             * @type {Object?}
+             */
             this.application = data.application;
         }
         if(data.application_id !== undefined) {
+            /**
+             * The ID of the interaction's application
+             * @type {String?}
+             */
             this.applicationID = data.application_id;
         }
 
@@ -338,6 +408,10 @@ class Message extends Base {
         }
 
         if(data.sticker_items !== undefined) {
+            /**
+             * The stickers sent with the message
+             * @type {Array<Object>?}
+             */
             this.stickerItems = data.sticker_items.map((sticker) => {
                 if(sticker.user) {
                     sticker.user = this.#client.users.update(sticker.user, client);
@@ -348,10 +422,18 @@ class Message extends Base {
         }
 
         if(data.components !== undefined) {
+            /**
+             * An array of component objects
+             * @type {Array<Object>}
+             */
             this.components = data.components;
         }
 
         if(data.mention_channels !== undefined) {
+            /**
+             * An array of mentioned channels (crossposted messages only)
+             * @type {Array<Object>?}
+             */
             this.crosspostedChannelMentions = data.mention_channels.map((channel) => ({
                 guildID: channel.guild_id,
                 id: channel.id,
@@ -361,14 +443,26 @@ class Message extends Base {
         }
 
         if(data.position !== undefined) {
+            /**
+             * The approximate position of a message in a thread
+             * @type {Number?}
+             */
             this.position = data.position;
         }
     }
 
+    /**
+     * Array of mentions channels' ids
+     * @type {Array<String>}
+     */
     get channelMentions() {
         return this.#channelMentions ?? (this.#channelMentions = (this.content?.match(/<#[0-9]+>/g) || []).map((mention) => mention.substring(2, mention.length - 1)));
     }
 
+    /**
+     * Message content with mentions replaced by names. Mentions are currently escaped, but this behavior is [DEPRECATED] and will be removed soon. Use allowed mentions, the official way of avoiding unintended mentions, when creating messages.
+     * @type {String?}
+     */
     get cleanContent() {
         let cleanContent = this.content?.replace(/<a?(:\w+:)[0-9]+>/g, "$1") || "";
 
@@ -405,6 +499,10 @@ class Message extends Base {
         return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
     }
 
+    /**
+     * The url used by Discord clients to jump to this message
+     * @type {String}
+     */
     get jumpLink() {
         return `${Endpoints.CLIENT_URL}${Endpoints.MESSAGE_LINK(this.guildID || "@me", this.channel.id, this.id)}`; // Messages outside of guilds (DMs) will never have a guildID property assigned
     }
@@ -625,3 +723,20 @@ class Message extends Base {
 }
 
 module.exports = Message;
+
+/**
+ * An object containing the reference to the original message if it is a crossposted message or reply
+ * @typedef Message.MessageReference
+ * @prop {String?} messageID The id of the original message this message was crossposted from
+ * @prop {String} channelID The id of the channel this message was crossposted from
+ * @prop {String?} guildID The id of the guild this message was crossposted from
+ */
+/**
+ * An object containing info about the interaction the message is responding to, if applicable
+ * @typedef Message.InteractionData
+ * @prop {String} id The id of the interaction
+ * @prop {Number} type The type of interaction
+ * @prop {String} name The name of the command
+ * @prop {User} user The user who invoked the interaction
+ * @prop {Member?} member The member who invoked the interaction
+ */

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -5,17 +5,20 @@ const Interaction = require("./Interaction");
 const {InteractionResponseTypes} = require("../Constants");
 
 /**
-* Represents a modal submit interaction. See Interaction for more properties
+* Represents a modal submit interaction.
 * @extends Interaction
-* @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached
-* @prop {Object} data The data attached to the interaction
-* @prop {String} data.custom_id The ID of the Modal
-* @prop {Array<Object>} data.components The values submitted by the user
-* @prop {String?} guildID The ID of the guild in which the interaction was created
-* @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
-* @prop {User?} user The user who triggered the interaction (This is only sent when the interaction is invoked within a dm)
 */
 class ModalSubmitInteraction extends Interaction {
+    /**
+     * @override
+     * @member {!(PrivateChannel | TextChannel | NewsChannel)} CommandInteraction#channel
+     */
+    /**
+     * The data attached to the interaction
+     * @override
+     * @member {ModalSubmitInteraction.InteractionData} ModalSubmitInteraction#data
+     */
+
     #client;
     constructor(data, client) {
         super(data, client);
@@ -295,3 +298,10 @@ class ModalSubmitInteraction extends Interaction {
 }
 
 module.exports = ModalSubmitInteraction;
+
+/**
+ * The data attached to the interaction
+ * @typedef ModalSubmitInteraction.InteractionData
+ * @prop {String} custom_id The ID of the Modal
+ * @prop {Array<Object>} components The values submitted by the user
+ */

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -3,7 +3,7 @@
 const TextChannel = require("./TextChannel");
 
 /**
-* Represents a guild news channel. See TextChannel for more properties and methods.
+* Represents a guild news channel.
 * @extends TextChannel
 */
 class NewsChannel extends TextChannel {

--- a/lib/structures/NewsThreadChannel.js
+++ b/lib/structures/NewsThreadChannel.js
@@ -3,7 +3,7 @@
 const ThreadChannel = require("./ThreadChannel");
 
 /**
-* Represents a news thread channel. See ThreadChannel for extra properties.
+* Represents a news thread channel.
 * @extends ThreadChannel
 */
 class NewsThreadChannel extends ThreadChannel {

--- a/lib/structures/Permission.js
+++ b/lib/structures/Permission.js
@@ -5,29 +5,40 @@ const {Permissions} = require("../Constants");
 
 /**
 * Represents a calculated permissions number
-* @prop {BigInt} allow The allowed permissions number
-* @prop {BigInt} deny The denied permissions number
-* @prop {Object} json A JSON representation of the permissions number.
-* If a permission key isn't there, it is not set by this permission.
-* If a permission key is false, it is denied by the permission.
-* If a permission key is true, it is allowed by the permission.
-* i.e.:
-* {
-*   "readMessages": true,
-*   "sendMessages": true,
-*   "manageMessages": false
-* }
-* In the above example, readMessages and sendMessages are allowed permissions, and manageMessages is denied. Everything else is not explicitly set.
-* [A full list of permission nodes can be found in Constants](https://github.com/projectdysnomia/dysnomia/blob/dev/lib/Constants.js#L442)
 */
 class Permission extends Base {
     #json;
     constructor(allow, deny = 0) {
         super();
+        /**
+         * The allowed permissions number
+         * @type {BigInt}
+         */
         this.allow = BigInt(allow);
+        /**
+         * The denied permissions number
+         * @type {BigInt}
+         */
         this.deny = BigInt(deny);
     }
 
+    /**
+     * A JSON representation of the permissions number.
+     * If a permission key isn't there, it is not set by this permission.
+     * If a permission key is false, it is denied by the permission.
+     * If a permission key is true, it is allowed by the permission.
+     * i.e.:
+     * ```json
+     * {
+     *   "readMessages": true,
+     *   "sendMessages": true,
+     *   "manageMessages": false
+     * }
+     * ```
+     * In the above example, readMessages and sendMessages are allowed permissions, and manageMessages is denied. Everything else is not explicitly set.
+     * [A full list of permission nodes can be found in Constants](https://github.com/projectdysnomia/dysnomia/blob/dev/lib/Constants.js#L442)
+     * @type {Object<string, boolean>}
+     */
     get json() {
         if(!this.#json) {
             this.#json = {};

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -5,13 +5,19 @@ const Permission = require("./Permission");
 /**
 * Represents a permission overwrite
 * @extends Permission
-* @prop {String} id The ID of the overwrite
-* @prop {Number} type The type of the overwrite, either 1 for "member" or 0 for "role"
 */
 class PermissionOverwrite extends Permission {
     constructor(data) {
         super(data.allow, data.deny);
+        /**
+         * The ID of the overwrite
+         * @type {String}
+         */
         this.id = data.id;
+        /**
+         * The type of the overwrite, either 1 for "member" or 0 for "role"
+         * @type {Number}
+         */
         this.type = data.type;
     }
 

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -7,22 +7,32 @@ const {ChannelTypes} = require("../Constants");
 const User = require("./User");
 
 /**
-* Represents a private channel. See Channel for more properties and methods.
+* Represents a private channel.
 * @extends Channel
-* @prop {String} lastMessageID The ID of the last message in this channel
-* @prop {Collection<Message>} messages Collection of Messages in this channel
-* @prop {User} recipient The recipient in this private channel (private channels only)
 */
 class PrivateChannel extends Channel {
     #client;
     constructor(data, client) {
         super(data, client);
         this.#client = client;
+        /**
+         * The ID of the last message in this channel
+         * @type {String}
+         */
         this.lastMessageID = data.last_message_id;
+
         this.rateLimitPerUser = data.rate_limit_per_user;
         if(this.type === ChannelTypes.DM || this.type === undefined) {
+            /**
+             * The recipient in this private channel (private channels only)
+             * @type {User}
+             */
             this.recipient = new User(data.recipients[0], client);
         }
+        /**
+         * Collection of Messages in this channel
+         * @type {Collection<Message>}
+         */
         this.messages = new Collection(Message, client.options.messageLimit);
     }
 

--- a/lib/structures/PrivateThreadChannel.js
+++ b/lib/structures/PrivateThreadChannel.js
@@ -5,12 +5,6 @@ const ThreadChannel = require("./ThreadChannel");
 /**
 * Represents a private thread channel. See ThreadChannel for extra properties.
 * @extends ThreadChannel
-* @prop {Object} threadMetadata Metadata for the thread
-* @prop {Number} threadMetadata.archiveTimestamp Timestamp when the thread's archive status was last changed, used for calculating recent activity
-* @prop {Boolean} threadMetadata.archived Whether the thread is archived
-* @prop {Number} threadMetadata.autoArchiveDuration Duration in minutes to automatically archive the thread after recent activity, either 60, 1440, 4320 or 10080
-* @prop {Boolean} threadMetadata.invitable Whether non-moderators can add other non-moderators to the thread
-* @prop {Boolean} threadMetadata.locked Whether the thread is locked
 */
 class PrivateThreadChannel extends ThreadChannel {
     constructor(data, client, messageLimit) {
@@ -20,6 +14,11 @@ class PrivateThreadChannel extends ThreadChannel {
     update(data, client) {
         super.update(data, client);
         if(data.thread_metadata !== undefined) {
+            /**
+             * Metadata for the thread
+             * @override
+             * @type {ThreadChannel.ThreadMetadata}
+             */
             this.threadMetadata = {
                 archiveTimestamp: Date.parse(data.thread_metadata.archive_timestamp),
                 archived: data.thread_metadata.archived,

--- a/lib/structures/PublicThreadChannel.js
+++ b/lib/structures/PublicThreadChannel.js
@@ -5,7 +5,6 @@ const ThreadChannel = require("./ThreadChannel");
 /**
 * Represents a public thread channel. See ThreadChannel for extra properties.
 * @extends ThreadChannel
-* @prop {Array<String>} appliedTags An array of applied tag IDs for the thread (available only in threads in thread-only channels)
 */
 class PublicThreadChannel extends ThreadChannel {
     constructor(data, client, messageLimit) {
@@ -15,6 +14,10 @@ class PublicThreadChannel extends ThreadChannel {
     update(data, client) {
         super.update(data, client);
         if(data.applied_tags !== undefined) {
+            /**
+             * An array of applied tag IDs for the thread (available only in threads in thread-only channels)
+             * @type {Array<String>?}
+             */
             this.appliedTags = data.applied_tags;
         }
     }

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -6,57 +6,85 @@ const Permission = require("./Permission");
 
 /**
 * Represents a role
-* @prop {Number} color The hex color of the role in base 10
-* @prop {Number} createdAt Timestamp of the role's creation
-* @prop {Number} flags Role flags. See [Discord's documentation](https://discord.com/developers/docs/topics/permissions#role-object-role-flags) for a list of them
-* @prop {Guild} guild The guild that owns the role
-* @prop {Boolean} hoist Whether users with this role are hoisted in the user list or not
-* @prop {String?} icon The hash of the role's icon, or null if no icon
-* @prop {String?} iconURL The URL of the role's icon
-* @prop {String} id The ID of the role
-* @prop {Object} json Generates a JSON representation of the role permissions
-* @prop {Boolean} managed Whether a guild integration manages this role or not
-* @prop {String} mention A string that mentions the role
-* @prop {Boolean} mentionable Whether the role is mentionable or not
-* @prop {String} name The name of the role
-* @prop {Permission} permissions The permissions representation of the role
-* @prop {Number} position The position of the role
-* @prop {Object?} tags The tags of the role
-* @prop {String?} tags.bot_id The ID of the bot associated with the role
-* @prop {String?} tags.integration_id The ID of the integration associated with the role
-* @prop {Boolean?} tags.premium_subscriber Whether the role is the guild's premium subscriber role
-* @prop {String?} unicodeEmoji Unicode emoji for the role
+* @extends Base
 */
 class Role extends Base {
+    /**
+     * The ID of the role
+     * @member {String} Role#id
+     */
+    /**
+     * Timestamp of the role's creation
+     * @member {Number} Role#createdAt
+     */
     constructor(data, guild) {
         super(data.id);
+        /**
+         * The guild that owns the role
+         * @type {Guild}
+         */
         this.guild = guild;
         this.update(data);
     }
 
     update(data) {
         if(data.name !== undefined) {
+            /**
+             * The name of the role
+             * @type {String}
+             */
             this.name = data.name;
         }
         if(data.mentionable !== undefined) {
+            /**
+             * Whether the role is mentionable or not
+             * @type {Boolean}
+             */
             this.mentionable = data.mentionable;
         }
         if(data.managed !== undefined) {
+            /**
+             * Whether a guild integration manages this role or not
+             * @type {Boolean}
+             */
             this.managed = data.managed;
         }
         if(data.hoist !== undefined) {
+            /**
+             * Whether users with this role are hoisted in the user list or not
+             * @type {Boolean}
+             */
             this.hoist = data.hoist;
         }
         if(data.color !== undefined) {
+            /**
+             * The hex color of the role in base 10
+             * @type {Number}
+             */
             this.color = data.color;
         }
         if(data.position !== undefined) {
+            /**
+             * The position of the role
+             * @type {Number}
+             */
             this.position = data.position;
         }
         if(data.permissions !== undefined) {
+            /**
+             * The permissions representation of the role
+             * @type {Permission}
+             */
             this.permissions = new Permission(data.permissions);
         }
         if(data.tags !== undefined) {
+            /**
+             * The tags of the role
+             * @type {Object<string, string | boolean>}
+             * @prop {String?} bot_id The ID of the bot associated with the role
+             * @prop {String?} integration_id The ID of the integration associated with the role
+             * @prop {Boolean?} premium_subscriber Whether the role is the guild's premium subscriber role
+             */
             this.tags = data.tags;
             if(this.tags.guild_connections === null) {
                 this.tags.guild_connections = true;
@@ -69,24 +97,48 @@ class Role extends Base {
             }
         }
         if(data.icon !== undefined) {
+            /**
+             * The hash of the role's icon, or null if no icon
+             * @type {String?}
+             */
             this.icon = data.icon;
         }
         if(data.unicode_emoji !== undefined) {
+            /**
+             * Unicode emoji for the role
+             * @type {String?}
+             */
             this.unicodeEmoji = data.unicode_emoji;
         }
         if(data.flags !== undefined) {
+            /**
+             * Role flags. See [Discord's documentation](https://discord.com/developers/docs/topics/permissions#role-object-role-flags) for a list of them
+             * @type {Number}
+             */
             this.flags = data.flags;
         }
     }
 
+    /**
+     * The URL of the role's icon
+     * @type {String}
+     */
     get iconURL() {
         return this.icon ? this.guild.shard.client._formatImage(Endpoints.ROLE_ICON(this.id, this.icon)) : null;
     }
 
+    /**
+     * Generates a JSON representation of the role permissions
+     * @type {Object<string, boolean>}
+     */
     get json() {
         return this.permissions.json;
     }
 
+    /**
+     * A string that mentions the role
+     * @type {String}
+     */
     get mention() {
         return `<@&${this.id}>`;
     }

--- a/lib/structures/StageChannel.js
+++ b/lib/structures/StageChannel.js
@@ -3,7 +3,7 @@
 const TextVoiceChannel = require("./TextVoiceChannel");
 
 /**
-* Represents a guild stage channel. See TextVoiceChannel for more properties and methods.
+* Represents a guild stage channel.
 * @extends TextVoiceChannel
 */
 class StageChannel extends TextVoiceChannel {

--- a/lib/structures/StageInstance.js
+++ b/lib/structures/StageInstance.js
@@ -4,33 +4,55 @@ const Base = require("./Base");
 
 /**
 * Represents a stage instance
-* @prop {StageChannel} channel The associated stage channel
-* @prop {Boolean} discoverableDisabled [DEPRECATED] Whether or not stage discovery is disabled
-* @prop {Guild} guild The guild of the associated stage channel
-* @prop {GuildScheduledEvent} guildScheduledEvent The event associated with this instance
-* @prop {String} id The ID of the stage instance
-* @prop {Number} privacyLevel The privacy level of the stage instance. 1 is public (deprecated), 2 is guild only
-* @prop {String} topic The stage instance topic
 */
 class StageInstance extends Base {
+    /**
+     * The ID of the stage instance
+     * @member {String} StageInstance#id
+     */
     #client;
     constructor(data, client) {
         super(data.id);
         this.#client = client;
+        /**
+         * The associated stage channel
+         * @type {StageChannel}
+         */
         this.channel = client.getChannel(data.channel_id) || {id: data.channel_id};
+        /**
+         * The guild of the associated stage channel
+         * @type {Guild}
+         */
         this.guild = client.guilds.get(data.guild_id) || {id: data.guild_id};
+        /**
+         * The event associated with this instance
+         * @type {GuildScheduledEvent}
+         */
         this.guildScheduledEvent = this.guild.events?.get(data.guild_scheduled_event_id) || {id: data.guild_scheduled_event_id};
         this.update(data);
     }
 
     update(data) {
         if(data.discoverable_disabled !== undefined) {
+            /**
+             * Whether or not stage discovery is disabled
+             * @deprecated Deprecated in Discord's API
+             * @type {Boolean}
+             */
             this.discoverableDisabled = data.discoverable_disabled;
         }
         if(data.privacy_level !== undefined) {
+            /**
+             * The privacy level of the stage instance. 1 is public (deprecated), 2 is guild only
+             * @type {Number}
+             */
             this.privacyLevel = data.privacy_level;
         }
         if(data.topic !== undefined) {
+            /**
+             * The stage instance topic
+             * @type {String}
+             */
             this.topic = data.topic;
         }
     }

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -8,24 +8,31 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 /**
 * Represents a guild text channel. See GuildChannel for more properties and methods.
 * @extends GuildChannel
-* @prop {Number} defaultAutoArchiveDuration The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080)
-* @prop {String} lastMessageID The ID of the last message in this channel
-* @prop {Number} lastPinTimestamp The timestamp of the last pinned message
-* @prop {Collection<Message>} messages Collection of Messages in this channel
-* @prop {Boolean} nsfw Whether the channel is an NSFW channel or not
-* @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
-* @prop {Number} position The position of the channel
-* @prop {Number} rateLimitPerUser The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
-* @prop {String?} topic The topic of the channel
 */
 class TextChannel extends GuildChannel {
     #client;
     constructor(data, client, messageLimit) {
         super(data, client);
         this.#client = client;
+        /**
+         * Collection of Messages in this channel
+         * @type {Collection<Message>}
+         */
         this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
+        /**
+         * The ID of the last message in this channel
+         * @type {String?}
+         */
         this.lastMessageID = data.last_message_id || null;
+        /**
+         * The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
+         * @type {Number}
+         */
         this.rateLimitPerUser = data.rate_limit_per_user == null ? null : data.rate_limit_per_user;
+        /**
+         * The timestamp of the last pinned message
+         * @type {Number?}
+         */
         this.lastPinTimestamp = data.last_pin_timestamp ? Date.parse(data.last_pin_timestamp) : null;
     }
 
@@ -35,21 +42,41 @@ class TextChannel extends GuildChannel {
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
         if(data.topic !== undefined) {
+            /**
+             * The topic of the channel
+             * @type {String?}
+             */
             this.topic = data.topic;
         }
         if(data.default_auto_archive_duration !== undefined) {
+            /**
+             * The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080)
+             * @type {Number}
+             */
             this.defaultAutoArchiveDuration = data.default_auto_archive_duration;
         }
         if(data.permission_overwrites) {
+            /**
+             * Collection of PermissionOverwrites in this channel
+             * @type {Collection<PermissionOverwrite>}
+             */
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.position !== undefined) {
+            /**
+             * The position of the channel
+             * @type {Number}
+             */
             this.position = data.position;
         }
         if(data.nsfw !== undefined) {
+            /**
+             * Whether the channel is an NSFW channel or not
+             * @type {Boolean}
+             */
             this.nsfw = data.nsfw;
         }
     }

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -7,18 +7,26 @@ const Message = require("./Message");
 /**
 * Represents a Text-in-Voice channel. See VoiceChannel for more properties and methods.
 * @extends VoiceChannel
-* @prop {String} lastMessageID The ID of the last message in this channel
-* @prop {Collection<Message>} messages Collection of Messages in this channel
-* @prop {Number} rateLimitPerUser The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
-* @prop {Number?} userLimit The max number of users that can join the channel
-* @prop {Number?} videoQualityMode The camera video quality mode of the voice channel. `1` is auto, `2` is 720p
 */
 class TextVoiceChannel extends VoiceChannel {
     #client;
     constructor(data, client, messageLimit) {
         super(data, client);
         this.#client = client;
+        /**
+         * Collection of Messages in this channel
+         * @type {Collection<Message>}
+         */
         this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
+        /**
+         * Whether the channel is an NSFW channel or not
+         * @type {Boolean}
+         */
+        this.nsfw = data.nsfw;
+        /**
+         * The ID of the last message in this channel
+         * @type {String?}
+         */
         this.lastMessageID = data.last_message_id || null;
     }
 
@@ -26,12 +34,24 @@ class TextVoiceChannel extends VoiceChannel {
         super.update(data, client);
         // "not yet, possibly TBD"
         if(data.rate_limit_per_user !== undefined) {
+            /**
+             * The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
+             * @type {Number}
+             */
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
         if(data.user_limit !== undefined) {
+            /**
+             * The max number of users that can join the channel
+             * @type {Number?}
+             */
             this.userLimit = data.user_limit;
         }
         if(data.video_quality_mode !== undefined) {
+            /**
+             * The camera video quality mode of the voice channel. `1` is auto, `2` is 720p
+             * @type {Number?}
+             */
             this.videoQualityMode = data.video_quality_mode;
         }
     }

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -6,50 +6,64 @@ const Message = require("./Message");
 const ThreadMember = require("./ThreadMember");
 
 /**
-* Represents a thread channel. You also probably want to look at NewsThreadChannel, PublicThreadChannel, and PrivateThreadChannel. See GuildChannel for extra properties.
+* Represents a thread channel. You also probably want to look at NewsThreadChannel, PublicThreadChannel, and PrivateThreadChannel.
 * @extends GuildChannel
-* @prop {String} lastMessageID The ID of the last message in this channel
-* @prop {Object?} member Thread member for the current user, if they have joined the thread
-* @prop {Number} member.flags The user's thread settings
-* @prop {String} member.id The ID of the thread
-* @prop {Number} member.joinTimestamp The time the user last joined the thread
-* @prop {String} member.userID The ID of the user
-* @prop {Number} memberCount An approximate number of users in the thread (stops at 50)
-* @prop {Collection<ThreadMember>} members Collection of members in this channel
-* @prop {Number} messageCount An approximate number of messages in the thread
-* @prop {Collection<Message>} messages Collection of Messages in this channel
-* @prop {String} ownerID The ID of the user that created the thread
-* @prop {Number} rateLimitPerUser The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
-* @prop {Object} threadMetadata Metadata for the thread
-* @prop {Number} threadMetadata.archiveTimestamp Timestamp when the thread's archive status was last changed, used for calculating recent activity
-* @prop {Boolean} threadMetadata.archived Whether the thread is archived
-* @prop {Number} threadMetadata.autoArchiveDuration Duration in minutes to automatically archive the thread after recent activity, either 60, 1440, 4320 or 10080
-* @prop {Boolean} threadMetadata.locked Whether the thread is locked
-* @prop {Number} totalMessageSent The total amount of messages sent into the thread
 */
 class ThreadChannel extends GuildChannel {
     #client;
     constructor(data, client, messageLimit) {
         super(data, client);
         this.#client = client;
+        /**
+         * Collection of Messages in this channel
+         * @type {Collection<Message>}
+         */
         this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
+        /**
+         * Collection of members in this channel
+         * @type {Collection<ThreadMember>}
+         */
         this.members = new Collection(ThreadMember);
+        /**
+         * The ID of the last message in this channel
+         * @type {String?}
+         */
         this.lastMessageID = data.last_message_id || null;
+        /**
+         * The ID of the user that created the thread
+         * @type {String}
+         */
         this.ownerID = data.owner_id;
     }
 
     update(data, client) {
         super.update(data, client);
         if(data.member_count !== undefined) {
+            /**
+             * An approximate number of users in the thread (stops at 50)
+             * @type {Number}
+             */
             this.memberCount = data.member_count;
         }
         if(data.message_count !== undefined) {
+            /**
+             * An approximate number of messages in the thread
+             * @type {Number}
+             */
             this.messageCount = data.message_count;
         }
         if(data.rate_limit_per_user !== undefined) {
+            /**
+             * The ratelimit of the channel, in seconds. 0 means no ratelimit is enabled
+             * @type {Number}
+             */
             this.rateLimitPerUser = data.rate_limit_per_user;
         }
         if(data.thread_metadata !== undefined) {
+            /**
+             * Metadata for the thread
+             * @type {ThreadChannel.ThreadMetadata}
+             */
             this.threadMetadata = {
                 archiveTimestamp: Date.parse(data.thread_metadata.archive_timestamp),
                 archived: data.thread_metadata.archived,
@@ -59,9 +73,17 @@ class ThreadChannel extends GuildChannel {
             };
         }
         if(data.member !== undefined) {
+            /**
+             * Thread member for the current user, if they have joined the thread
+             * @type {ThreadMember?}
+             */
             this.member = new ThreadMember(data.member, client);
         }
         if(data.total_message_sent !== undefined) {
+            /**
+             * The total amount of messages sent into the thread
+             * @type {Number}
+             */
             this.totalMessageSent = data.total_message_sent;
         }
     }
@@ -328,3 +350,14 @@ class ThreadChannel extends GuildChannel {
 }
 
 module.exports = ThreadChannel;
+
+/**
+ * Metadata for the thread
+ * @typedef {Object} ThreadChannel.ThreadMetadata
+ * @prop {Number} archiveTimestamp Timestamp when the thread's archive status was last changed, used for calculating recent activity
+ * @prop {Boolean} archived Whether the thread is archived
+ * @prop {Number} autoArchiveDuration Duration in minutes to automatically archive the thread after recent activity, either 60, 1440, 4320 or 10080
+ * @prop {Number?} createTimestamp The timestamp when the thread was created
+ * @prop {Boolean} invitable Whether non-moderators can add other non-moderators to the thread (private thread channels only)
+ * @prop {Boolean} locked Whether the thread is locked
+ */

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -5,19 +5,31 @@ const Member = require("./Member");
 
 /**
 * Represents a thread member
-* @prop {Number} flags The user-thread settings of this member
-* @prop {Member?} guildMember The guild member that this thread member belongs to
-* @prop {String} id The ID of the thread member
-* @prop {Number} joinTimestamp Timestamp of when the member joined the thread
-* @prop {String} threadID The ID of the thread this member is a part of
+* @extends Base
 */
 class ThreadMember extends Base {
+    /**
+     * The ID of the thread member
+     * @member {String} ThreadMember#id
+     */
     #client;
     constructor(data, client) {
         super(data.user_id);
         this.#client = client;
+        /**
+         * The user-thread settings of this member
+         * @type {Number}
+         */
         this.flags = data.flags;
+        /**
+         * The ID of the thread this member is a part of
+         * @type {String}
+         */
         this.threadID = data.thread_id || data.id; // Thanks Discord
+        /**
+         * Timestamp of when the member joined the thread
+         * @type {Number}
+         */
         this.joinTimestamp = Date.parse(data.join_timestamp);
 
         if(data.member !== undefined) {
@@ -26,6 +38,10 @@ class ThreadMember extends Base {
             }
 
             const guild = this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
+            /**
+             * The guild member that this thread member belongs to
+             * @type {Member?}
+             */
             this.guildMember = guild ? guild.members.update(data.member, guild) : new Member(data.member, guild, client);
             if(data.presence !== undefined) {
                 this.guildMember.update(data.presence);

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -4,14 +4,24 @@ const Base = require("./Base");
 
 /**
 * Represents a guild
-* @prop {String} id The ID of the guild
-* @prop {Boolean} unavailable Whether the guild is unavailable or not
-* @prop {Shard} shard The Shard that owns the guild
+* @extends Base
 */
 class UnavailableGuild extends Base {
+    /**
+     * The ID of the guild
+     * @member {String} UnavailableGuild#id
+     */
     constructor(data, client) {
         super(data.id);
+        /**
+         * The shard that owns this guild
+         * @type {Shard}
+         */
         this.shard = client.shards.get(client.guildShardMap[this.id]);
+        /**
+         * Whether the guild is unavailable or not
+         * @type {Boolean}
+         */
         this.unavailable = !!data.unavailable;
     }
 

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -5,25 +5,18 @@ const Endpoints = require("../rest/Endpoints");
 
 /**
 * Represents a user
-* @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
-* @prop {String?} avatar The hash of the user's avatar, or null if no avatar
-* @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
-* @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
-* @prop {String?} bannerURL The URL of the user's banner
-* @prop {Boolean} bot Whether the user is an OAuth bot or not
-* @prop {Number} createdAt Timestamp of the user's creation
-* @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
-* @prop {String} defaultAvatarURL The URL of the user's default avatar
-* @prop {String} discriminator The discriminator of the user - if a single zero digit ("0"), the user is using the unique username system
-* @prop {String} id The ID of the user
-* @prop {String?} globalName The globally visible display name of the user
-* @prop {String} mention A string that mentions the user
-* @prop {Number?} publicFlags Publicly visible flags for this user
-* @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
-* @prop {Boolean} system Whether the user is an official Discord system user (e.g. urgent messages)
-* @prop {String} username The username of the user
+* @extends Base
 */
 class User extends Base {
+    /**
+     * The ID of the user
+     * @member {String} User#id
+     */
+    /**
+     * Timestamp of the user's creation
+     * @member {Number} User#createdAt
+     */
+
     #client;
     #missingClientError;
     constructor(data, client) {
@@ -32,35 +25,75 @@ class User extends Base {
             this.#missingClientError = new Error("Missing client in constructor"); // Preserve constructor callstack
         }
         this.#client = client;
+        /**
+         * Whether the user is an OAuth bot or not
+         * @type {Boolean}
+         */
         this.bot = !!data.bot;
+        /**
+         * Whether the user is an official Discord system user (e.g. urgent messages)
+         * @type {Boolean}
+         */
         this.system = !!data.system;
         this.update(data);
     }
 
     update(data) {
         if(data.avatar !== undefined) {
+            /**
+             * The hash of the user's avatar, or null if no avatar
+             * @type {String?}
+             */
             this.avatar = data.avatar;
         }
         if(data.username !== undefined) {
+            /**
+             * The username of the user
+             * @type {String}
+             */
             this.username = data.username;
         }
         if(data.discriminator !== undefined) {
+            /**
+             * The discriminator of the user - if a single zero digit ("0"), the user is using the unique username system
+             * @type {String}
+             */
             this.discriminator = data.discriminator;
         }
         if(data.public_flags !== undefined) {
+            /**
+             * Publicly visible flags for this user
+             * @type {Number?}
+             */
             this.publicFlags = data.public_flags;
         }
         if(data.banner !== undefined) {
+            /**
+             * The hash of the user's banner, or null if no banner (REST only)
+             * @type {String?}
+             */
             this.banner = data.banner;
         }
         if(data.accent_color !== undefined) {
+            /**
+             * The user's banner color, or null if no banner color (REST only)
+             * @type {Number?}
+             */
             this.accentColor = data.accent_color;
         }
         if(data.global_name !== undefined) {
+            /**
+             * The globally visible display name of the user
+             * @type {String?}
+             */
             this.globalName = data.global_name;
         }
     }
 
+    /**
+     * The URL of the user's avatar which can be either a JPG or GIF
+     * @type {String}
+     */
     get avatarURL() {
         if(this.#missingClientError) {
             throw this.#missingClientError;
@@ -68,6 +101,10 @@ class User extends Base {
         return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar)) : this.defaultAvatarURL;
     }
 
+    /**
+     * The URL of the user's banner
+     * @type {String?}
+     */
     get bannerURL() {
         if(!this.banner) {
             return null;
@@ -78,6 +115,10 @@ class User extends Base {
         return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner));
     }
 
+    /**
+     * The hash for the default avatar of a user if there is no avatar set
+     * @type {String}
+     */
     get defaultAvatar() {
         if(this.discriminator === "0") {
             return Base.getDiscordEpoch(this.id) % 6;
@@ -85,14 +126,26 @@ class User extends Base {
         return this.discriminator % 5;
     }
 
+    /**
+     * The URL of the user's default avatar
+     * @type {String}
+     */
     get defaultAvatarURL() {
         return `${Endpoints.CDN_URL}${Endpoints.DEFAULT_USER_AVATAR(this.defaultAvatar)}.png`;
     }
 
+    /**
+     * A string that mentions the user
+     * @type {String}
+     */
     get mention() {
         return `<@${this.id}>`;
     }
 
+    /**
+     * The URL of the user's avatar (always a JPG)
+     * @type {String}
+     */
     get staticAvatarURL() {
         if(this.#missingClientError) {
             throw this.#missingClientError;

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -8,18 +8,16 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 /**
 * Represents a guild voice channel. See GuildChannel for more properties and methods.
 * @extends GuildChannel
-* @prop {Number?} bitrate The bitrate of the channel
-* @prop {Boolean} nsfw Whether the channel is an NSFW channel or not
-* @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
-* @prop {Number} position The position of the channel
-* @prop {String?} rtcRegion The RTC region ID of the channel (automatic when `null`)
-* @prop {Collection<Member>} voiceMembers Collection of Members in this channel
 */
 class VoiceChannel extends GuildChannel {
     #client;
     constructor(data, client) {
         super(data, client);
         this.#client = client;
+        /**
+         * Collection of Members in this channel
+         * @type {Collection<Member>}
+         */
         this.voiceMembers = new Collection(Member);
     }
 
@@ -27,21 +25,41 @@ class VoiceChannel extends GuildChannel {
         super.update(data, client);
 
         if(data.bitrate !== undefined) {
+            /**
+             * The bitrate of the channel
+             * @type {Number?}
+             */
             this.bitrate = data.bitrate;
         }
         if(data.rtc_region !== undefined) {
+            /**
+             * The RTC region ID of the channel (automatic when `null`)
+             * @type {String?}
+             */
             this.rtcRegion = data.rtc_region;
         }
         if(data.permission_overwrites) {
+            /**
+             * Collection of PermissionOverwrites in this channel
+             * @type {Collection<PermissionOverwrite>}
+             */
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
                 this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.position !== undefined) {
+            /**
+             * The position of the channel
+             * @type {Number}
+             */
             this.position = data.position;
         }
         if(data.nsfw !== undefined) {
+            /**
+             * Whether the channel is an NSFW channel or not
+             * @type {Boolean}
+             */
             this.nsfw = data.nsfw;
         }
     }

--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -4,35 +4,69 @@ const Base = require("./Base");
 
 /**
 * Represents a member's voice state in a guild
-* @prop {String?} channelID The ID of the member's current voice channel
-* @prop {Boolean} deaf Whether the member is server deafened or not
-* @prop {String} id The ID of the member
-* @prop {Boolean} mute Whether the member is server muted or not
-* @prop {Number?} requestToSpeakTimestamp Timestamp of the member's latest request to speak
-* @prop {Boolean} selfDeaf Whether the member is self deafened or not
-* @prop {Boolean} selfMute Whether the member is self muted or not
-* @prop {Boolean} selfStream Whether the member is streaming using "Go Live"
-* @prop {Boolean} selfVideo Whether the member's camera is enabled
-* @prop {Boolean} suppress Whether the member is suppressed or not
-* @prop {String?} sessionID The ID of the member's current voice session
+* @extends Base
 */
 class VoiceState extends Base {
+    /**
+     * The ID of the member
+     * @member {String} VoiceState#id
+     */
     constructor(data) {
         super(data.id);
+        /**
+         * Whether the member is server muted or not
+         * @type {Boolean}
+         */
         this.mute = false;
+        /**
+         * Whether the member is server deafened or not
+         * @type {Boolean}
+         */
         this.deaf = false;
+        /**
+         * Timestamp of the member's latest request to speak
+         * @type {Number?}
+         */
         this.requestToSpeakTimestamp = null;
+        /**
+         * Whether the member is self muted or not
+         * @type {Boolean}
+         */
         this.selfMute = false;
+        /**
+         * Whether the member is self deafened or not
+         * @type {Boolean}
+         */
         this.selfDeaf = false;
+        /**
+         * Whether the member is streaming using "Go Live"
+         * @type {Boolean}
+         */
         this.selfStream = false;
+        /**
+         * Whether the member's camera is enabled
+         * @type {Boolean}
+         */
         this.selfVideo = false;
+        /**
+         * Whether the member is suppressed or not
+         * @type {Boolean}
+         */
         this.suppress = false;
         this.update(data);
     }
 
     update(data) {
         if(data.channel_id !== undefined) {
+            /**
+             * The ID of the member's current voice channel
+             * @type {String?}
+             */
             this.channelID = data.channel_id;
+            /**
+             * The ID of the member's current voice session
+             * @type {String?}
+             */
             this.sessionID = data.channel_id === null ? null : data.session_id;
         } else if(this.channelID === undefined) {
             this.channelID = this.sessionID = null;

--- a/lib/util/BrowserWebSocket.js
+++ b/lib/util/BrowserWebSocket.js
@@ -18,10 +18,13 @@ class BrowserWebSocketError extends Error {
 /**
 * Represents a browser's websocket usable by Dysnomia
 * @extends EventEmitter
-* @prop {String} url The URL to connect to
 */
 class BrowserWebSocket extends EventEmitter {
     #ws;
+    /**
+     * Creates a browser web socket
+     * @param {String} url The URL to connect to
+     */
     constructor(url) {
         super();
 

--- a/lib/util/Bucket.js
+++ b/lib/util/Bucket.js
@@ -5,16 +5,23 @@ const Base = require("../structures/Base");
 
 /**
 * Handle ratelimiting something
-* @prop {Number} interval How long (in ms) to wait between clearing used tokens
-* @prop {Number} lastReset Timestamp of last token clearing
-* @prop {Number} lastSend Timestamp of last token consumption
-* @prop {Number} tokenLimit The max number tokens the bucket can consume per interval
-* @prop {Number} tokens How many tokens the bucket has consumed in this interval
 */
 class Bucket {
     #queue = [];
+    /**
+     * Timestamp of last token clearing
+     * @type {Number}
+     */
     lastReset = 0;
+    /**
+     * Timestamp of last token consumption
+     * @type {Number}
+     */
     lastSend = 0;
+    /**
+     * How many tokens the bucket has consumed in this interval
+     * @type {Number}
+     */
     tokens = 0;
     /**
     * Construct a Bucket
@@ -26,7 +33,15 @@ class Bucket {
     * @arg {Number} options.reservedTokens How many tokens to reserve for priority operations
     */
     constructor(tokenLimit, interval, options = {}) {
+        /**
+         * The max number tokens the bucket can consume per interval
+         * @type {Number}
+         */
         this.tokenLimit = tokenLimit;
+        /**
+         * How long (in ms) to wait between clearing used tokens
+         * @type {Number}
+         */
         this.interval = interval;
         this.latencyRef = options.latencyRef || {latency: 0};
         this.reservedTokens = options.reservedTokens || 0;

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -2,9 +2,8 @@
 
 /**
 * Hold a bunch of something
-* @extends Map
-* @prop {Class} baseObject The base class for all items
-* @prop {Number?} limit Max number of items to hold
+* @template Class
+* @extends Map<Class>
 */
 class Collection extends Map {
     /**
@@ -14,7 +13,15 @@ class Collection extends Map {
     */
     constructor(baseObject, limit) {
         super();
+        /**
+         * The base class for all items
+         * @type {Class}
+         */
         this.baseObject = baseObject;
+        /**
+         * Max number of items to hold
+         * @type {Number?}
+         */
         this.limit = limit;
     }
 

--- a/lib/util/SequentialBucket.js
+++ b/lib/util/SequentialBucket.js
@@ -6,15 +6,24 @@ const Base = require("../structures/Base");
 /**
 * Ratelimit requests and release in sequence
 * TODO: add latencyref
-* @prop {Number} limit How many tokens the bucket can consume in the current interval
-* @prop {Boolean} processing Whether the queue is being processed
-* @prop {Number} remaining How many tokens the bucket has left in the current interval
-* @prop {Number} reset Timestamp of next reset
 */
 class SequentialBucket {
     #queue = [];
+    /**
+     * Whether the queue is being processed
+     * @type {Boolean}
+     */
     processing = false;
+    /**
+     * Timestamp of next reset
+     * @type {Number}
+     */
     reset = 0;
+    /**
+     * How many tokens the bucket has left in the current interval
+     * @member {Number} SequentialBucket#remaining
+     */
+
     /**
     * Construct a SequentialBucket
     * @arg {Number} limit The max number of tokens the bucket can consume per interval
@@ -22,6 +31,10 @@ class SequentialBucket {
     * @arg {Number} latencyRef.latency Interval between consuming tokens
     */
     constructor(limit, latencyRef = {latency: 0}) {
+        /**
+         * How many tokens the bucket can consume in the current interval
+         * @type {Number}
+         */
         this.limit = this.remaining = limit;
         this.latencyRef = latencyRef;
     }

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -17,20 +17,27 @@ try {
 /**
 * Represents a collection of VoiceConnections sharing an input stream
 * @extends EventEmitter
-* @prop {Object?} current The current stream
-* @prop {Boolean} ended Whether the stream ended
-* @prop {Boolean} playing Whether the voice connection is playing something
-* @prop {Boolean} speaking Whether someone is speaking
-* @prop {Number} volume The current volume level of the connection
 */
 class SharedStream extends EventEmitter {
     #send;
     bitrate = 64_000;
     channels = 2;
+    /**
+     * Whether the stream ended
+     * @type {Boolean}
+     */
     ended = true;
     frameDuration = 20;
+    /**
+     * Whether the voice connection is playing something
+     * @type {Boolean}
+     */
     playing = false;
     samplingRate = 48_000;
+    /**
+     * Whether someone is speaking
+     * @type {Boolean}
+     */
     speaking = false;
     voiceConnections = new Collection(VoiceConnection);
 
@@ -55,6 +62,10 @@ class SharedStream extends EventEmitter {
         this.#send = this.#sendUnbound.bind(this);
     }
 
+    /**
+     * The current volume level of the connection
+     * @type {Number}
+     */
     get volume() {
         return this.piper.volumeLevel;
     }
@@ -106,6 +117,10 @@ class SharedStream extends EventEmitter {
         }
 
         this.ended = false;
+        /**
+         * The current stream
+         * @type {VoiceConnection.CurrentState}
+         */
         this.current = {
             startTime: 0, // later
             playTime: 0,

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -54,37 +54,32 @@ converterCommand.pickCommand = function pickCommand() {
 /**
 * Represents a voice connection
 * @extends EventEmitter
-* @prop {String} channelID The ID of the voice connection's current channel
-* @prop {Boolean} connecting Whether the voice connection is connecting
-* @prop {Object?} current The state of the currently playing stream
-* @prop {Object} current.options The custom options for the current stream
-* @prop {Array<String>?} current.options.encoderArgs Additional encoder parameters to pass to ffmpeg/avconv (after -i)
-* @prop {String?} current.options.format The format of the resource. If null, FFmpeg will attempt to guess and play the format. Available options: "dca", "ogg", "webm", "pcm", null
-* @prop {Number?} current.options.frameDuration The resource opus frame duration (required for DCA/Ogg)
-* @prop {Number?} current.options.frameSize The resource opus frame size
-* @prop {Boolean?} current.options.inlineVolume Whether to enable on-the-fly volume changing. Note that enabling this leads to increased CPU usage
-* @prop {Array<String>?} current.options.inputArgs Additional input parameters to pass to ffmpeg/avconv (before -i)
-* @prop {Number?} current.options.sampleRate The resource audio sampling rate
-* @prop {Number?} current.options.voiceDataTimeout Timeout when waiting for voice data (-1 for no timeout)
-* @prop {Number} current.pausedTime How long the current stream has been paused for, in milliseconds
-* @prop {Number} current.pausedTimestamp The timestamp of the most recent pause
-* @prop {Number} current.playTime How long the current stream has been playing for, in milliseconds
-* @prop {Number} current.startTime The timestamp of the start of the current stream
-* @prop {String} id The guild ID of the voice connection
-* @prop {Boolean} paused Whether the voice connection is paused
-* @prop {Boolean} playing Whether the voice connection is playing something
-* @prop {Boolean} ready Whether the voice connection is ready
-* @prop {Number} volume The current volume level of the connection
 */
 class VoiceConnection extends EventEmitter {
     #send;
     bitrate = 64_000;
+    /**
+     * The ID of the voice connection's current channel
+     * @type {String}
+     */
     channelID = null;
     channels = 2;
+    /**
+     * Whether the voice connection is connecting
+     * @type {Boolean}
+     */
     connecting = false;
     connectionTimeout = null;
     frameDuration = 20;
+    /**
+     * Whether the voice connection is paused
+     * @type {Boolean}
+     */
     paused = true;
+    /**
+     * Whether the voice connection is ready
+     * @type {Boolean}
+     */
     ready = false;
     reconnecting = false;
     samplingRate = 48_000;
@@ -121,6 +116,10 @@ class VoiceConnection extends EventEmitter {
             }
         }
 
+        /**
+         * The guild ID of the voice connection
+         * @type {String}
+         */
         this.id = id;
         this.shared = !!options.shared;
         this.shard = options.shard || {};
@@ -153,6 +152,10 @@ class VoiceConnection extends EventEmitter {
         this.#send = this.#sendUnbound.bind(this);
     }
 
+    /**
+     * The current volume level of the connection
+     * @type {Number}
+     */
     get volume() {
         return this.piper.volumeLevel;
     }
@@ -518,6 +521,10 @@ class VoiceConnection extends EventEmitter {
         }
 
         this.ended = false;
+        /**
+         * The state of the currently playing stream
+         * @type {VoiceConnection.CurrentState}
+         */
         this.current = {
             startTime: 0, // later
             playTime: 0,
@@ -529,6 +536,10 @@ class VoiceConnection extends EventEmitter {
             buffer: null
         };
 
+        /**
+         * Whether the voice connection is playing something
+         * @type {Boolean}
+         */
         this.playing = true;
 
         /**
@@ -649,7 +660,7 @@ class VoiceConnection extends EventEmitter {
         this.timestamp = (this.timestamp + frameSize) >>> 0;
         this.sequence = (this.sequence + 1) & 0xFFFF;
 
-        return this.#sendAudioFrame(frame);
+        return this._sendAudioFrame(frame);
     }
 
     /**
@@ -805,7 +816,7 @@ class VoiceConnection extends EventEmitter {
         this.current.timeout = setTimeout(this.#send, this.current.startTime + this.current.pausedTime + this.current.playTime - Date.now());
     }
 
-    #sendAudioFrame(frame) {
+    _sendAudioFrame(frame) {
         this.sendNonce.writeUInt16BE(this.sequence, 2);
         this.sendNonce.writeUInt32BE(this.timestamp, 4);
 
@@ -856,3 +867,26 @@ class VoiceConnection extends EventEmitter {
 VoiceConnection._converterCommand = converterCommand;
 
 module.exports = VoiceConnection;
+
+/**
+ * The state of the currently playing stream
+ * @typedef VoiceConnection.CurrentState
+ * @prop {VoiceConnection.CurrentStateOptions} options The custom options for the current stream
+ * @prop {Number} pausedTime How long the current stream has been paused for, in milliseconds
+ * @prop {Number} pausedTimestamp The timestamp of the most recent pause
+ * @prop {Number} playTime How long the current stream has been playing for, in milliseconds
+ * @prop {Number} startTime The timestamp of the start of the current stream
+ */
+
+/**
+ * The custom options for the current stream
+ * @typedef VoiceConnection.CurrentStateOptions
+ * @prop {Array<String>?} encoderArgs Additional encoder parameters to pass to ffmpeg/avconv (after -i)
+ * @prop {String?} format The format of the resource. If null, FFmpeg will attempt to guess and play the format. Available options: "dca", "ogg", "webm", "pcm", null
+ * @prop {Number?} frameDuration The resource opus frame duration (required for DCA/Ogg)
+ * @prop {Number?} frameSize The resource opus frame size
+ * @prop {Boolean?} inlineVolume Whether to enable on-the-fly volume changing. Note that enabling this leads to increased CPU usage
+ * @prop {Array<String>?} inputArgs Additional input parameters to pass to ffmpeg/avconv (before -i)
+ * @prop {Number?} sampleRate The resource audio sampling rate
+ * @prop {Number?} voiceDataTimeout Timeout when waiting for voice data (-1 for no timeout)
+ */

--- a/lib/voice/VoiceDataStream.js
+++ b/lib/voice/VoiceDataStream.js
@@ -10,11 +10,14 @@ try {
 /**
 * Represents a voice data stream
 * @extends EventEmitter
-* @prop {String} type The targeted voice data type for the stream, either "opus" or "pcm"
 */
 class VoiceDataStream extends EventEmitter {
     constructor(type) {
         super();
+        /**
+         * The targeted voice data type for the stream, either "opus" or "pcm"
+         * @type {String}
+         */
         this.type = type;
     }
 }


### PR DESCRIPTION
This PR aims to aid proper JSDoc generation with correct inheritance by moving away from `@prop` inline statements at the class declaration down to their respective assignments.