### PR TITLE
chore(BrowserWebSocket): hint arraybuffer preference

### DIFF
--- a/lib/util/BrowserWebSocket.js
+++ b/lib/util/BrowserWebSocket.js
@@ -35,6 +35,7 @@ class BrowserWebSocket extends EventEmitter {
         }
 
         this.#ws = new window.WebSocket(url);
+        this.#ws.binaryType = "arraybuffer";
         this.#ws.onopen = () => this.emit("open");
         this.#ws.onmessage = this.#onMessage.bind(this);
         this.#ws.onerror = (event) => this.emit("error", new BrowserWebSocketError("Unknown error", event));


### PR DESCRIPTION
Setting `binaryType` on Web API WebSockets looks to be supported all the way since 2012 [1], the Blob path will be kept in case the data still ends up to be a Blob (although this behavior is very unlikely).

In the future, a migration over to Web API WebSockets may be considered, as modern Node.js LTS releases (22+) have support for them.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/binaryType#browser_compatibility