### PR TITLE
chore: update to ESLint v9, add eqeqeq rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,6 +124,10 @@ export default ts.config(
             ],
             "prefer-const": "error",
             "require-atomic-updates": "warn",
+            "eqeqeq": [
+                "error",
+                "allow-null"
+            ],
             "sort-class-members/sort-class-members": [
                 "error",
                 {
@@ -176,9 +180,7 @@ export default ts.config(
         }
     },
     {
-        files: [
-            "**/*.ts"
-        ],
+        files: tsFiles,
         extends: [
             ...ts.configs.recommended
         ],
@@ -235,6 +237,7 @@ export default ts.config(
                 "ts-expect-error": "allow-with-description",
                 "ts-ignore": "allow-with-description"
             }],
+            "@typescript-eslint/no-require-imports": "off",
             "sort-class-members/sort-class-members": ["error", {
                 ...classSortCommon,
                 order: [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -115,7 +115,7 @@ export default ts.config(
         },
         rules: {
             "curly": "error",
-            "no-prototype-builtins": "off",
+            "prefer-object-has-own": "error",
             "no-trailing-spaces": "error",
             "no-var": "error",
             "object-shorthand": [

--- a/lib/errors/DiscordHTTPError.js
+++ b/lib/errors/DiscordHTTPError.js
@@ -49,7 +49,7 @@ class DiscordHTTPError extends Error {
     flattenErrors(errors, keyPrefix = "") {
         let messages = [];
         for(const fieldName in errors) {
-            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
+            if(!Object.hasOwn(errors, fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
             if(Array.isArray(errors[fieldName])) {

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -53,7 +53,7 @@ class DiscordRESTError extends Error {
     flattenErrors(errors, keyPrefix = "") {
         let messages = [];
         for(const fieldName in errors) {
-            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
+            if(!Object.hasOwn(errors, fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
             if(errors[fieldName]._errors) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -99,7 +99,7 @@ class Shard extends EventEmitter {
      * Tells the shard to connect
      */
     connect() {
-        if(this.ws && this.ws.readyState != WebSocket.CLOSED) {
+        if(this.ws && this.ws.readyState !== WebSocket.CLOSED) {
             this.emit("error", new Error("Existing connection detected"), this.id);
             return;
         }
@@ -448,7 +448,7 @@ class Shard extends EventEmitter {
                  * @prop {Number} id The ID of the shard
                  */
                 this.emit("hello", packet.d._trace, this.id);
-                break; /* eslint-enable no-unreachable */
+                break;
             }
             case GatewayOPCodes.HEARTBEAT_ACK: {
                 this.lastHeartbeatAck = true;
@@ -586,7 +586,7 @@ class Shard extends EventEmitter {
     }
 
     wsEvent(packet) {
-        switch(packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
+        switch(packet.t) { // (╯°□°）╯︵ ┻━┻
             case "AUTO_MODERATION_ACTION_EXECUTION": {
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
@@ -785,7 +785,7 @@ class Shard extends EventEmitter {
                 };
                 const oldChannelID = member.voiceState.channelID;
                 member.update(packet.d, this.client);
-                if(oldChannelID != packet.d.channel_id) {
+                if(oldChannelID !== packet.d.channel_id) {
                     let oldChannel, newChannel;
                     if(oldChannelID) {
                         oldChannel = guild.channels.get(oldChannelID);
@@ -2377,7 +2377,7 @@ class Shard extends EventEmitter {
                 this.emit("unknown", packet, this.id);
                 break;
             }
-        } /* eslint-enable no-redeclare */
+        }
     }
 
     #onWSCloseUnbound(code, reason) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -234,7 +234,7 @@ class Shard extends EventEmitter {
             activities = [activities];
         }
         if(activities !== undefined) {
-            if(activities.length > 0 && !activities[0].hasOwnProperty("type")) {
+            if(activities.length > 0 && !Object.hasOwn(activities[0], "type")) {
                 activities[0].type = activities[0].url ? 1 : 0;
             }
             this.presence.activities = activities;
@@ -510,7 +510,7 @@ class Shard extends EventEmitter {
         this.preReady = false;
         if(this.requestMembersPromise !== undefined) {
             for(const guildID in this.requestMembersPromise) {
-                if(!this.requestMembersPromise.hasOwnProperty(guildID)) {
+                if(!Object.hasOwn(this.requestMembersPromise, guildID)) {
                     continue;
                 }
                 clearTimeout(this.requestMembersPromise[guildID].timeout);
@@ -1689,17 +1689,17 @@ class Shard extends EventEmitter {
                     member?.update(presence);
                 });
 
-                if(this.requestMembersPromise.hasOwnProperty(packet.d.nonce)) {
+                if(Object.hasOwn(this.requestMembersPromise, packet.d.nonce)) {
                     this.requestMembersPromise[packet.d.nonce].members.push(...members);
                 }
 
                 if(packet.d.chunk_index >= packet.d.chunk_count - 1) {
-                    if(this.requestMembersPromise.hasOwnProperty(packet.d.nonce)) {
+                    if(Object.hasOwn(this.requestMembersPromise, packet.d.nonce)) {
                         clearTimeout(this.requestMembersPromise[packet.d.nonce].timeout);
                         this.requestMembersPromise[packet.d.nonce].res(this.requestMembersPromise[packet.d.nonce].members);
                         delete this.requestMembersPromise[packet.d.nonce];
                     }
-                    if(this.getAllUsersCount.hasOwnProperty(guild.id)) {
+                    if(Object.hasOwn(this.getAllUsersCount, guild.id)) {
                         delete this.getAllUsersCount[guild.id];
                         this.checkReady();
                     }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -126,7 +126,7 @@ class RequestHandler {
                         if(method === "GET" || method === "DELETE") {
                             let qs = "";
                             Object.keys(body).forEach(function(key) {
-                                if(body[key] != undefined) {
+                                if(body[key] != null) {
                                     if(Array.isArray(body[key])) {
                                         body[key].forEach(function(val) {
                                             qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
@@ -248,7 +248,7 @@ class RequestHandler {
                             this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
                         }
 
-                        if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == undefined || resp.headers["x-ratelimit-limit"] == undefined) && this.ratelimits[route].limit !== 1) {
+                        if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == null || resp.headers["x-ratelimit-limit"] == null) && this.ratelimits[route].limit !== 1) {
                             this.#client.emit("debug", `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n`
                             + `${resp.statusCode} ${resp.statusMessage}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
                             + "content-type = " + resp.headers["content-type"] + "\n"

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -46,7 +46,7 @@ class Base {
         // http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         const copy = new {[this.constructor.name]: class {}}[this.constructor.name]();
         for(const key in this) {
-            if(this.hasOwnProperty(key) && !key.startsWith("_") && this[key] !== undefined) {
+            if(Object.hasOwn(this, key) && !key.startsWith("_") && this[key] !== undefined) {
                 copy[key] = this[key];
             }
         }

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -54,10 +54,10 @@ class GuildAuditLogEntry extends Base {
             this.before = {};
             this.after = {};
             data.changes.forEach((change) => {
-                if(change.old_value != undefined) {
+                if(change.old_value != null) {
                     this.before[change.key] = change.old_value;
                 }
-                if(change.new_value != undefined) {
+                if(change.new_value != null) {
                     this.after[change.key] = change.new_value;
                 }
             });

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -65,7 +65,7 @@ class Member extends Base {
 
     update(data) {
         // Handle updates from voice states
-        if(data.hasOwnProperty("channel_id") && this.guild) {
+        if(Object.hasOwn(data, "channel_id") && this.guild) {
             const state = this.guild.voiceStates.get(this.id);
             if(data.channel_id === null && !data.mute && !data.deaf) {
                 this.guild.voiceStates.delete(this.id);
@@ -74,7 +74,7 @@ class Member extends Base {
             } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
                 this.guild.voiceStates.update(data);
             }
-            if(data.hasOwnProperty("member")) {
+            if(Object.hasOwn(data, "member")) {
                 data = data.member;
             }
         }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -390,7 +390,7 @@ class Message extends Base {
              */
             this.pinned = !!data.pinned;
         }
-        if(data.edited_timestamp != undefined) {
+        if(data.edited_timestamp != null) {
             /**
              * Timestamp of latest message edit
              * @type {Number?}

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -29,7 +29,7 @@ function resolveHTTPType(link) {
 function webGetter(link, depth = 8) {
     return new Promise((resolve, reject) => {
         resolveHTTPType(link).get(link, (res) => {
-            const {statusCode, headers} = res.hasOwnProperty("statusCode") ? res : res.res;
+            const {statusCode, headers} = Object.hasOwn(res, "statusCode") ? res : res.res;
 
             if(statusCode === 301 || statusCode === 302 || statusCode === 307 || statusCode === 308) {
                 if(depth <= 0) {
@@ -211,7 +211,7 @@ class Piper extends EventEmitter {
         }
 
         this.#endStream = this.streams[this.streams.length - 1];
-        if(this.#endStream.hasOwnProperty("manualCB")) {
+        if(Object.hasOwn(this.#endStream, "manualCB")) {
             this.#endStream.manualCB = true;
         }
 

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -152,7 +152,7 @@ class SharedStream extends EventEmitter {
     }
 
     setSpeaking(value) {
-        if((value = !!value) != this.speaking) {
+        if((value = !!value) !== this.speaking) {
             this.speaking = value;
             for(const vc of this.voiceConnections.values()) {
                 vc.setSpeaking(value);

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@eslint/js": "^8.57.0",
+    "@eslint/js": "^9.9.0",
     "@stylistic/eslint-plugin": "^2.4.0",
     "@types/node": "^18.19.41",
     "@types/ws": "^8.5.11",
-    "eslint": "^8.57.0",
-    "eslint-plugin-jsdoc": "^48.10.2",
+    "eslint": "^9.9.0",
+    "eslint-plugin-jsdoc": "^50.2.2",
     "eslint-plugin-sort-class-members": "^1.20.0",
     "globals": "^15.8.0",
-    "typescript": "^5.5.3",
-    "typescript-eslint": "^7.18.0"
+    "typescript": "^5.5.4",
+    "typescript-eslint": "^8.2.0"
   },
   "optionalDependencies": {
     "opusscript": "^0.1.1",


### PR DESCRIPTION
Updates ESLint to v9, and adds an `eqeqeq` rule to enforce strict equality usage across the codebase (`== null` is still allowed).