### PR TITLE
fix(Shard): wrong options used in shard

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -116,7 +116,7 @@ class Shard extends EventEmitter {
     createGuild(_guild) {
         this.client.guildShardMap[_guild.id] = this.id;
         const guild = this.client.guilds.add(_guild, this.client, true);
-        if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
+        if(this.client.shards.options.getAllUsers && guild.members.size < guild.memberCount) {
             this.getAllUsersCount[guild.id] = true;
             this.requestGuildMembers(guild.id, {
                 presences: this.client.shards.options.intents && this.client.shards.options.intents & Constants.Intents.guildPresences
@@ -1719,7 +1719,7 @@ class Shard extends EventEmitter {
                 } else {
                     this.resumeURL = `${packet.d.resume_gateway_url}?v=${Constants.GATEWAY_VERSION}&encoding=${Erlpack ? "etf" : "json"}`;
 
-                    if(this.client.options.compress) {
+                    if(this.client.shards.options.compress) {
                         this.resumeURL += "&compress=zlib-stream";
                     }
                 }


### PR DESCRIPTION
**Problem**
In the file `Shard.js` there are currently 2 options loaded through `this.client.options` but the doc within the `Client.js` file shows that they should be within `options.gateway`. The options listed under `.gateway` aren't accessible within `this.client.options`.

**Solution**
Load the shard options instead (`this.client.shards.options`) for does 2 options