### PR TITLE
feat(Attachment): support the `title` field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2489,6 +2489,7 @@ declare namespace Dysnomia {
     id: string;
     proxyURL: string;
     size: number;
+    title?: string;
     url: string;
     waveform?: string;
     width?: number;

--- a/lib/structures/Attachment.js
+++ b/lib/structures/Attachment.js
@@ -50,6 +50,13 @@ class Attachment extends Base {
     }
 
     update(data) {
+        if(data.title !== undefined) {
+            /**
+             * The title of the attachment
+             * @type {String?}
+             */
+            this.title = data.title;
+        }
         if(data.description !== undefined) {
             /**
              * The description of the attachment


### PR DESCRIPTION
Ref: https://github.com/discord/discord-api-docs/commit/1449ec3442658206b7a5f5ff07998279e6441eb6