### PR TITLE
fix(types): add `globalName` alias to `Member`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3780,6 +3780,7 @@ declare namespace Dysnomia {
     discriminator: string;
     flags: number;
     game: Activity | null;
+    globalName: string | null;
     guild: Guild;
     id: string;
     joinedAt: number | null;


### PR DESCRIPTION
The alias is present in JS, see ref.

Ref: https://github.com/projectdysnomia/dysnomia/blob/cfb9dff454c4e2634fcfb8e0e896bfeb2dadbe79/lib/structures/Member.js#L247