### PR TITLE
fix(RequestHandler): correct debug message on missing ratelimit headers

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -250,8 +250,8 @@ class RequestHandler {
 
                         if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == undefined || resp.headers["x-ratelimit-limit"] == undefined) && this.ratelimits[route].limit !== 1) {
                             this.#client.emit("debug", `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n`
-                                + `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
-                                + "content-type = " +  + "\n"
+                                + `${resp.statusCode} ${resp.statusMessage}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
+                                + "content-type = " + resp.headers["content-type"] + "\n"
                                 + "x-ratelimit-remaining = " + resp.headers["x-ratelimit-remaining"] + "\n"
                                 + "x-ratelimit-limit = " + resp.headers["x-ratelimit-limit"] + "\n"
                                 + "x-ratelimit-reset = " + resp.headers["x-ratelimit-reset"] + "\n"


### PR DESCRIPTION
Moves the `content-type` where it is supposed to be and adds the status message next to the status code.