### PR TITLE
fix(GuildScheduledEvent): recurrence rules may be nullable

### DIFF
--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -129,20 +129,22 @@ class GuildScheduledEvent extends Base {
         if(data.recurrence_rule !== undefined) {
             /**
              * The recurrence rules for the event
-             * @type {GuildScheduledEvent.RecurrenceRule}
+             * @type {GuildScheduledEvent.RecurrenceRule?}
              */
-            this.recurrenceRule = {
-                start: Date.parse(data.recurrence_rule.start),
-                end: data.recurrence_rule.end ? Date.parse(data.recurrence_rule.end) : null,
-                frequency: data.recurrence_rule.frequency,
-                interval: data.recurrence_rule.interval,
-                byWeekday: data.recurrence_rule.by_weekday,
-                byNWeekday: data.recurrence_rule.by_n_weekday,
-                byMonth: data.recurrence_rule.by_month,
-                byMonthDay: data.recurrence_rule.by_month_day,
-                byYearDay: data.recurrence_rule.by_year_day,
-                count: data.recurrence_rule.count
-            };
+            this.recurrenceRule = data.recurrence_rule != null
+                ? {
+                        start: Date.parse(data.recurrence_rule.start),
+                        end: data.recurrence_rule.end ? Date.parse(data.recurrence_rule.end) : null,
+                        frequency: data.recurrence_rule.frequency,
+                        interval: data.recurrence_rule.interval,
+                        byWeekday: data.recurrence_rule.by_weekday,
+                        byNWeekday: data.recurrence_rule.by_n_weekday,
+                        byMonth: data.recurrence_rule.by_month,
+                        byMonthDay: data.recurrence_rule.by_month_day,
+                        byYearDay: data.recurrence_rule.by_year_day,
+                        count: data.recurrence_rule.count
+                    }
+                : null;
         }
     }
 


### PR DESCRIPTION
This was apparently forgotten when I decided to transform the event object and fell under the radar due to the guilds intent being disabled on my testing bot.