### PR TITLE
feat(voice): use StableLib as a non-native fallback

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -19,6 +19,7 @@ try {
     EventEmitter = require("node:events").EventEmitter;
 }
 
+let StableLib = null;
 let Sodium = null;
 let crypto = null;
 let aes256Available = false;
@@ -92,6 +93,7 @@ class VoiceConnection extends EventEmitter {
 
     #nonce = 0;
     #nonceBuffer = null;
+    #stablelib = null;
     sequence = 0;
     speaking = false;
     ssrcUserMap = {};
@@ -116,7 +118,13 @@ class VoiceConnection extends EventEmitter {
             try {
                 Sodium = require("sodium-native");
             } catch{
-                throw new Error("Error loading libsodium, voice not available");
+                if(!StableLib) {
+                    try {
+                        StableLib = require("@stablelib/xchacha20poly1305");
+                    } catch{
+                        throw new Error("Error loading libsodium/stablelib, voice not available");
+                    }
+                }
             }
         }
 
@@ -330,6 +338,9 @@ class VoiceConnection extends EventEmitter {
                     this.mode = packet.d.mode;
                     this.secret = Buffer.from(packet.d.secret_key);
                     this.#nonceBuffer = Buffer.alloc(this.mode === "aead_aes256_gcm_rtpsize" ? 12 : 24);
+                    if(this.mode === "aead_xchacha20_poly1305_rtpsize" && StableLib) {
+                        this.#stablelib = new StableLib.XChaCha20Poly1305(this.secret);
+                    }
                     this.connecting = false;
                     this.reconnecting = false;
                     this.ready = true;
@@ -523,6 +534,7 @@ class VoiceConnection extends EventEmitter {
             this.sessionID = null;
             this.token = null;
             this.wsSequence = -1;
+            this.#stablelib = null;
             this.updateVoiceState();
             /**
              * Fired when the voice connection disconnects
@@ -697,6 +709,17 @@ class VoiceConnection extends EventEmitter {
                     nonce,
                     this.secret
                 );
+            } else if(this.#stablelib) {
+                data = this.#stablelib.open(
+                    nonce,
+                    msg.subarray(headerSize, msg.length - 4),
+                    msg.subarray(0, headerSize)
+                );
+                if(!data) {
+                    return this.emit("warn", "Failed to unseal received packet");
+                }
+                // Stablelib returns a UInt8Array, but we should keep it a buffer to be consistent
+                data = Buffer.from(data);
             }
 
             // RFC3550 5.1: Padding (may need testing)
@@ -951,6 +974,18 @@ class VoiceConnection extends EventEmitter {
                 null,
                 this.#nonceBuffer,
                 this.secret
+            );
+            this.sendHeader.copy(this.sendBuffer, 0, 0, headerSize);
+            this.#nonceBuffer.copy(this.sendBuffer, headerSize + length, 0, 4); // nonce padding
+            return this.sendUDPPacket(this.sendBuffer.subarray(0, headerSize + length + 4));
+        } else if(this.#stablelib) {
+            const length = frame.length + StableLib.TAG_LENGTH;
+            this.sendBuffer.fill(0, headerSize + frame.length, headerSize + length);
+            this.#stablelib.seal(
+                this.#nonceBuffer,
+                frame,
+                this.sendHeader,
+                this.sendBuffer.subarray(headerSize, headerSize + length)
             );
             this.sendHeader.copy(this.sendBuffer, 0, 0, headerSize);
             this.#nonceBuffer.copy(this.sendBuffer, headerSize + length, 0, 4); // nonce padding

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -719,7 +719,7 @@ class VoiceConnection extends EventEmitter {
                     return this.emit("warn", "Failed to unseal received packet");
                 }
                 // Stablelib returns a UInt8Array, but we should keep it a buffer to be consistent
-                data = Buffer.from(data);
+                data = Buffer.from(data.buffer);
             }
 
             // RFC3550 5.1: Padding (may need testing)

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -114,7 +114,7 @@ class VoiceConnection extends EventEmitter {
             emittedBrowserLikeRuntimeWarning = true;
         }
 
-        if(!Sodium) {
+        if(!Sodium && !StableLib) {
             try {
                 Sodium = require("sodium-native");
             } catch{

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "typescript-eslint": "^8.6.0"
   },
   "optionalDependencies": {
+    "@stablelib/xchacha20poly1305": "~1.0.1",
     "opusscript": "^0.1.1"
   },
   "browser": {
@@ -76,6 +77,9 @@
   },
   "peerDependenciesMeta": {
     "@discordjs/opus": {
+      "optional": true
+    },
+    "@stablelib/xchacha20poly1305": {
       "optional": true
     },
     "eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -79,9 +79,6 @@
     "@discordjs/opus": {
       "optional": true
     },
-    "@stablelib/xchacha20poly1305": {
-      "optional": true
-    },
     "eventemitter3": {
       "optional": true
     },


### PR DESCRIPTION
Use [StableLib](https://github.com/StableLib/stablelib)'s `@stablelib/xchacha20poly1305` module for non-native support. The package is locked to version 1 due to ESM.