### PR TITLE
fix(Interaction): set the member ID even if the guild is not cached

### DIFF
--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -95,8 +95,8 @@ class Interaction extends Base {
         }
 
         if(data.member !== undefined) {
+            data.member.id = data.member.user.id;
             if(this.channel.guild) {
-                data.member.id = data.member.user.id;
                 /**
                  * The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)
                  * @type {Member?}


### PR DESCRIPTION
Ref: https://github.com/abalabahaha/eris/issues/1512