### PR TITLE
ci: bump workflows from v3 to v4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with: 
           node-version: lts/*
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: npm i --omit=optional
       - name: Lint ${{ matrix.lang.name }} files


### PR DESCRIPTION
Actions based on Node.js v16 are deprecated. Using a new version of the actions bumps their runtime version to Node.js v20.

Ref: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
