### PR TITLE
docs(ApplicationCommand, Attachment): fix `id` type in jsdoc

### DIFF
--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -10,7 +10,7 @@ class ApplicationCommand extends Base {
     /**
      * The ID of the application command
      * @override
-     * @member {Number} ApplicationCommand#id
+     * @member {String} ApplicationCommand#id
      */
 
     #client;

--- a/lib/structures/Attachment.js
+++ b/lib/structures/Attachment.js
@@ -10,7 +10,7 @@ class Attachment extends Base {
     /**
      * The attachment ID
      * @override
-     * @member {Number} Attachment#id
+     * @member {String} Attachment#id
      */
 
     constructor(data) {


### PR DESCRIPTION
Somehow, this managed to flow under the radar…