### PR TITLE
fix(types): widen the `AnyChannel` type to cover all channel types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,10 +69,12 @@ declare namespace Dysnomia {
   interface Uncached { id: string }
 
   // Channel
-  type AnyChannel = AnyGuildChannel | GroupChannel | PrivateChannel;
-  type AnyGuildChannel = GuildTextableChannel | AnyVoiceChannel | CategoryChannel;
+  type AnyChannel = AnyNonThreadChannel | AnyThreadChannel;
+  type AnyGuildChannel = GuildTextableChannel | AnyVoiceChannel | CategoryChannel | GuildThreadOnlyChannel;
+  type AnyNonThreadChannel = AnyGuildChannel | GroupChannel | PrivateChannel;
   type AnyThreadChannel = NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel | ThreadChannel;
   type AnyVoiceChannel = TextVoiceChannel | StageChannel;
+  type GuildThreadOnlyChannel = ForumChannel | MediaChannel;
   type GuildTextableChannel = TextChannel | TextVoiceChannel | NewsChannel | StageChannel;
   type GuildTextableWithThreads = GuildTextableChannel | AnyThreadChannel;
   type InviteChannel = InvitePartialChannel | Exclude<AnyGuildChannel, CategoryChannel | AnyThreadChannel>;
@@ -777,7 +779,7 @@ declare namespace Dysnomia {
     autoModerationRuleDelete: [guild: Guild, rule: AutoModerationRule];
     autoModerationRuleUpdate: [guild: Guild, rule: AutoModerationRule | null, newRule: AutoModerationRule];
     channelCreate: [channel: AnyGuildChannel];
-    channelDelete: [channel: AnyChannel];
+    channelDelete: [channel: AnyNonThreadChannel];
     channelPinUpdate: [channel: TextableChannel, timestamp: number, oldTimestamp: number];
     channelUpdate: [channel: AnyGuildChannel, oldChannel: OldGuildChannel | OldGuildTextChannel | OldVoiceChannel];
     connect: [id: number];


### PR DESCRIPTION
Widening the type makes it better correspond with what can be passed/returned in JS. However, this may be breaking for consumers that rely on `AnyChannel` not containing thread types - use `AnyNonThreadChannel` if this is the case.

Fixes #200.