### PR TITLE
feat(Client): allow `appliedTags` in `executeWebhook()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1745,6 +1745,7 @@ declare namespace Dysnomia {
   }
   interface WebhookPayload {
     allowedMentions?: AllowedMentions;
+    appliedTags?: string[];
     auth?: boolean;
     attachments?: AdvancedMessageContentAttachment[];
     avatarURL?: string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1965,6 +1965,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.allowedMentions.everyone] Whether or not to allow @everyone/@here.
     * @arg {Boolean | Array<String>} [options.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
     * @arg {Boolean | Array<String>} [options.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
+    * @arg {Array<String>} [options.appliedTags] The tags to apply to the created thread (available only in threads in thread-only channels)
     * @arg {Array<Object>} [content.attachments] The files to attach to the message
     * @arg {Buffer} content.attachments[].file A buffer containing file data
     * @arg {String} content.attachments[].filename What to name the file
@@ -1994,6 +1995,7 @@ class Client extends EventEmitter {
         const {files, attachments} = options.attachments ? this._processAttachments(options.attachments) : [];
 
         return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (qs ? "?" + qs : ""), !!options.auth, {
+            applied_tags: options.appliedTags,
             content: options.content,
             embeds: options.embeds,
             username: options.username,


### PR DESCRIPTION
Ref: https://github.com/discord/discord-api-docs/commit/4060a747f67f8a66ff85e1f34c1cc96f0a5a2c23