### PR TITLE
hotfix(Shard): add avatarDecorationData to userUpdate

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1812,7 +1812,8 @@ class Shard extends EventEmitter {
                         username: user.username,
                         discriminator: user.discriminator,
                         avatar: user.avatar,
-                        globalName: user.globalName
+                        globalName: user.globalName,
+                        avatarDecorationData: user.avatarDecorationData
                     };
                 }
                 user = this.client.users.update(packet.d, this.client);


### PR DESCRIPTION
Probably not a big deal as USER_UPDATE only fires on the currently logged-in user (and bots cannot have their avatar decorated), but include it anyways for the sake of brevity.