### PR TITLE
refactor: reduce dependency on the Client class

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -28,6 +28,9 @@ const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
 const AutoModerationRule = require("./structures/AutoModerationRule");
 const emitDeprecation = require("./util/emitDeprecation");
+const formatAllowedMentions = require("./util/formatAllowedMentions");
+const processAttachments = require("./util/processAttachments");
+
 
 let EventEmitter;
 try {
@@ -170,21 +173,8 @@ class Client extends EventEmitter {
          * Dysnomia options
          * @type {Object}
          */
-        this.options = Object.assign({
-            allowedMentions: {
-                users: true,
-                roles: true
-            },
-            defaultImageFormat: "jpg",
-            defaultImageSize: 128,
-            messageLimit: 100,
-            opusOnly: false,
-            rest: {},
-            restMode: false,
-            ws: {},
-            gateway: {}
-        }, options);
-        this.options.allowedMentions = this._formatAllowedMentions(this.options.allowedMentions);
+        this.options = Object.assign({}, Constants.DefaultClientOptions, options);
+        this.options.allowedMentions = formatAllowedMentions(this.options.allowedMentions, this);
         if(!Constants.ImageFormats.includes(this.options.defaultImageFormat.toLowerCase())) {
             throw new TypeError(`Invalid default image format: ${this.options.defaultImageFormat}`);
         }
@@ -797,7 +787,7 @@ class Client extends EventEmitter {
             } else if(content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
             }
-            content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+            content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this);
             content.sticker_ids = content.stickerIDs;
             if(content.messageReference) {
                 content.message_reference = content.messageReference;
@@ -820,7 +810,7 @@ class Client extends EventEmitter {
             }
         }
 
-        const {files, attachments} = this._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.requestHandler.request("POST", Endpoints.CHANNEL_MESSAGES(channelID), true, content, files).then((message) => new Message(message, this));
@@ -913,11 +903,11 @@ class Client extends EventEmitter {
             if(options.message.content !== undefined && typeof options.message.content !== "string") {
                 options.message.content = "" + options.message.content;
             }
-            options.message.allowed_mentions = this._formatAllowedMentions(options.message.allowedMentions);
+            options.message.allowed_mentions = formatAllowedMentions(options.message.allowedMentions, this);
             options.message.sticker_ids = options.message.stickerIDs;
         }
 
-        const {files, attachments} = options.message ? this._processAttachments(options.message.attachments) : {};
+        const {files, attachments} = options.message ? processAttachments(options.message.attachments) : {};
         if(options.message) {
             options.message.attachments = attachments;
         }
@@ -1734,11 +1724,11 @@ class Client extends EventEmitter {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this);
             }
         }
 
-        const {files, attachments} = content.attachments ? this._processAttachments(content.attachments) : [];
+        const {files, attachments} = content.attachments ? processAttachments(content.attachments) : {};
         content.attachments = attachments;
 
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content, files).then((message) => new Message(message, this));
@@ -1920,10 +1910,10 @@ class Client extends EventEmitter {
             qs += "&thread_id=" + options.threadID;
         }
         if(options.allowedMentions) {
-            options.allowed_mentions = this._formatAllowedMentions(options.allowedMentions);
+            options.allowed_mentions = formatAllowedMentions(options.allowedMentions, this);
         }
 
-        const {files, attachments} = options.attachments ? this._processAttachments(options.attachments) : [];
+        const {files, attachments} = options.attachments ? processAttachments(options.attachments) : {};
         options.attachments = attachments;
 
         return this.requestHandler.request("PATCH", Endpoints.WEBHOOK_MESSAGE(webhookID, token, messageID) + (qs ? "?" + qs : ""), false, options, files).then((response) => new Message(response, this));
@@ -1991,7 +1981,7 @@ class Client extends EventEmitter {
             qs += "&thread_id=" + options.threadID;
         }
 
-        const {files, attachments} = options.attachments ? this._processAttachments(options.attachments) : [];
+        const {files, attachments} = options.attachments ? processAttachments(options.attachments) : {};
 
         return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (qs ? "?" + qs : ""), !!options.auth, {
             content: options.content,
@@ -2000,7 +1990,7 @@ class Client extends EventEmitter {
             avatar_url: options.avatarURL,
             tts: options.tts,
             flags: options.flags,
-            allowed_mentions: this._formatAllowedMentions(options.allowedMentions),
+            allowed_mentions: formatAllowedMentions(options.allowedMentions, this),
             components: options.components,
             attachments: attachments,
             thread_name: options.threadName
@@ -3179,79 +3169,6 @@ class Client extends EventEmitter {
     */
     unpinMessage(channelID, messageID) {
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_PIN(channelID, messageID), true);
-    }
-
-    _formatAllowedMentions(allowed) {
-        if(!allowed) {
-            return this.options.allowedMentions;
-        }
-        const result = {
-            parse: []
-        };
-        if(allowed.everyone) {
-            result.parse.push("everyone");
-        }
-        if(allowed.roles === true) {
-            result.parse.push("roles");
-        } else if(Array.isArray(allowed.roles)) {
-            if(allowed.roles.length > 100) {
-                throw new Error("Allowed role mentions cannot exceed 100.");
-            }
-            result.roles = allowed.roles;
-        }
-        if(allowed.users === true) {
-            result.parse.push("users");
-        } else if(Array.isArray(allowed.users)) {
-            if(allowed.users.length > 100) {
-                throw new Error("Allowed user mentions cannot exceed 100.");
-            }
-            result.users = allowed.users;
-        }
-        if(allowed.repliedUser !== undefined) {
-            result.replied_user = allowed.repliedUser;
-        }
-        return result;
-    }
-
-    _formatImage(url, format, size) {
-        if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
-            format = url.includes("/a_") ? "gif" : this.options.defaultImageFormat;
-        }
-        if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
-            size = this.options.defaultImageSize;
-        }
-        return `${Endpoints.CDN_URL}${url}.${format}?size=${size}`;
-    }
-
-    _processAttachments(attachments) {
-        if(!attachments) {
-            return {};
-        }
-        const files = [];
-        const resultAttachments = [];
-
-        attachments.forEach((attachment, idx) => {
-            if(attachment.id) {
-                resultAttachments.push(attachment);
-            } else {
-                files.push({
-                    fieldName: `files[${idx}]`,
-                    file: attachment.file,
-                    name: attachment.filename
-                });
-
-                resultAttachments.push({
-                    ...attachment,
-                    file: undefined,
-                    id: idx
-                });
-            }
-        });
-
-        return {
-            files: files.length ? files : undefined,
-            attachments: resultAttachments
-        };
     }
 
     toString() {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -218,6 +218,21 @@ module.exports.ConnectionVisibilityTypes = {
     EVERYONE: 1
 };
 
+module.exports.DefaultClientOptions = Object.freeze({
+    allowedMentions: {
+        users: true,
+        roles: true
+    },
+    defaultImageFormat: "jpg",
+    defaultImageSize: 128,
+    messageLimit: 100,
+    opusOnly: false,
+    rest: {},
+    restMode: false,
+    ws: {},
+    gateway: {}
+});
+
 module.exports.DefaultMessageNotificationLevels = {
     ALL_MESSAGES:  0,
     ONLY_MENTIONS: 1

--- a/lib/structures/AutoModerationRule.js
+++ b/lib/structures/AutoModerationRule.js
@@ -19,10 +19,7 @@ class AutoModerationRule extends Base {
          * An array of [auto moderation action objects](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object)
          * @type {Array<Object>}
          */
-        this.actions = data.actions.map((action) => ({
-            type: action.type,
-            metadata: action.metadata
-        }));
+        this.actions = data.actions;
         /**
          * The ID of the user who created this auto moderation rule
          * @type {String}

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -9,10 +9,6 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 * @extends GuildChannel
 */
 class CategoryChannel extends GuildChannel {
-    constructor(data, client) {
-        super(data, client);
-    }
-
     update(data, client) {
         super.update(data, client);
         if(data.permission_overwrites) {

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -8,8 +8,10 @@ const Channel = require("./Channel");
 const Message = require("./Message");
 const Attachment = require("./Attachment");
 const Collection = require("../util/Collection");
+const formatAllowedMentions = require("../util/formatAllowedMentions");
 
 const {InteractionResponseTypes} = require("../Constants");
+const processAttachments = require("../util/processAttachments");
 
 /**
 * Represents an application command interaction.
@@ -164,11 +166,11 @@ class CommandInteraction extends Interaction {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this.#client);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -7,8 +7,10 @@ const Role = require("./Role");
 const Channel = require("./Channel");
 const Message = require("./Message");
 const Collection = require("../util/Collection");
+const formatAllowedMentions = require("../util/formatAllowedMentions");
 
 const {InteractionResponseTypes} = require("../Constants");
+const processAttachments = require("../util/processAttachments");
 
 /**
 * Represents a message component interaction.
@@ -153,11 +155,11 @@ class ComponentInteraction extends Interaction {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this.#client);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
@@ -341,11 +343,11 @@ class ComponentInteraction extends Interaction {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this.#client);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/ExtendedUser.js
+++ b/lib/structures/ExtendedUser.js
@@ -7,10 +7,6 @@ const User = require("./User");
 * @extends User
 */
 class ExtendedUser extends User {
-    constructor(data, client) {
-        super(data, client);
-    }
-
     update(data) {
         super.update(data);
         if(data.email !== undefined) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -13,6 +13,7 @@ const GuildScheduledEvent = require("./GuildScheduledEvent");
 const {Permissions} = require("../Constants");
 const StageInstance = require("./StageInstance");
 const ThreadChannel = require("./ThreadChannel");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a guild
@@ -457,7 +458,7 @@ class Guild extends Base {
      * @type {String?}
      */
     get bannerURL() {
-        return this.banner ? this.#client._formatImage(Endpoints.BANNER(this.id, this.banner)) : null;
+        return this.banner ? formatImage(Endpoints.BANNER(this.id, this.banner), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -465,7 +466,7 @@ class Guild extends Base {
      * @type {String?}
      */
     get iconURL() {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon)) : null;
+        return this.icon ? formatImage(Endpoints.GUILD_ICON(this.id, this.icon), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -473,7 +474,7 @@ class Guild extends Base {
      * @type {String?}
      */
     get splashURL() {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash)) : null;
+        return this.splash ? formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -481,7 +482,7 @@ class Guild extends Base {
      * @type {String?}
      */
     get discoverySplashURL() {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash)) : null;
+        return this.discoverySplash ? formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -768,7 +769,7 @@ class Guild extends Base {
     * @returns {String?}
     */
     dynamicBannerURL(format, size) {
-        return this.banner ? this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size) : null;
+        return this.banner ? formatImage(Endpoints.BANNER(this.id, this.banner), format, size, this.#client) : null;
     }
 
     /**
@@ -778,7 +779,7 @@ class Guild extends Base {
      * @returns {String?}
      */
     dynamicDiscoverySplashURL(format, size) {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size) : null;
+        return this.discoverySplash ? formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size, this.#client) : null;
     }
 
     /**
@@ -788,7 +789,7 @@ class Guild extends Base {
     * @returns {String?}
     */
     dynamicIconURL(format, size) {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
+        return this.icon ? formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size, this.#client) : null;
     }
 
     /**
@@ -798,7 +799,7 @@ class Guild extends Base {
     * @returns {String?}
     */
     dynamicSplashURL(format, size) {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
+        return this.splash ? formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size, this.#client) : null;
     }
 
     /**

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -17,7 +17,7 @@ class GuildChannel extends Channel {
          * The guild that owns the channel
          * @type {Guild}
          */
-        this.guild = client.guilds.get(data.guild_id) || {
+        this.guild = client?.guilds.get(data.guild_id) || {
             id: data.guild_id
         };
 

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -2,6 +2,7 @@
 
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints.js");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a GuildPreview structure
@@ -74,7 +75,7 @@ class GuildPreview extends Base {
      * @type {String?}
      */
     get iconURL() {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon)) : null;
+        return this.icon ? formatImage(Endpoints.GUILD_ICON(this.id, this.icon), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -82,7 +83,7 @@ class GuildPreview extends Base {
      * @type {String?}
      */
     get splashURL() {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash)) : null;
+        return this.splash ? formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -90,7 +91,7 @@ class GuildPreview extends Base {
      * @type {String?}
      */
     get discoverySplashURL() {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash)) : null;
+        return this.discoverySplash ? formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), undefined, undefined, this.#client) : null;
     }
 
     /**
@@ -100,7 +101,7 @@ class GuildPreview extends Base {
     * @returns {String?}
     */
     dynamicDiscoverySplashURL(format, size) {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size) : null;
+        return this.discoverySplash ? formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size, this.#client) : null;
     }
 
     /**
@@ -110,7 +111,7 @@ class GuildPreview extends Base {
     * @returns {String?}
     */
     dynamicIconURL(format, size) {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
+        return this.icon ? formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size, this.#client) : null;
     }
 
     /**
@@ -120,7 +121,7 @@ class GuildPreview extends Base {
     * @returns {String?}
     */
     dynamicSplashURL(format, size) {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
+        return this.splash ? formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size, this.#client) : null;
     }
 
     toJSON(props = []) {

--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -2,6 +2,7 @@
 
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a guild scheduled event
@@ -133,7 +134,7 @@ class GuildScheduledEvent extends Base {
      * @type {String?}
      */
     get imageURL() {
-        return this.image ? this.#client._formatImage(Endpoints.GUILD_SCHEDULED_EVENT_COVER(this.id, this.image)) : null;
+        return this.image ? formatImage(Endpoints.GUILD_SCHEDULED_EVENT_COVER(this.id, this.image), undefined, undefined, this.#client) : null;
     }
 
     /**

--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -2,6 +2,7 @@
 
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
+const User = require("./User");
 const formatImage = require("../util/formatImage");
 
 /**
@@ -23,7 +24,7 @@ class GuildScheduledEvent extends Base {
              * The user that created the scheduled event. For events created before October 25 2021, this will be null. Please see the relevant Discord documentation for more details
              * @type {User?}
              */
-            this.creator = client.users.update(data.creator, this.client);
+            this.creator = client?.users.update(data.creator, this.#client) ?? new User(data.creator, this.#client);
         } else {
             this.creator = null;
         }
@@ -31,7 +32,7 @@ class GuildScheduledEvent extends Base {
          * The guild which the event belongs to. Can be partial with only `id` if not cached
          * @type {Guild | Object}
          */
-        this.guild = client.guilds.get(data.guild_id) || {
+        this.guild = client?.guilds.get(data.guild_id) || {
             id: data.guild_id
         };
         /**

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -1,5 +1,6 @@
 const Base = require("./Base");
 const Guild = require("./Guild");
+const User = require("./User");
 
 /**
 * Represents a guild template
@@ -22,7 +23,7 @@ class GuildTemplate {
          * The user that created the template
          * @type {User}
          */
-        this.creator = client.users.update(data.creator, client);
+        this.creator = client?.users.update(data.creator, client) ?? new User(data.creator, client);
         /**
          * The template description
          * @type {String?}
@@ -47,7 +48,7 @@ class GuildTemplate {
          * The guild this template is based on. If the guild is not cached, this will be an object with `id` key. No other property is guaranteed
          * @type {Guild | Object}
          */
-        this.sourceGuild = client.guilds.get(data.source_guild_id) || {id: data.source_guild_id};
+        this.sourceGuild = client?.guilds.get(data.source_guild_id) || {id: data.source_guild_id};
         /**
          * Timestamp of template update
          * @type {Number}

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -4,6 +4,7 @@ const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
 const User = require("./User");
 const VoiceState = require("./VoiceState");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a server member
@@ -158,7 +159,7 @@ class Member extends Base {
      * @type {String}
      */
     get avatarURL() {
-        return this.avatar ? this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar)) : this.user.avatarURL;
+        return this.avatar ? formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), undefined, undefined, this.guild.shard.client) : this.user.avatarURL;
     }
 
     /**
@@ -305,7 +306,7 @@ class Member extends Base {
         if(!this.avatar) {
             return this.user.dynamicAvatarURL(format, size);
         }
-        return this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size);
+        return formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size, this.guild.shard.client);
     }
     /**
     * Edit the guild member

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -1,8 +1,10 @@
 "use strict";
 
 const Interaction = require("./Interaction");
+const formatAllowedMentions = require("../util/formatAllowedMentions");
 
 const {InteractionResponseTypes} = require("../Constants");
+const processAttachments = require("../util/processAttachments");
 
 /**
 * Represents a modal submit interaction.
@@ -98,11 +100,11 @@ class ModalSubmitInteraction extends Interaction {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this.#client);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
@@ -270,11 +272,11 @@ class ModalSubmitInteraction extends Interaction {
                 content.content = "" + content.content;
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
-                content.allowed_mentions = this.#client._formatAllowedMentions(content.allowedMentions);
+                content.allowed_mentions = formatAllowedMentions(content.allowedMentions, this.#client);
             }
         }
 
-        const {files, attachments} = this.#client._processAttachments(content.attachments);
+        const {files, attachments} = processAttachments(content.attachments);
         content.attachments = attachments;
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/NewsThreadChannel.js
+++ b/lib/structures/NewsThreadChannel.js
@@ -6,10 +6,6 @@ const ThreadChannel = require("./ThreadChannel");
 * Represents a news thread channel.
 * @extends ThreadChannel
 */
-class NewsThreadChannel extends ThreadChannel {
-    constructor(data, client, messageLimit) {
-        super(data, client, messageLimit);
-    }
-}
+class NewsThreadChannel extends ThreadChannel {}
 
 module.exports = NewsThreadChannel;

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -3,7 +3,7 @@
 const Channel = require("./Channel");
 const Collection = require("../util/Collection");
 const Message = require("./Message");
-const {ChannelTypes} = require("../Constants");
+const {ChannelTypes, DefaultClientOptions} = require("../Constants");
 const User = require("./User");
 
 /**
@@ -33,7 +33,7 @@ class PrivateChannel extends Channel {
          * Collection of Messages in this channel
          * @type {Collection<Message>}
          */
-        this.messages = new Collection(Message, client.options.messageLimit);
+        this.messages = new Collection(Message, client?.options.messageLimit ?? DefaultClientOptions.messageLimit);
     }
 
     /**

--- a/lib/structures/PrivateThreadChannel.js
+++ b/lib/structures/PrivateThreadChannel.js
@@ -7,10 +7,6 @@ const ThreadChannel = require("./ThreadChannel");
 * @extends ThreadChannel
 */
 class PrivateThreadChannel extends ThreadChannel {
-    constructor(data, client, messageLimit) {
-        super(data, client, messageLimit);
-    }
-
     update(data, client) {
         super.update(data, client);
         if(data.thread_metadata !== undefined) {

--- a/lib/structures/PublicThreadChannel.js
+++ b/lib/structures/PublicThreadChannel.js
@@ -7,10 +7,6 @@ const ThreadChannel = require("./ThreadChannel");
 * @extends ThreadChannel
 */
 class PublicThreadChannel extends ThreadChannel {
-    constructor(data, client, messageLimit) {
-        super(data, client, messageLimit);
-    }
-
     update(data, client) {
         super.update(data, client);
         if(data.applied_tags !== undefined) {

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -3,6 +3,7 @@
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
 const Permission = require("./Permission");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a role
@@ -124,7 +125,7 @@ class Role extends Base {
      * @type {String}
      */
     get iconURL() {
-        return this.icon ? this.guild.shard.client._formatImage(Endpoints.ROLE_ICON(this.id, this.icon)) : null;
+        return this.icon ? formatImage(Endpoints.ROLE_ICON(this.id, this.icon), undefined, undefined, this.guild.shard.client) : null;
     }
 
     /**

--- a/lib/structures/StageInstance.js
+++ b/lib/structures/StageInstance.js
@@ -18,12 +18,12 @@ class StageInstance extends Base {
          * The associated stage channel
          * @type {StageChannel}
          */
-        this.channel = client.getChannel(data.channel_id) || {id: data.channel_id};
+        this.channel = client?.getChannel(data.channel_id) || {id: data.channel_id};
         /**
          * The guild of the associated stage channel
          * @type {Guild}
          */
-        this.guild = client.guilds.get(data.guild_id) || {id: data.guild_id};
+        this.guild = client?.guilds.get(data.guild_id) || {id: data.guild_id};
         /**
          * The event associated with this instance
          * @type {GuildScheduledEvent}

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -4,6 +4,7 @@ const Collection = require("../util/Collection");
 const GuildChannel = require("./GuildChannel");
 const Message = require("./Message");
 const PermissionOverwrite = require("./PermissionOverwrite");
+const Constants = require("../Constants");
 
 /**
 * Represents a guild text channel. See GuildChannel for more properties and methods.
@@ -18,7 +19,7 @@ class TextChannel extends GuildChannel {
          * Collection of Messages in this channel
          * @type {Collection<Message>}
          */
-        this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
+        this.messages = new Collection(Message, messageLimit == null ? (client?.options.messageLimit ?? Constants.DefaultClientOptions.messageLimit) : messageLimit);
         /**
          * The ID of the last message in this channel
          * @type {String?}

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -3,6 +3,7 @@
 const VoiceChannel = require("./VoiceChannel");
 const Collection = require("../util/Collection");
 const Message = require("./Message");
+const Constants = require("../Constants");
 
 /**
 * Represents a Text-in-Voice channel. See VoiceChannel for more properties and methods.
@@ -17,7 +18,7 @@ class TextVoiceChannel extends VoiceChannel {
          * Collection of Messages in this channel
          * @type {Collection<Message>}
          */
-        this.messages = new Collection(Message, messageLimit == null ? client.options.messageLimit : messageLimit);
+        this.messages = new Collection(Message, messageLimit == null ? (client.options.messageLimit ?? Constants.DefaultClientOptions.messageLimit) : messageLimit);
         /**
          * Whether the channel is an NSFW channel or not
          * @type {Boolean}

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -17,7 +17,7 @@ class UnavailableGuild extends Base {
          * The shard that owns this guild
          * @type {Shard}
          */
-        this.shard = client.shards.get(client.guildShardMap[this.id]);
+        this.shard = client?.shards.get(client.guildShardMap[this.id]);
         /**
          * Whether the guild is unavailable or not
          * @type {Boolean}

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -19,12 +19,8 @@ class User extends Base {
      */
 
     #client;
-    #missingClientError;
     constructor(data, client) {
         super(data.id);
-        if(!client) {
-            this.#missingClientError = new Error("Missing client in constructor"); // Preserve constructor callstack
-        }
         this.#client = client;
         /**
          * Whether the user is an OAuth bot or not
@@ -96,9 +92,6 @@ class User extends Base {
      * @type {String}
      */
     get avatarURL() {
-        if(this.#missingClientError) {
-            throw this.#missingClientError;
-        }
         return this.avatar ? formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), undefined, undefined, this.#client) : this.defaultAvatarURL;
     }
 
@@ -109,9 +102,6 @@ class User extends Base {
     get bannerURL() {
         if(!this.banner) {
             return null;
-        }
-        if(this.#missingClientError) {
-            throw this.#missingClientError;
         }
         return formatImage(Endpoints.BANNER(this.id, this.banner), undefined, undefined, this.#client);
     }
@@ -148,9 +138,6 @@ class User extends Base {
      * @type {String}
      */
     get staticAvatarURL() {
-        if(this.#missingClientError) {
-            throw this.#missingClientError;
-        }
         return this.avatar ? formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "jpg", undefined, this.#client) : this.defaultAvatarURL;
     }
 
@@ -164,9 +151,6 @@ class User extends Base {
         if(!this.avatar) {
             return this.defaultAvatarURL;
         }
-        if(this.#missingClientError) {
-            throw this.#missingClientError;
-        }
         return formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size, this.#client);
     }
 
@@ -179,9 +163,6 @@ class User extends Base {
     dynamicBannerURL(format, size) {
         if(!this.banner) {
             return null;
-        }
-        if(this.#missingClientError) {
-            throw this.#missingClientError;
         }
         return formatImage(Endpoints.BANNER(this.id, this.banner), format, size, this.#client);
     }

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -2,6 +2,7 @@
 
 const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
+const formatImage = require("../util/formatImage");
 
 /**
 * Represents a user
@@ -98,7 +99,7 @@ class User extends Base {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar)) : this.defaultAvatarURL;
+        return this.avatar ? formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), undefined, undefined, this.#client) : this.defaultAvatarURL;
     }
 
     /**
@@ -112,7 +113,7 @@ class User extends Base {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner));
+        return formatImage(Endpoints.BANNER(this.id, this.banner), undefined, undefined, this.#client);
     }
 
     /**
@@ -150,7 +151,7 @@ class User extends Base {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "jpg") : this.defaultAvatarURL;
+        return this.avatar ? formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "jpg", undefined, this.#client) : this.defaultAvatarURL;
     }
 
     /**
@@ -166,7 +167,7 @@ class User extends Base {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size);
+        return formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size, this.#client);
     }
 
     /**
@@ -182,7 +183,7 @@ class User extends Base {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size);
+        return formatImage(Endpoints.BANNER(this.id, this.banner), format, size, this.#client);
     }
 
     /**

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -11,14 +11,15 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 */
 class VoiceChannel extends GuildChannel {
     #client;
+    /**
+     * Collection of Members in this channel
+     * @type {Collection<Member>}
+     */
+    voiceMembers = new Collection(Member);
+
     constructor(data, client) {
         super(data, client);
         this.#client = client;
-        /**
-         * Collection of Members in this channel
-         * @type {Collection<Member>}
-         */
-        this.voiceMembers = new Collection(Member);
     }
 
     update(data, client) {

--- a/lib/util/formatAllowedMentions.js
+++ b/lib/util/formatAllowedMentions.js
@@ -1,0 +1,37 @@
+const Constants = require("../Constants");
+
+const defaultAllowedMentions = formatAllowedMentions(Constants.DefaultClientOptions.allowedMentions);
+
+function formatAllowedMentions(allowed, client) {
+    if(!allowed) {
+        return client?.options.allowedMentions ?? defaultAllowedMentions;
+    }
+    const result = {
+        parse: []
+    };
+    if(allowed.everyone) {
+        result.parse.push("everyone");
+    }
+    if(allowed.roles === true) {
+        result.parse.push("roles");
+    } else if(Array.isArray(allowed.roles)) {
+        if(allowed.roles.length > 100) {
+            throw new Error("Allowed role mentions cannot exceed 100.");
+        }
+        result.roles = allowed.roles;
+    }
+    if(allowed.users === true) {
+        result.parse.push("users");
+    } else if(Array.isArray(allowed.users)) {
+        if(allowed.users.length > 100) {
+            throw new Error("Allowed user mentions cannot exceed 100.");
+        }
+        result.users = allowed.users;
+    }
+    if(allowed.repliedUser !== undefined) {
+        result.replied_user = allowed.repliedUser;
+    }
+    return result;
+}
+
+module.exports = formatAllowedMentions;

--- a/lib/util/formatImage.js
+++ b/lib/util/formatImage.js
@@ -1,0 +1,14 @@
+const Constants = require("../Constants");
+const Endpoints = require("../rest/Endpoints");
+
+function formatImage(url, format, size, client) {
+    if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
+        format = url.includes("/a_") ? "gif" : (client?.options.defaultImageFormat ?? Constants.DefaultClientOptions.defaultImageFormat);
+    }
+    if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
+        size = client?.options.defaultImageSize ?? Constants.DefaultClientOptions.defaultImageSize;
+    }
+    return `${Endpoints.CDN_URL}${url}.${format}?size=${size}`;
+}
+
+module.exports = formatImage;

--- a/lib/util/processAttachments.js
+++ b/lib/util/processAttachments.js
@@ -1,0 +1,32 @@
+function processAttachments(attachments) {
+    if(!attachments) {
+        return {};
+    }
+    const files = [];
+    const resultAttachments = [];
+
+    attachments.forEach((attachment, idx) => {
+        if(attachment.id) {
+            resultAttachments.push(attachment);
+        } else {
+            files.push({
+                fieldName: `files[${idx}]`,
+                file: attachment.file,
+                name: attachment.filename
+            });
+
+            resultAttachments.push({
+                ...attachment,
+                file: undefined,
+                id: idx
+            });
+        }
+    });
+
+    return {
+        files: files.length ? files : undefined,
+        attachments: resultAttachments
+    };
+}
+
+module.exports = processAttachments;


### PR DESCRIPTION
This PR introduces changes that aim to reduce the dependency of data structures on the Client class (and internal cached state in general) in order to prepare for the REST and WS parts of the client being split in #52.