### PR TITLE
fix(DiscordRESTError): properly parse request errors

### DIFF
--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -60,9 +60,7 @@ class DiscordRESTError extends Error {
                 messages = messages.concat(
                     errors._errors.map((obj) => `${keyPrefix ? `${keyPrefix}: ` : ""}${obj.message}`)
                 );
-                continue;
-            }
-            if(errors[fieldName]._errors) {
+            } else if(errors[fieldName]._errors) {
                 messages = messages.concat(errors[fieldName]._errors.map((obj) => `${keyPrefix + fieldName}: ${obj.message}`));
             } else if(Array.isArray(errors[fieldName])) {
                 messages = messages.concat(errors[fieldName].map((str) => `${keyPrefix + fieldName}: ${str}`));

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -56,6 +56,12 @@ class DiscordRESTError extends Error {
             if(!Object.hasOwn(errors, fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
+            if(fieldName === "_errors") {
+                messages = messages.concat(
+                    errors._errors.map((obj) => `${keyPrefix ? `${keyPrefix}: ` : ""}${obj.message}`)
+                );
+                continue;
+            }
             if(errors[fieldName]._errors) {
                 messages = messages.concat(errors[fieldName]._errors.map((obj) => `${keyPrefix + fieldName}: ${obj.message}`));
             } else if(Array.isArray(errors[fieldName])) {


### PR DESCRIPTION
Ref https://discord.com/developers/docs/reference#error-messages-request-error

```sh
# before
Invalid Form Body
  _errors: [object Object]

# after
Invalid Form Body
  Field "type" is required to determine the model type.
```