### PR TITLE
feat: emit full message objects in messageUpdate events

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -883,10 +883,7 @@ class Shard extends EventEmitter {
             case "MESSAGE_UPDATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 if(!channel) {
-                    packet.d.channel = {
-                        id: packet.d.channel_id
-                    };
-                    this.emit("messageUpdate", packet.d, null);
+                    this.emit("messageUpdate", new Message(packet.d, this.client), null);
                     break;
                 }
                 const message = channel.messages.get(packet.d.id);
@@ -905,15 +902,11 @@ class Shard extends EventEmitter {
                         roleMentions: message.roleMentions,
                         tts: message.tts
                     };
-                } else if(!packet.d.timestamp) {
-                    packet.d.channel = channel;
-                    this.emit("messageUpdate", packet.d, null);
-                    break;
                 }
                 /**
                  * Fired when a message is updated
                  * @event Client#messageUpdate
-                 * @prop {Message} message The updated message. If oldMessage is null, it is recommended to discard this event, since the message data will be very incomplete (only `id` and `channel` are guaranteed). If the channel isn't cached, `channel` will be an object with an `id` key.
+                 * @prop {Message} message The updated message. If the channel isn't cached, `channel` will be an object with an `id` key.
                  * @prop {Object?} oldMessage The old message data. If the message was cached, this will return the full old message. Otherwise, it will be null
                  * @prop {Array<Attachment>} oldMessage.attachments Array of attachments
                  * @prop {Array<String>} oldMessage.channelMentions Array of mentions channels' ids.


### PR DESCRIPTION
Discord now guarantees that all MESSAGE_UPDATE events will be full message objects.

Ref: https://github.com/discord/discord-api-docs/pull/7017
