### PR TITLE
feat: support `nonce`/`enforceNonce` when creating messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare namespace Dysnomia {
   type ComponentTypes = Constants["ComponentTypes"][keyof Constants["ComponentTypes"]];
   type ImageFormat = Constants["ImageFormats"][number];
   type MessageActivityTypes = Constants["MessageActivityTypes"][keyof Constants["MessageActivityTypes"]];
-  type MessageContent = string | AdvancedMessageContent;
+  type MessageContent<T extends "isNonceEnforceable" | "" = ""> = string | AdvancedMessageContent<T>;
   type MFALevel = Constants["MFALevels"][keyof Constants["MFALevels"]];
   type PossiblyUncachedMessage = Message | { author?: User | Uncached; channel: TextableChannel | { id: string; guild?: Uncached }; guildID?: string; id: string };
   type SelectMenu = BaseSelectMenu | ChannelSelectMenu | StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu;
@@ -438,7 +438,7 @@ declare namespace Dysnomia {
     lastMessageID: string;
     messages: Collection<Message<this>>;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
     getMessage(messageID: string): Promise<Message<this>>;
@@ -1344,14 +1344,16 @@ declare namespace Dysnomia {
     components: TextInput[];
     type: Constants["ComponentTypes"]["ACTION_ROW"];
   }
-  interface AdvancedMessageContent {
+  interface AdvancedMessageContent<T extends "isNonceEnforceable" | "" = ""> {
     allowedMentions?: AllowedMentions;
     attachments?: AdvancedMessageContentAttachment[];
     components?: ActionRow[];
     content?: string;
+    enforceNonce?: T extends "isNonceEnforceable" ? boolean : never;
     embeds?: EmbedOptions[];
     flags?: number;
     messageReference?: MessageReferenceReply;
+    nonce?: string | number;
     stickerIDs?: string[];
     tts?: boolean;
   }
@@ -2643,7 +2645,7 @@ declare namespace Dysnomia {
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createGuildTemplate(guildID: string, name: string, description?: string | null): Promise<GuildTemplate>;
     createInteractionResponse(interactionID: string, interactionToken: string, options: InteractionResponse, file?: FileContent | FileContent[]): Promise<void>;
-    createMessage(channelID: string, content: MessageContent): Promise<Message>;
+    createMessage(channelID: string, content: MessageContent<"isNonceEnforceable">): Promise<Message>;
     createRole(guildID: string, options?: RoleOptions, reason?: string): Promise<Role>;
     createRole(guildID: string, options?: Role, reason?: string): Promise<Role>;
     createStageInstance(channelID: string, options: CreateStageInstanceOptions): Promise<StageInstance>;
@@ -3349,6 +3351,7 @@ declare namespace Dysnomia {
     mentionEveryone: boolean;
     mentions: User[];
     messageReference: MessageReference | null;
+    nonce?: string | number;
     pinned: boolean;
     position?: number;
     reactions: { [s: string]: { count: number; me: boolean } };
@@ -3402,7 +3405,7 @@ declare namespace Dysnomia {
     rateLimitPerUser: 0;
     type: Constants["ChannelTypes"]["GUILD_ANNOUNCEMENT"];
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", this>>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     createThreadWithMessage(messageID: string, options: CreateThreadOptions): Promise<NewsThreadChannel>;
     crosspostMessage(messageID: string): Promise<Message<this>>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
@@ -3461,7 +3464,7 @@ declare namespace Dysnomia {
     recipient: User;
     type: PrivateChannelTypes;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
     getMessage(messageID: string): Promise<Message<this>>;
@@ -3674,7 +3677,7 @@ declare namespace Dysnomia {
     constructor(data: BaseData, client: Client, messageLimit: number);
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", this>>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     createThread(options: CreateThreadWithoutMessageOptions): Promise<ThreadChannel>;
     createThreadWithMessage(messageID: string, options: CreateThreadOptions): Promise<PublicThreadChannel>;
     createWebhook(options: Omit<WebhookOptions, "channelID">, reason?: string): Promise<Webhook>;
@@ -3706,7 +3709,7 @@ declare namespace Dysnomia {
     messages: Collection<Message<this>>;
     rateLimitPerUser: number;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     createWebhook(options: { name: string; avatar?: string | null }, reason?: string): Promise<Webhook>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
@@ -3738,7 +3741,7 @@ declare namespace Dysnomia {
     type: GuildThreadChannelTypes;
     constructor(data: BaseData, client: Client, messageLimit?: number);
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent): Promise<Message<this>>;
+    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     edit(options: Pick<EditChannelOptions, "archived" | "autoArchiveDuration" | "invitable" | "locked" | "name" | "rateLimitPerUser">, reason?: string): Promise<this>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare namespace Dysnomia {
   type ComponentTypes = Constants["ComponentTypes"][keyof Constants["ComponentTypes"]];
   type ImageFormat = Constants["ImageFormats"][number];
   type MessageActivityTypes = Constants["MessageActivityTypes"][keyof Constants["MessageActivityTypes"]];
-  type MessageContent<T extends "isNonceEnforceable" | "" = ""> = string | AdvancedMessageContent<T>;
+  type MessageContent<T extends "hasNonce" | "" = ""> = string | AdvancedMessageContent<T>;
   type MFALevel = Constants["MFALevels"][keyof Constants["MFALevels"]];
   type PossiblyUncachedMessage = Message | { author?: User | Uncached; channel: TextableChannel | { id: string; guild?: Uncached }; guildID?: string; id: string };
   type SelectMenu = BaseSelectMenu | ChannelSelectMenu | StringSelectMenu | UserSelectMenu | RoleSelectMenu | MentionableSelectMenu;
@@ -438,7 +438,7 @@ declare namespace Dysnomia {
     lastMessageID: string;
     messages: Collection<Message<this>>;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
     getMessage(messageID: string): Promise<Message<this>>;
@@ -1344,16 +1344,16 @@ declare namespace Dysnomia {
     components: TextInput[];
     type: Constants["ComponentTypes"]["ACTION_ROW"];
   }
-  interface AdvancedMessageContent<T extends "isNonceEnforceable" | "" = ""> {
+  interface AdvancedMessageContent<T extends "hasNonce" | "" = ""> {
     allowedMentions?: AllowedMentions;
     attachments?: AdvancedMessageContentAttachment[];
     components?: ActionRow[];
     content?: string;
-    enforceNonce?: T extends "isNonceEnforceable" ? boolean : never;
+    enforceNonce?: T extends "hasNonce" ? boolean : never;
     embeds?: EmbedOptions[];
     flags?: number;
     messageReference?: MessageReferenceReply;
-    nonce?: string | number;
+    nonce?: T extends "hasNonce" ? (string | number) : never;
     stickerIDs?: string[];
     tts?: boolean;
   }
@@ -2645,7 +2645,7 @@ declare namespace Dysnomia {
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createGuildTemplate(guildID: string, name: string, description?: string | null): Promise<GuildTemplate>;
     createInteractionResponse(interactionID: string, interactionToken: string, options: InteractionResponse, file?: FileContent | FileContent[]): Promise<void>;
-    createMessage(channelID: string, content: MessageContent<"isNonceEnforceable">): Promise<Message>;
+    createMessage(channelID: string, content: MessageContent<"hasNonce">): Promise<Message>;
     createRole(guildID: string, options?: RoleOptions, reason?: string): Promise<Role>;
     createRole(guildID: string, options?: Role, reason?: string): Promise<Role>;
     createStageInstance(channelID: string, options: CreateStageInstanceOptions): Promise<StageInstance>;
@@ -3405,7 +3405,7 @@ declare namespace Dysnomia {
     rateLimitPerUser: 0;
     type: Constants["ChannelTypes"]["GUILD_ANNOUNCEMENT"];
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", this>>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     createThreadWithMessage(messageID: string, options: CreateThreadOptions): Promise<NewsThreadChannel>;
     crosspostMessage(messageID: string): Promise<Message<this>>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
@@ -3464,7 +3464,7 @@ declare namespace Dysnomia {
     recipient: User;
     type: PrivateChannelTypes;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
     getMessage(messageID: string): Promise<Message<this>>;
@@ -3677,7 +3677,7 @@ declare namespace Dysnomia {
     constructor(data: BaseData, client: Client, messageLimit: number);
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", this>>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     createThread(options: CreateThreadWithoutMessageOptions): Promise<ThreadChannel>;
     createThreadWithMessage(messageID: string, options: CreateThreadOptions): Promise<PublicThreadChannel>;
     createWebhook(options: Omit<WebhookOptions, "channelID">, reason?: string): Promise<Webhook>;
@@ -3709,7 +3709,7 @@ declare namespace Dysnomia {
     messages: Collection<Message<this>>;
     rateLimitPerUser: number;
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     createWebhook(options: { name: string; avatar?: string | null }, reason?: string): Promise<Webhook>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
@@ -3741,7 +3741,7 @@ declare namespace Dysnomia {
     type: GuildThreadChannelTypes;
     constructor(data: BaseData, client: Client, messageLimit?: number);
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
-    createMessage(content: MessageContent<"isNonceEnforceable">): Promise<Message<this>>;
+    createMessage(content: MessageContent<"hasNonce">): Promise<Message<this>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     edit(options: Pick<EditChannelOptions, "archived" | "autoArchiveDuration" | "invitable" | "locked" | "name" | "rateLimitPerUser">, reason?: string): Promise<this>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -777,6 +777,7 @@ class Client extends EventEmitter {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
+    * @arg {Boolean} [content.enforceNonce] If set and nonce is present, check the message for uniqueness in the past few minutes
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] Message flags. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
@@ -784,6 +785,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
     * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
     * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String | Number} [content.nonce] A value that can be used to check if the message was sent
     * @arg {Array<String>} [content.stickerIDs] An array of IDs corresponding to stickers to send
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @returns {Promise<Message>}
@@ -818,6 +820,7 @@ class Client extends EventEmitter {
                     content.messageReference.failIfNotExists = undefined;
                 }
             }
+            content.enforce_nonce = content.enforceNonce;
         }
 
         const {files, attachments} = this._processAttachments(content.attachments);

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -191,6 +191,13 @@ class Message extends Base {
             };
         }
 
+        /**
+         * A unique user-provided value used to check whether a message was sent.
+         * Only provided when the message is created over REST
+         * @type {(String | Number)?}
+         */
+        this.nonce = data.nonce;
+
         switch(this.type) {
             case MessageTypes.DEFAULT: {
                 break;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -193,7 +193,9 @@ class Message extends Base {
 
         /**
          * A unique user-provided value used to check whether a message was sent.
-         * Only provided when the message is created over REST
+         * Available only when the message is created over REST, or received via 
+         * the messageCreate event.
+         *
          * @type {(String | Number)?}
          */
         this.nonce = data.nonce;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -193,7 +193,7 @@ class Message extends Base {
 
         /**
          * A unique user-provided value used to check whether a message was sent.
-         * Available only when the message is created over REST, or received via 
+         * Available only when the message is created over REST, or received via
          * the messageCreate event.
          *
          * @type {(String | Number)?}

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -60,12 +60,14 @@ class PrivateChannel extends Channel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
+    * @arg {Boolean} [content.enforceNonce] If set and nonce is present, check the message for uniqueness in the past few minutes
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
     * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
     * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String | Number} [content.nonce] A value that can be used to check if the message was sent
     * @arg {Array<String>} [content.stickerIDs] An array of IDs corresponding to stickers to send
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @returns {Promise<Message>}

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -119,6 +119,7 @@ class TextChannel extends GuildChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [Discord's Documentation](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
+    * @arg {Boolean} [content.enforceNonce] If set and nonce is present, check the message for uniqueness in the past few minutes
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] Message flags. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
@@ -126,6 +127,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
     * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
     * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String | Number} [content.nonce] A value that can be used to check if the message was sent
     * @arg {Array<String>} [content.stickerIDs] An array of IDs corresponding to stickers to send
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @returns {Promise<Message>}

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -94,12 +94,14 @@ class TextVoiceChannel extends VoiceChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} content.content A content string
+    * @arg {Boolean} [content.enforceNonce] If set and nonce is present, check the message for uniqueness in the past few minutes
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
     * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
     * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String | Number} [content.nonce] A unique value that can be used to check if the message was sent
     * @arg {Array<String>} [content.stickerIDs] An array of IDs corresponding to the stickers to send
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @returns {Promise<Message>}

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -112,12 +112,14 @@ class ThreadChannel extends GuildChannel {
     * @arg {String} [content.attachments[].description] A description for the attachment
     * @arg {Array<Object>} [content.components] An array of components. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/message-components#what-is-a-component) for object structure
     * @arg {String} [content.content] A content string
+    * @arg {Boolean} [content.enforceNonce] If set and nonce is present, check the message for uniqueness in the past few minutes
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
     * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
     * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String | Number} [content.nonce] A value that can be used to check if the message was sent
     * @arg {Array<String>} [content.stickerIDs] An array of IDs corresponding to stickers to send
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @returns {Promise<Message>}


### PR DESCRIPTION
Adds support for Discord's new `enforce_nonce` parameter in `createMessage()` calls. Additionally, `Message#nonce` is now exposed.

Ref: https://github.com/discord/discord-api-docs/commit/d8effe15d56a12eec0bb977a5bf4487b9ebffcad
