### PR TITLE
fix(Message): fix message with snapshot construction in known guild

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -176,7 +176,7 @@ class Message extends Base {
                  * @type {Member?}
                  */
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else if(this.channel.guild.members.has(this.author.id)) {
+            } else if(this.author && this.channel.guild.members.has(this.author.id)) {
                 this.member = this.channel.guild.members.get(this.author.id);
             } else {
                 this.member = null;


### PR DESCRIPTION
Got this error a bunch during deployment... Seems to be because during the message.channel.guild check it doesn't account for null authors.