### PR TITLE
fix(Member): fix updating from voice state updates

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -64,6 +64,19 @@ class Member extends Base {
     }
 
     update(data) {
+        // update if its from voice state
+        if(data.hasOwnProperty("member") && data.hasOwnProperty("channel_id") && this.guild) {
+            const state = this.guild.voiceStates.get(this.id);
+            if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
+                this.guild.voiceStates.delete(this.id);
+            } else if(state) {
+                state.update(data);
+            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
+                this.guild.voiceStates.update(data);
+            }
+            data = data.member;
+        }
+
         if(data.status !== undefined) {
             /**
              * The member's status. Either "online", "idle", "dnd", or "offline"
@@ -98,16 +111,6 @@ class Member extends Base {
              * @type {Number?}
              */
             this.premiumSince = data.premium_since === null ? null : Date.parse(data.premium_since);
-        }
-        if(data.hasOwnProperty("mute") && this.guild) {
-            const state = this.guild.voiceStates.get(this.id);
-            if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
-                this.guild.voiceStates.delete(this.id);
-            } else if(state) {
-                state.update(data);
-            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
-                this.guild.voiceStates.update(data);
-            }
         }
         if(data.nick !== undefined) {
             this.nick = data.nick;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -64,7 +64,7 @@ class Member extends Base {
     }
 
     update(data) {
-        // update if its from voice state
+        // Handle updates from voice states
         if(data.hasOwnProperty("member") && data.hasOwnProperty("channel_id") && this.guild) {
             const state = this.guild.voiceStates.get(this.id);
             if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -146,6 +146,9 @@ class Member extends Base {
         if(data.flags !== undefined) {
             this.flags = data.flags;
         }
+        if(data.user !== undefined) {
+            this.user.update(data.user);
+        }
     }
 
     /**


### PR DESCRIPTION
Noticed that voice updates don't also update member's roles, so this should update that stuff (and also update user stuff)

This is really only useful for use cases where you aren't receiving member/user updates already.