### PR TITLE
fix: make UDP and IP discovery more reliable

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -322,7 +322,7 @@ class VoiceConnection extends EventEmitter {
                     });
                     this.udpTimeout = setTimeout(() => {
                         if(!this.ready) {
-                            this.disconnect(new Error("UDP response timeout"));
+                            this.disconnect(new Error("IP discovery timeout"));
                         }
                         this.udpTimeout = null;
                     }, 10000).unref();

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -98,6 +98,7 @@ class VoiceConnection extends EventEmitter {
     speaking = false;
     ssrcUserMap = {};
     timestamp = 0;
+    udpTimeout = null;
     wsSequence = -1;
 
     // frameSize and pcmSize must come after the properties they reference to get initialized correctly
@@ -194,6 +195,7 @@ class VoiceConnection extends EventEmitter {
             return;
         }
         clearTimeout(this.connectionTimeout);
+        clearTimeout(this.udpTimeout);
         this.connectionTimeout = setTimeout(() => {
             if(this.connecting) {
                 this.disconnect(new Error("Voice connection timeout"));
@@ -289,6 +291,10 @@ class VoiceConnection extends EventEmitter {
                         }
                     });
                     this.udpSocket.once("message", (packet) => {
+                        if(this.udpTimeout) {
+                            clearTimeout(this.udpTimeout);
+                            this.udpTimeout = null;
+                        }
                         let i = 8;
                         while(packet[i] !== 0) {
                             i++;
@@ -314,7 +320,13 @@ class VoiceConnection extends EventEmitter {
                             this.disconnect(err);
                         }
                     });
-                    const udpMessage = Buffer.allocUnsafe(74);
+                    this.udpTimeout = setTimeout(() => {
+                        if(!this.ready) {
+                            this.disconnect(new Error("UDP response timeout"));
+                        }
+                        this.udpTimeout = null;
+                    }, 10000).unref();
+                    const udpMessage = Buffer.alloc(74);
                     udpMessage.writeUInt16BE(0x1, 0);
                     udpMessage.writeUInt16BE(70, 2);
                     udpMessage.writeUInt32BE(this.ssrc, 4);

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -93,14 +93,14 @@ class VoiceConnectionManager extends Collection {
             return;
         }
         this.pendingGuilds[data.guild_id].waiting = true;
-        const disconnectHandler = () => {
+        const disconnectHandler = (err) => {
             connection = this.get(data.guild_id);
             if(connection) {
                 connection.removeListener("ready", readyHandler);
                 connection.removeListener("error", errorHandler);
             }
             if(this.pendingGuilds[data.guild_id]) {
-                this.pendingGuilds[data.guild_id].rej(new Error("Disconnected"));
+                this.pendingGuilds[data.guild_id].rej(err || new Error("Disconnected"));
                 delete this.pendingGuilds[data.guild_id];
             }
         };


### PR DESCRIPTION
Found a couple of issues when it comes to using UDP (and one on voice in general):
- If the UDP doesn't respond, the connection doesn't properly time that out
- It *seems* that some voice servers may reject our packet if it has some garbage data from using `Buffer.allocUnsafe`, although I can't exactly pinpoint the voice servers doing this, it seems to be newer ones.
- When using the VoiceConnectionManager to join channels, the disconnect error doesn't propogate up and rather always uses the "Disconnected" error. 

Also noticed that the voice connection timeout uses the gateway options instead of its own, and i didn't make a UDP timeout option yet. Maybe it is time to make a new `voice` options prop.