### PR TITLE
feat: support `with_response` on interaction callbacks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3114,7 +3114,7 @@ declare namespace Dysnomia {
     deleteOriginalMessage(): Promise<void>;
     editMessage(messageID: string, content: string | InteractionContentEdit): Promise<Message>;
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
-    editParent(content: InteractionContentEdit): Promise<void>;
+    editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
     launchActivity(): Promise<void>;
     /** @deprecated */
@@ -3656,7 +3656,7 @@ declare namespace Dysnomia {
     deleteOriginalMessage(): Promise<void>;
     editMessage(messageID: string, content: string | InteractionContentEdit): Promise<Message>;
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
-    editParent(content: InteractionContentEdit): Promise<void>;
+    editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
     launchActivity(): Promise<void>;
     /** @deprecated */

--- a/index.d.ts
+++ b/index.d.ts
@@ -3082,7 +3082,7 @@ declare namespace Dysnomia {
     user?: User;
     acknowledge(flags?: number): Promise<void>;
     createFollowup(content: string | InteractionContent): Promise<Message>;
-    createMessage(content: string | InteractionContent): Promise<void>;
+    createMessage(content: string | InteractionContent): Promise<Message>;
     createModal(content: InteractionModalContent): Promise<void>;
     defer(flags?: number): Promise<void>;
     deleteMessage(messageID: string): Promise<void>;
@@ -3106,7 +3106,7 @@ declare namespace Dysnomia {
     user?: User;
     acknowledge(): Promise<void>;
     createFollowup(content: string | InteractionContent): Promise<Message>;
-    createMessage(content: string | InteractionContent): Promise<void>;
+    createMessage(content: string | InteractionContent): Promise<Message>;
     createModal(content: InteractionModalContent): Promise<void>;
     defer(flags?: number): Promise<void>;
     deferUpdate(): Promise<void>;
@@ -3649,7 +3649,7 @@ declare namespace Dysnomia {
     user?: User;
     acknowledge(): Promise<void>;
     createFollowup(content: string | InteractionContent): Promise<Message>;
-    createMessage(content: string | InteractionContent): Promise<void>;
+    createMessage(content: string | InteractionContent): Promise<Message>;
     defer(flags?: number): Promise<void>;
     deferUpdate(): Promise<void>;
     deleteMessage(messageID: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ declare namespace Dysnomia {
   type InteractionDataOptionsUser = InteractionDataOption<"USER", string>;
   type InteractionDataOptionsWithOptions = InteractionDataOptionsSubCommand | InteractionDataOptionsSubCommandGroup;
   type InteractionDataOptionsWithValue = InteractionDataOptionsString | InteractionDataOptionsInteger | InteractionDataOptionsBoolean | InteractionDataOptionsUser | InteractionDataOptionsChannel | InteractionDataOptionsRole | InteractionDataOptionsMentionable | InteractionDataOptionsNumber;
-  type InteractionResponse = InteractionResponseAutocomplete | InteractionResponseDeferred | InteractionResponseMessage;
+  type InteractionResponse = InteractionResponseAutocomplete | InteractionResponseDeferred | InteractionResponseLaunchActivity | InteractionResponseMessage | InteractionResponsePong | InteractionResponsePremiumRequired;
   type InteractionResponseTypes = Constants["InteractionResponseTypes"][keyof Constants["InteractionResponseTypes"]];
   type InteractionTypes = Constants["InteractionTypes"][keyof Constants["InteractionTypes"]];
 
@@ -1300,6 +1300,9 @@ declare namespace Dysnomia {
     };
     type: Constants["InteractionResponseTypes"]["DEFERRED_UPDATE_MESSAGE" | "DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE"];
   }
+  interface InteractionResponseLaunchActivity extends InteractionResponseBase {
+    type: Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"];
+  }
   interface InteractionResponseMessage extends InteractionResponseBase {
     data: RawInteractionContent;
     type: Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE" | "PREMIUM_REQUIRED"];
@@ -1309,8 +1312,12 @@ declare namespace Dysnomia {
     type: Constants["InteractionResponseTypes"]["MODAL"];
 
   }
-  interface InteractionResponsePong {
+  interface InteractionResponsePong extends InteractionResponseBase {
     type: Constants["InteractionResponseTypes"]["PONG"];
+  }
+  /** @deprecated */
+  interface InteractionResponsePremiumRequired extends InteractionResponseBase {
+    type: Constants["InteractionResponseTypes"]["PREMIUM_REQUIRED"];
   }
 
   interface RawInteractionContent extends Pick<WebhookPayload, "content" | "embeds" | "tts" | "flags" | "components"> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1254,9 +1254,7 @@ declare namespace Dysnomia {
     resource: T extends Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE" | "LAUNCH_ACTIVITY"]
       ? {
         type: T;
-        activity_instance: T extends Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"] ? {
-          id: string;
-        } : never;
+        activity_instance: T extends Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"] ? ActivityInstance : never;
         message: T extends Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE"] ? {
           id: string;
           [key: string]: unknown;
@@ -1275,9 +1273,6 @@ declare namespace Dysnomia {
   interface InteractionDataOptionsSubCommandGroup extends InteractionDataOptionsBase<Constants["ApplicationCommandOptionTypes"]["SUB_COMMAND_GROUP"]> {
     // technically these can have zero options, but it will then not show in the client so it's effectively not possible
     options: (InteractionDataOptionsSubCommand | InteractionDataOptionsWithValue)[];
-  }
-  interface InteractionLaunchActivityOptions {
-    withResponse?: boolean;
   }
   interface InteractionModalContent {
     title: string;
@@ -1961,6 +1956,11 @@ declare namespace Dysnomia {
   interface OAuthInstallParams {
     scopes: string[];
     permissions: string;
+  }
+
+  // Activities
+  interface ActivityInstance {
+    id: string;
   }
   /* eslint-disable @stylistic/key-spacing, @stylistic/no-multi-spaces */
   interface Constants {
@@ -3125,7 +3125,7 @@ declare namespace Dysnomia {
     editMessage(messageID: string, content: string | InteractionContentEdit): Promise<Message>;
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
+    launchActivity(): Promise<ActivityInstance>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }
@@ -3151,7 +3151,7 @@ declare namespace Dysnomia {
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
+    launchActivity(): Promise<ActivityInstance>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }
@@ -3693,7 +3693,7 @@ declare namespace Dysnomia {
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
+    launchActivity(): Promise<ActivityInstance>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1276,6 +1276,9 @@ declare namespace Dysnomia {
     // technically these can have zero options, but it will then not show in the client so it's effectively not possible
     options: (InteractionDataOptionsSubCommand | InteractionDataOptionsWithValue)[];
   }
+  interface InteractionLaunchActivityOptions {
+    withResponse?: boolean;
+  }
   interface InteractionModalContent {
     title: string;
     custom_id: string;
@@ -3122,7 +3125,7 @@ declare namespace Dysnomia {
     editMessage(messageID: string, content: string | InteractionContentEdit): Promise<Message>;
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity(): Promise<void>;
+    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }
@@ -3148,7 +3151,7 @@ declare namespace Dysnomia {
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity(): Promise<void>;
+    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }
@@ -3690,7 +3693,7 @@ declare namespace Dysnomia {
     editOriginalMessage(content: string | InteractionContentEdit): Promise<Message>;
     editParent(content: InteractionContentEdit): Promise<Message>;
     getOriginalMessage(): Promise<Message>;
-    launchActivity(): Promise<void>;
+    launchActivity<T extends InteractionLaunchActivityOptions>(options?: T): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"]> : void>;
     /** @deprecated */
     requirePremium(): Promise<void>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,7 @@ declare namespace Dysnomia {
   type InteractionDataOptionsWithOptions = InteractionDataOptionsSubCommand | InteractionDataOptionsSubCommandGroup;
   type InteractionDataOptionsWithValue = InteractionDataOptionsString | InteractionDataOptionsInteger | InteractionDataOptionsBoolean | InteractionDataOptionsUser | InteractionDataOptionsChannel | InteractionDataOptionsRole | InteractionDataOptionsMentionable | InteractionDataOptionsNumber;
   type InteractionResponse = InteractionResponseAutocomplete | InteractionResponseDeferred | InteractionResponseMessage;
+  type InteractionResponseTypes = Constants["InteractionResponseTypes"][keyof Constants["InteractionResponseTypes"]];
   type InteractionTypes = Constants["InteractionTypes"][keyof Constants["InteractionTypes"]];
 
   // Invite
@@ -1241,6 +1242,27 @@ declare namespace Dysnomia {
     values: string[];
     resolved?: InteractionResolvedData;
   }
+  interface InteractionCallbackResponse<T extends InteractionResponseTypes = InteractionResponseTypes> {
+    interaction: {
+      id: string;
+      type: InteractionTypes;
+      activity_instance_id?: string;
+      response_message_id?: string;
+      response_message_loading?: boolean;
+      response_message_ephemeral?: boolean;
+    };
+    resource: T extends Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE" | "LAUNCH_ACTIVITY"]
+      ? {
+        type: T;
+        activity_instance: T extends Constants["InteractionResponseTypes"]["LAUNCH_ACTIVITY"] ? {
+          id: string;
+        } : never;
+        message: T extends Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE"] ? {
+          id: string;
+          [key: string]: unknown;
+        } : never;
+      } : never;
+  }
   interface InteractionDataOptionsBase<T extends ApplicationCommandOptionsTypes, V = unknown> {
     focused?: T extends ApplicationCommandOptionsTypesWithAutocomplete ? boolean : never;
     name: string;
@@ -1265,21 +1287,24 @@ declare namespace Dysnomia {
     roles?: Collection<Role>;
     users?: Collection<User>;
   }
-  interface InteractionResponseAutocomplete {
+  interface InteractionResponseAutocomplete extends InteractionResponseBase {
     data: ApplicationCommandOptionsChoice[];
     type: Constants["InteractionResponseTypes"]["APPLICATION_COMMAND_AUTOCOMPLETE_RESULT"];
   }
-  interface InteractionResponseDeferred {
+  interface InteractionResponseBase {
+    withResponse?: boolean;
+  }
+  interface InteractionResponseDeferred extends InteractionResponseBase {
     data?: {
       flags?: number;
     };
     type: Constants["InteractionResponseTypes"]["DEFERRED_UPDATE_MESSAGE" | "DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE"];
   }
-  interface InteractionResponseMessage {
+  interface InteractionResponseMessage extends InteractionResponseBase {
     data: RawInteractionContent;
     type: Constants["InteractionResponseTypes"]["CHANNEL_MESSAGE_WITH_SOURCE" | "UPDATE_MESSAGE" | "PREMIUM_REQUIRED"];
   }
-  interface InteractionResponseModal {
+  interface InteractionResponseModal extends InteractionResponseBase {
     data: InteractionModalContent;
     type: Constants["InteractionResponseTypes"]["MODAL"];
 
@@ -2855,7 +2880,7 @@ declare namespace Dysnomia {
     createGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, event: GuildScheduledEventOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createGuildTemplate(guildID: string, name: string, description?: string | null): Promise<GuildTemplate>;
-    createInteractionResponse(interactionID: string, interactionToken: string, options: InteractionResponse, file?: FileContent | FileContent[]): Promise<void>;
+    createInteractionResponse<T extends InteractionResponse>(interactionID: string, interactionToken: string, options: T, file?: FileContent | FileContent[]): Promise<T["withResponse"] extends true ? InteractionCallbackResponse<T["type"]> : void>;
     createMessage(channelID: string, content: MessageContent<"hasNonce">): Promise<Message>;
     createRole(guildID: string, options?: RoleOptions, reason?: string): Promise<Role>;
     createRole(guildID: string, options?: Role, reason?: string): Promise<Role>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -799,7 +799,7 @@ class Client extends EventEmitter {
      * @param {String} [file.fieldName] The multipart field name
      * @param {Buffer} file.file A buffer containing file data
      * @param {String} file.name What to name the file
-     * @returns {Promise<Object?>}
+     * @returns {Promise<Object?>} If `options.withResponse` is true, returns an [interaction callback response object](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object).
      */
     createInteractionResponse(interactionID, interactionToken, options, file) {
         let qs = "";

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -794,14 +794,21 @@ class Client extends EventEmitter {
      * @param {Object} options The options object.
      * @param {Object} [options.data] The data to send with the response. **WARNING: This call expects raw API data and does not transform it in any way.**
      * @param {Number} options.type The response type to send. See [the official Discord API documentation entry](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type) for valid types
+     * @param {Boolean} [options.withResponse=false] Whether to respond with an interaction callback response or not
      * @param {Object | Array<Object>} [file] A file object (or an Array of them)
      * @param {String} [file.fieldName] The multipart field name
      * @param {Buffer} file.file A buffer containing file data
      * @param {String} file.name What to name the file
-     * @returns {Promise}
+     * @returns {Promise<Object?>}
      */
     createInteractionResponse(interactionID, interactionToken, options, file) {
-        return this.requestHandler.request("POST", Endpoints.INTERACTION_RESPOND(interactionID, interactionToken), true, options, file, "/interactions/:id/:token/callback");
+        let qs = "";
+        const withResponse = !!options.withResponse;
+        options.withResponse = undefined;
+        if(withResponse) {
+            qs += "&with_response=true";
+        }
+        return this.requestHandler.request("POST", Endpoints.INTERACTION_RESPOND(interactionID, interactionToken) + (qs ? "?" + qs : ""), true, options, file, "/interactions/:id/:token/callback");
     }
 
     /**

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -152,7 +152,7 @@ class CommandInteraction extends Interaction {
      * @param {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
      * @param {Object} [content.poll] A poll object. See [Discord's Documentation](https://discord.com/developers/docs/resources/poll#poll-create-request-object-poll-create-request-object-structure) for object structure
      * @param {Boolean} [content.tts] Set the message TTS flag
-     * @returns {Promise}
+     * @returns {Promise<Message>}
      */
     createMessage(content) {
         if(this.acknowledged === true) {
@@ -176,8 +176,12 @@ class CommandInteraction extends Interaction {
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
-        }, files).then(() => this.update());
+            data: content,
+            withResponse: true
+        }, files).then((resp) => {
+            this.update();
+            return new Message(resp.resource.message, this);
+        });
     }
 
     /**

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -180,7 +180,7 @@ class CommandInteraction extends Interaction {
             withResponse: true
         }, files).then((resp) => {
             this.update();
-            return new Message(resp.resource.message, this);
+            return new Message(resp.resource.message, this.#client);
         });
     }
 

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -324,17 +324,15 @@ class CommandInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @param {Object} [options] Options for the activity
-     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object>} Returns [the created activity instance](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-activity-instance-resource)
      */
-    launchActivity(options = {}) {
+    launchActivity() {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.LAUNCH_ACTIVITY,
-            withResponse: !!options.withResponse
+            withResponse: true
         }).then((resp) => {
             this.update();
-            return resp;
+            return resp.resource.activity_instance;
         });
     }
 

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -324,12 +324,18 @@ class CommandInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @returns {Promise}
+     * @param {Object} [options] Options for the activity
+     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
+     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
-    launchActivity() {
+    launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.LAUNCH_ACTIVITY
-        }).then(() => this.update());
+            type: InteractionResponseTypes.LAUNCH_ACTIVITY,
+            withResponse: !!options.withResponse
+        }).then((resp) => {
+            this.update();
+            return resp;
+        });
     }
 
     /**

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -326,7 +326,7 @@ class CommandInteraction extends Interaction {
      * Responds to the interaction with launching an activity
      * @param {Object} [options] Options for the activity
      * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
     launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -333,7 +333,7 @@ class ComponentInteraction extends Interaction {
      * @param {Array<Object>} [content.embeds] An array of embed objects. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
      * @param {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
      * @param {Boolean} [content.tts] Set the message TTS flag
-     * @returns {Promise}
+     * @returns {Promise<Message>}
      */
     editParent(content) {
         if(this.acknowledged === true) {
@@ -357,8 +357,12 @@ class ComponentInteraction extends Interaction {
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.UPDATE_MESSAGE,
-            data: content
-        }, files).then(() => this.update());
+            data: content,
+            withResponse: true
+        }, files).then((resp) => {
+            this.update();
+            return new Message(resp.resource.message, this.#client);
+        });
     }
 
     /**

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -141,7 +141,7 @@ class ComponentInteraction extends Interaction {
      * @param {Number} [content.flags] A number representing the flags to apply. See [Discord's Documentation](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for a list
      * @param {Object} [content.poll] A poll object. See [Discord's Documentation](https://discord.com/developers/docs/resources/poll#poll-create-request-object-poll-create-request-object-structure) for object structure
      * @param {Boolean} [content.tts] Set the message TTS flag
-     * @returns {Promise}
+     * @returns {Promise<Message>}
      */
     createMessage(content) {
         if(this.acknowledged === true) {
@@ -165,8 +165,12 @@ class ComponentInteraction extends Interaction {
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
-        }, files).then(() => this.update());
+            data: content,
+            withResponse: true
+        }, files).then((resp) => {
+            this.update();
+            return new Message(resp.resource.message, this);
+        });
     }
 
     /**

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -169,7 +169,7 @@ class ComponentInteraction extends Interaction {
             withResponse: true
         }, files).then((resp) => {
             this.update();
-            return new Message(resp.resource.message, this);
+            return new Message(resp.resource.message, this.#client);
         });
     }
 

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -381,7 +381,7 @@ class ComponentInteraction extends Interaction {
      * Responds to the interaction with launching an activity
      * @param {Object} [options] Options for the activity
      * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
     launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -379,17 +379,15 @@ class ComponentInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @param {Object} [options] Options for the activity
-     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object>} Returns [the created activity instance](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-activity-instance-resource)
      */
-    launchActivity(options = {}) {
+    launchActivity() {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.LAUNCH_ACTIVITY,
-            withResponse: !!options.withResponse
+            withResponse: true
         }).then((resp) => {
             this.update();
-            return resp;
+            return resp.resource.activity_instance;
         });
     }
 

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -379,12 +379,18 @@ class ComponentInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @returns {Promise}
+     * @param {Object} [options] Options for the activity
+     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
+     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
-    launchActivity() {
+    launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.LAUNCH_ACTIVITY
-        }).then(() => this.update());
+            type: InteractionResponseTypes.LAUNCH_ACTIVITY,
+            withResponse: !!options.withResponse
+        }).then((resp) => {
+            this.update();
+            return resp;
+        });
     }
 
     /**

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -115,7 +115,7 @@ class ModalSubmitInteraction extends Interaction {
             withResponse: true
         }, files).then((resp) => {
             this.update();
-            return new Message(resp.resource.message, this);
+            return new Message(resp.resource.message, this.#client);
         });
     }
 

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Interaction = require("./Interaction");
+const Message = require("./Message");
 
 const {InteractionResponseTypes} = require("../Constants");
 const emitDeprecation = require("../util/emitDeprecation");
@@ -86,7 +87,7 @@ class ModalSubmitInteraction extends Interaction {
      * @param {Boolean} [content.flags] 64 for Ephemeral
      * @param {Object} [content.poll] A poll object. See [Discord's Documentation](https://discord.com/developers/docs/resources/poll#poll-create-request-object-poll-create-request-object-structure) for object structure
      * @param {Boolean} [content.tts] Set the message TTS flag
-     * @returns {Promise}
+     * @returns {Promise<Message>}
      */
     async createMessage(content) {
         if(this.acknowledged === true) {
@@ -110,8 +111,12 @@ class ModalSubmitInteraction extends Interaction {
 
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: content
-        }, files).then(() => this.update());
+            data: content,
+            withResponse: true
+        }, files).then((resp) => {
+            this.update();
+            return new Message(resp.resource.message, this);
+        });
     }
 
     /**

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -263,7 +263,7 @@ class ModalSubmitInteraction extends Interaction {
      * @param {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
      * @param {Boolean} [content.flags] 64 for Ephemeral
      * @param {Boolean} [content.tts] Set the message TTS flag
-     * @returns {Promise}
+     * @returns {Promise<Message>}
      */
     async editParent(content) {
         if(this.acknowledged === true) {
@@ -288,7 +288,10 @@ class ModalSubmitInteraction extends Interaction {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.UPDATE_MESSAGE,
             data: content
-        }, files).then(() => this.update());
+        }, files).then((resp) => {
+            this.update();
+            return new Message(resp.resource.message, this.#client);
+        });
     }
 
     /**

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -308,17 +308,15 @@ class ModalSubmitInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @param {Object} [options] Options for the activity
-     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object>} Returns [the created activity instance](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-activity-instance-resource)
      */
-    launchActivity(options = {}) {
+    launchActivity() {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
             type: InteractionResponseTypes.LAUNCH_ACTIVITY,
-            withResponse: !!options.withResponse
+            withResponse: true
         }).then((resp) => {
             this.update();
-            return resp;
+            return resp.resource.activity_instance;
         });
     }
 

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -310,7 +310,7 @@ class ModalSubmitInteraction extends Interaction {
      * Responds to the interaction with launching an activity
      * @param {Object} [options] Options for the activity
      * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
-     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
+     * @returns {Promise<Object?>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
     launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -308,12 +308,18 @@ class ModalSubmitInteraction extends Interaction {
 
     /**
      * Responds to the interaction with launching an activity
-     * @returns {Promise}
+     * @param {Object} [options] Options for the activity
+     * @param {Boolean} [options.withResponse] Whether to respond with the activity instance data
+     * @returns {Promise<Object>} If `options.withResponse` is true, returns [the interaction callback response data](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback-interaction-callback-response-object)
      */
-    launchActivity() {
+    launchActivity(options = {}) {
         return this.#client.createInteractionResponse.call(this.#client, this.id, this.token, {
-            type: InteractionResponseTypes.LAUNCH_ACTIVITY
-        }).then(() => this.update());
+            type: InteractionResponseTypes.LAUNCH_ACTIVITY,
+            withResponse: !!options.withResponse
+        }).then((resp) => {
+            this.update();
+            return resp;
+        });
     }
 
     /**


### PR DESCRIPTION
Separated from #162 as this change is broader.

Adds support for the `with_response` parameter for the interaction callback. This is leveraged: 
- [x] in interaction `createMessage`/`editParent` calls to return a fully-fledged Message object
- [x] in interaction `launchActivity` calls to return the callback response


Not so sure about including this parameter for other Interaction methods as the usefulness of the data is nearly zero as it is available in user code while performing the interaction.

Ref: https://github.com/discord/discord-api-docs/commit/8bc883cb09135521fda2ae2a123c5d3ae791b605