### PR TITLE
fix(types): correct `OAuthApplicationInfo#integration_types_config` inner object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2001,7 +2001,7 @@ declare namespace Dysnomia {
     id: string;
     install_params?: OAuthInstallParams;
     integration_types_config?: Record<ApplicationIntegrationTypes, {
-      install_params?: OAuthInstallParams;
+      oauth2_install_params?: OAuthInstallParams;
     }>;
     interactions_endpoint_url?: string;
     name: string;


### PR DESCRIPTION
Got my notes wrong, it's `oauth2_install_params`, not `install_params` :(