### PR TITLE
fix(Client): wrong request url in editGuildWidget

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1692,7 +1692,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} A guild widget object
     */
     editGuildWidget(guildID, options) {
-        return this.requestHandler.request("PATCH", Endpoints.GUILD_WIDGET(guildID), true, options);
+        return this.requestHandler.request("PATCH", Endpoints.GUILD_WIDGET_SETTINGS(guildID), true, options);
     }
 
     /**


### PR DESCRIPTION
Fixes wrong endpoint used in edtGuildWidget, it was requesting to widget.json instead of widget for some reason