### PR TITLE
fix(VoiceState): don't parse the request to speak timestamp when null

### DIFF
--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -78,7 +78,7 @@ class VoiceState extends Base {
             this.deaf = data.deaf;
         }
         if(data.request_to_speak_timestamp !== undefined) {
-            this.requestToSpeakTimestamp = Date.parse(data.request_to_speak_timestamp);
+            this.requestToSpeakTimestamp = data.request_to_speak_timestamp == null ? null : Date.parse(data.request_to_speak_timestamp);
         }
         if(data.self_mute !== undefined) {
             this.selfMute = data.self_mute;


### PR DESCRIPTION
Fixes the issue with the request to speak timestamp turning into NaN when it is null in the updated voice state if the user isn't requesting to speak.
