### PR TITLE
types(UnfurledMediaItem): add response-only properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1796,6 +1796,10 @@ declare namespace Dysnomia {
   }
   interface UnfurledMediaItem {
     url: string;
+    proxy_url?: string;
+    height?: number | null;
+    width?: number | null;
+    content_type?: string;
   }
   interface URLButton extends ButtonBase {
     style: Constants["ButtonStyles"]["LINK"];


### PR DESCRIPTION
Added the types as although they're not useful for most usages (i. e. sending), they might still be a bit useful when receiving.

Ref: https://github.com/discord/discord-api-docs/commit/af1843d15bca8fffb76e1421fbb060761361d469
