### PR TITLE
fix(Client): correctly return an array in `getApplicationEmojis`

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2220,7 +2220,7 @@ class Client extends EventEmitter {
      * @returns {Promise<Object[]>} An array of emoji objects with creator data
      */
     getApplicationEmojis() {
-        return this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJIS(this.application.id), true);
+        return this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJIS(this.application.id), true).then((data) => data.items);
     }
 
     /**


### PR DESCRIPTION
The raw response was returned, which is in violation of the documented behavior