### PR TITLE
fix(Message): construct interaction metadata construction

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -162,7 +162,7 @@ class Message extends Base {
              * An object containing metadata about the interaction the message is responding to, if applicable
              * @type {InteractionMetadata?}
              */
-            this.interactionMetadata = new InteractionMetadata(data, client);
+            this.interactionMetadata = new InteractionMetadata(data.interaction_metadata, client);
         }
 
         if(this.channel.guild) {


### PR DESCRIPTION
This unfortunately broke Message construction entirely, so this is released as a hotfix