### PR TITLE
chore: use only Discord's erlpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@discordjs/opus": "^0.9.0",
-    "erlpack": "github:discord/erlpack || github:abalabahaha/erlpack",
+    "erlpack": "github:discord/erlpack",
     "eventemitter3": "^5.0.1",
     "pako": "^2.1.0",
     "sodium-native": "^4.1.1",


### PR DESCRIPTION
guess you cannot do "this repo or this repo" in peer deps, it also makes package managers resolve dependencies incorrectly when in the dev tree.

Ref: https://discord.com/channels/1028639891363475527/1028644491776774225/1276174562358198272