### PR TITLE
feat: add recently-added methods to get objects via REST

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2910,6 +2910,7 @@ declare namespace Dysnomia {
     getRoleConnectionMetadata(): Promise<ApplicationRoleConnectionMetadata[]>;
     getSelf(): Promise<ExtendedUser>;
     getStageInstance(channelID: string): Promise<StageInstance>;
+    getStickerPack(packID: string): Promise<StickerPack>;
     getStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getThreadMember(channelID: string, memberID: string, options: GetThreadMemberOptions): Promise<ThreadMember>;
     getThreadMembers(channelID: string, options: GetThreadMembersOptions): Promise<ThreadMember[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2899,6 +2899,7 @@ declare namespace Dysnomia {
     getRESTGuildEmojis(guildID: string): Promise<Emoji[]>;
     getRESTGuildMember(guildID: string, memberID: string): Promise<Member>;
     getRESTGuildMembers(guildID: string, options?: GetRESTGuildMembersOptions): Promise<Member[]>;
+    getRESTGuildRole(guildID: string, roleID: string): Promise<Role>;
     getRESTGuildRoles(guildID: string): Promise<Role[]>;
     getRESTGuilds(options?: GetRESTGuildsOptions): Promise<Guild[]>;
     getRESTGuildScheduledEvent(guildID: string, eventID: string, options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent>;
@@ -3179,6 +3180,7 @@ declare namespace Dysnomia {
     getRESTEmojis(): Promise<Emoji[]>;
     getRESTMember(memberID: string): Promise<Member>;
     getRESTMembers(options?: GetRESTGuildMembersOptions): Promise<Member[]>;
+    getRESTRole(roleID: string): Promise<Role>;
     getRESTRoles(): Promise<Role[]>;
     getRESTScheduledEvent(eventID: string): Promise<GuildScheduledEvent>;
     getRESTSticker(stickerID: string): Promise<Sticker>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2905,6 +2905,7 @@ declare namespace Dysnomia {
     getRESTGuildScheduledEvent(guildID: string, eventID: string, options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent>;
     getRESTGuildSticker(guildID: string, stickerID: string): Promise<Sticker>;
     getRESTGuildStickers(guildID: string): Promise<Sticker[]>;
+    getRESTGuildVoiceState(guildID: string, userID: string): Promise<VoiceState>;
     getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTUser(userID: string): Promise<User>;
     getRoleConnectionMetadata(): Promise<ApplicationRoleConnectionMetadata[]>;
@@ -3186,6 +3187,7 @@ declare namespace Dysnomia {
     getRESTScheduledEvent(eventID: string): Promise<GuildScheduledEvent>;
     getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTStickers(): Promise<Sticker[]>;
+    getRESTVoiceState(userID: string): Promise<VoiceState>;
     getScheduledEvents(options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent[]>;
     getScheduledEventUsers(eventID: string, options?: GetGuildScheduledEventUsersOptions): Promise<GuildScheduledEventUser[]>;
     getTemplates(): Promise<GuildTemplate[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2905,7 +2905,7 @@ declare namespace Dysnomia {
     getRESTGuildScheduledEvent(guildID: string, eventID: string, options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent>;
     getRESTGuildSticker(guildID: string, stickerID: string): Promise<Sticker>;
     getRESTGuildStickers(guildID: string): Promise<Sticker[]>;
-    getRESTGuildVoiceState(guildID: string, userID: string): Promise<VoiceState>;
+    getRESTGuildVoiceState(guildID: string, userID?: string): Promise<VoiceState>;
     getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTUser(userID: string): Promise<User>;
     getRoleConnectionMetadata(): Promise<ApplicationRoleConnectionMetadata[]>;
@@ -3187,7 +3187,7 @@ declare namespace Dysnomia {
     getRESTScheduledEvent(eventID: string): Promise<GuildScheduledEvent>;
     getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTStickers(): Promise<Sticker[]>;
-    getRESTVoiceState(userID: string): Promise<VoiceState>;
+    getRESTVoiceState(userID?: string): Promise<VoiceState>;
     getScheduledEvents(options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent[]>;
     getScheduledEventUsers(eventID: string, options?: GetGuildScheduledEventUsersOptions): Promise<GuildScheduledEventUser[]>;
     getTemplates(): Promise<GuildTemplate[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -28,6 +28,7 @@ const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
 const AutoModerationRule = require("./structures/AutoModerationRule");
 const emitDeprecation = require("./util/emitDeprecation");
+const VoiceState = require("./structures/VoiceState");
 
 let EventEmitter;
 try {
@@ -2882,6 +2883,19 @@ class Client extends EventEmitter {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_STICKERS(guildID), true);
+    }
+
+    /**
+     * Gets a user's voice state in a guild via the REST API. REST mode is required to use this endpoint.
+     * @param {String} guildID The ID of the guild
+     * @param {String} [userID="@me"] The ID of the user
+     * @returns {Promise<VoiceState>}
+     */
+    getRESTGuildVoiceState(guildID, userID = "@me") {
+        if(!this.options.restMode) {
+            return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
+        }
+        return this.requestHandler.request("GET", Endpoints.GUILD_VOICE_STATE(guildID, userID), true).then((state) => new VoiceState(state));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2800,6 +2800,19 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Get a guild role via the REST API. REST mode is required to use this endpoint.
+     * @param {String} guildID The ID of the guild
+     * @param {String} roleID The ID of the role
+     * @returns {Promise<Array<Role>>}
+     */
+    getRESTGuildRole(guildID, roleID) {
+        if(!this.options.restMode) {
+            return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
+        }
+        return this.requestHandler.request("GET", Endpoints.GUILD_ROLE(guildID, roleID), true).then((role) => new Role(role, null));
+    }
+
+    /**
      * Get a guild's roles via the REST API. REST mode is required to use this endpoint.
      * @param {String} guildID The ID of the guild
      * @returns {Promise<Array<Role>>}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2938,6 +2938,15 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Get a sticker pack
+     * @param {String} packID The ID of the sticker pack
+     * @returns {Promise<Object>} Sticker pack data
+     */
+    getStickerPack(packID) {
+        return this.requestHandler.request("GET", Endpoints.STICKER_PACK(packID), true);
+    }
+
+    /**
      * Get the list of available sticker packs
      * @returns {Promise<Object>} An object which contains a value which contains an array of sticker packs
      */

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -87,6 +87,7 @@ module.exports.ROLE_CONNECTION_METADATA =                        (applicationID)
 module.exports.STAGE_INSTANCE =                                      (channelID) => `/stage-instances/${channelID}`;
 module.exports.STAGE_INSTANCES =                                                    "/stage-instances";
 module.exports.STICKER =                                             (stickerID) => `/stickers/${stickerID}`;
+module.exports.STICKER_PACK =                                           (packID) => `/sticker-packs/${packID}`;
 module.exports.STICKER_PACKS =                                                      "/sticker-packs";
 module.exports.THREAD_MEMBER =                               (channelID, userID) => `/channels/${channelID}/thread-members/${userID}`;
 module.exports.THREAD_MEMBERS =                                      (channelID) => `/channels/${channelID}/thread-members`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1251,6 +1251,15 @@ class Guild extends Base {
     }
 
     /**
+     * Get a guild's role via the REST API. REST mode is required to use this endpoint.
+     * @param {String} roleID The ID of the role
+     * @returns {Promise<Role>}
+     */
+    getRESTRole(roleID) {
+        return this.#client.getRESTGuildRole.call(this.#client, this.id, roleID);
+    }
+
+    /**
      * Get a guild's roles via the REST API. REST mode is required to use this endpoint.
      * @returns {Promise<Array<Role>>}
      */

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1296,6 +1296,15 @@ class Guild extends Base {
     }
 
     /**
+     * Gets a user's voice state in this guild via the REST API. REST mode is required to use this endpoint.
+     * @param {String} [userID="@me"] The ID of the user
+     * @returns {Promise<VoiceState>}
+     */
+    getRESTVoiceState(userID) {
+        return this.#client.getRESTGuildVoiceState.call(this.#client, this.id, userID);
+    }
+
+    /**
      * Get the guild's scheduled events
      * @param {Object} [options] Options for the request
      * @param {Boolean} [options.withUserCount] Whether to include the number of users subscribed to each event


### PR DESCRIPTION
Note that `/guilds/:guild/voice-states/:user` also gives you member + user data, but at the moment there's no way to access this with the current VoiceState class.

Ref: https://github.com/discord/discord-api-docs/commit/722480036365d610539ac92f37279d028a247563
Ref: https://github.com/discord/discord-api-docs/commit/072b4bc007397520593a34eeab7fdcc1eb44be7e
Ref: https://github.com/discord/discord-api-docs/commit/1a9e949f1be126a1b2e6797de4c0713dc868d438