### PR TITLE
fix(Client): assign id in `getRESTGuildVoiceState`

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3050,7 +3050,10 @@ class Client extends EventEmitter {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Dysnomia REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD_VOICE_STATE(guildID, userID), true).then((state) => new VoiceState(state));
+        return this.requestHandler.request("GET", Endpoints.GUILD_VOICE_STATE(guildID, userID), true).then((state) => {
+            state.id = state.user_id;
+            return new VoiceState(state);
+        });
     }
 
     /**


### PR DESCRIPTION
VoiceState takes its ID from the id property on the raw structure, which isn't assigned on the raw API response. A proper solution for this will be done in a later release.