### PR TITLE
feat: support paginated pins

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -432,6 +432,10 @@ declare namespace Dysnomia {
     limit?: number;
     withMember?: boolean;
   }
+  interface GetPinsOptions {
+    before?: Date;
+    limit?: number;
+  }
   interface GuildPinnable extends Pinnable {
     lastPinTimestamp: number | null;
     topic?: string | null;
@@ -461,6 +465,14 @@ declare namespace Dysnomia {
     getPins(): Promise<Message[]>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
+  }
+  interface GetPinsResponse {
+    hasMore: boolean;
+    items: MessagePin[];
+  }
+  interface MessagePin {
+    pinnedAt: number;
+    message: Message;
   }
   interface PurgeChannelOptions {
     after?: string;
@@ -3278,6 +3290,7 @@ declare namespace Dysnomia {
     getNitroStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getOAuthApplication(): Promise<OAuthApplicationInfo>;
     getPins(channelID: string): Promise<Message[]>;
+    getPinsPaginated(channelID: string, options?: GetPinsOptions): Promise<GetPinsResponse>;
     getPollAnswerVoters(channelID: string, messageID: string, answerID: number, options?: GetPollAnswerVotersOptions): Promise<User[]>;
     getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
     getRESTChannel(channelID: string): Promise<AnyChannel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -463,6 +463,7 @@ declare namespace Dysnomia {
   }
   interface Pinnable {
     getPins(): Promise<Message[]>;
+    getPins(options: GetPinsOptions): Promise<GetPinsResponse>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
   }
@@ -3290,7 +3291,7 @@ declare namespace Dysnomia {
     getNitroStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getOAuthApplication(): Promise<OAuthApplicationInfo>;
     getPins(channelID: string): Promise<Message[]>;
-    getPinsPaginated(channelID: string, options?: GetPinsOptions): Promise<GetPinsResponse>;
+    getPins(channelID: string, options: GetPinsOptions): Promise<GetPinsResponse>;
     getPollAnswerVoters(channelID: string, messageID: string, answerID: number, options?: GetPollAnswerVotersOptions): Promise<User[]>;
     getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
     getRESTChannel(channelID: string): Promise<AnyChannel>;
@@ -4014,6 +4015,7 @@ declare namespace Dysnomia {
     getMessage(messageID: string): Promise<Message<this>>;
     getMessages(options?: GetMessagesOptions): Promise<Message<this>[]>;
     getPins(): Promise<Message<this>[]>;
+    getPins(options: GetPinsOptions): Promise<GetPinsResponse>;
   }
 
   export class NewsThreadChannel extends ThreadChannel {
@@ -4071,6 +4073,7 @@ declare namespace Dysnomia {
     getMessageReaction(messageID: string, reaction: string, options?: GetMessageReactionOptions): Promise<User[]>;
     getMessages(options?: GetMessagesOptions): Promise<Message<this>[]>;
     getPins(): Promise<Message<this>[]>;
+    getPins(options: GetPinsOptions): Promise<GetPinsResponse>;
     leave(): Promise<void>;
     pinMessage(messageID: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string): Promise<void>;
@@ -4331,6 +4334,7 @@ declare namespace Dysnomia {
     getMessageReaction(messageID: string, reaction: string, options?: GetMessageReactionOptions): Promise<User[]>;
     getMessages(options?: GetMessagesOptions): Promise<Message<this>[]>;
     getPins(): Promise<Message<this>[]>;
+    getPins(options: GetPinsOptions): Promise<GetPinsResponse>;
     getWebhooks(): Promise<Webhook[]>;
     pinMessage(messageID: string): Promise<void>;
     purge(options: PurgeChannelOptions): Promise<number>;
@@ -4390,6 +4394,7 @@ declare namespace Dysnomia {
     getMessageReaction(messageID: string, reaction: string, options?: GetMessageReactionOptions): Promise<User[]>;
     getMessages(options?: GetMessagesOptions): Promise<Message<this>[]>;
     getPins(): Promise<Message<this>[]>;
+    getPins(options: GetPinsOptions): Promise<GetPinsResponse>;
     join(userID?: string): Promise<void>;
     leave(userID?: string): Promise<void>;
     pinMessage(messageID: string): Promise<void>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2874,32 +2874,28 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Get the first 50 pins in a channel
-     * @param {String} channelID The ID of the channel
-     * @returns {Promise<Array<Message>>} [DEPRECATED]
-     */
-    getPins(channelID) {
-        emitDeprecation("CHANNEL_PINS_NEW");
-        return this.getPinsPaginated(channelID).then((pins) => pins.items.map((pin) => pin.message));
-    }
-
-    /**
-     * Get the pins in a channel
+     * Get pins in a channel
      * @param {String} channelID The ID of the channel
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
-     * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
-     * @returns {Promise<{ hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}> }>}
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
+     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
      */
-    getPinsPaginated(channelID, options = {}) {
-        return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options)
-            .then((pins) => ({
+    getPins(channelID, options) {
+        const p = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options);
+        if(typeof options === "undefined") {
+            emitDeprecation("CHANNEL_PINS_NEW");
+            return p.then((pins) => pins.items.map((pin) => new Message(pin.message, this)));
+        } else {
+            return p.then((pins) => ({
                 hasMore: pins.has_more,
                 items: pins.items.map((pin) => ({
                     pinnedAt: Date.parse(pin.pinned_at),
                     message: new Message(pin.message, this)
                 }))
             }));
+        }
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2879,8 +2879,8 @@ class Client extends EventEmitter {
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
-     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
+     * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
      */
     getPins(channelID, options) {
         const p = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2880,7 +2880,7 @@ class Client extends EventEmitter {
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
      * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} if options are passed.
      */
     getPins(channelID, options) {
         const p = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2874,12 +2874,32 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Get all the pins in a channel
+     * Get the first 50 pins in a channel
      * @param {String} channelID The ID of the channel
-     * @returns {Promise<Array<Message>>}
+     * @returns {Promise<Array<Message>>} [DEPRECATED]
      */
     getPins(channelID) {
-        return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true).then((messages) => messages.map((message) => new Message(message, this)));
+        emitDeprecation("CHANNEL_PINS_NEW");
+        return this.getPinsPaginated(channelID).then((pins) => pins.items.map((pin) => pin.message));
+    }
+
+    /**
+     * Get the pins in a channel
+     * @param {String} channelID The ID of the channel
+     * @param {Object} [options] Options for fetching the pins
+     * @param {Date} [options.before] Get pins before this timestamp
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
+     * @returns {Promise<{ hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}> }>}
+     */
+    getPinsPaginated(channelID, options = {}) {
+        return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options)
+            .then((pins) => ({
+                hasMore: pins.has_more,
+                items: pins.items.map((pin) => ({
+                    pinnedAt: Date.parse(pin.pinned_at),
+                    message: new Message(pin.message, this)
+                }))
+            }));
     }
 
     /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -28,8 +28,8 @@ module.exports.CHANNEL_MESSAGE_REACTIONS =                       (chanID, msgID)
 module.exports.CHANNEL_MESSAGE =                                 (chanID, msgID) => `/channels/${chanID}/messages/${msgID}`;
 module.exports.CHANNEL_MESSAGES =                                       (chanID) => `/channels/${chanID}/messages`;
 module.exports.CHANNEL_PERMISSION =                             (chanID, overID) => `/channels/${chanID}/permissions/${overID}`;
-module.exports.CHANNEL_PIN =                                     (chanID, msgID) => `/channels/${chanID}/pins/${msgID}`;
-module.exports.CHANNEL_PINS =                                           (chanID) => `/channels/${chanID}/pins`;
+module.exports.CHANNEL_PIN =                                     (chanID, msgID) => `/channels/${chanID}/messages/pins/${msgID}`;
+module.exports.CHANNEL_PINS =                                           (chanID) => `/channels/${chanID}/messages/pins`;
 module.exports.CHANNEL_POLL_ANSWERS =                  (chanID, msgID, answerID) => `/channels/${chanID}/polls/${msgID}/answers/${answerID}`;
 module.exports.CHANNEL_POLL_EXPIRE =                             (chanID, msgID) => `/channels/${chanID}/polls/${msgID}/expire`;
 module.exports.CHANNEL_TYPING =                                         (chanID) => `/channels/${chanID}/typing`;

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -157,8 +157,8 @@ class PrivateChannel extends Channel {
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
-     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
+     * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -154,10 +154,14 @@ class PrivateChannel extends Channel {
 
     /**
      * Get all the pins in a text channel
-     * @returns {Promise<Array<Message>>}
+     * @param {Object} [options] Options for fetching the pins
+     * @param {Date} [options.before] Get pins before this timestamp
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
+     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
      */
-    getPins() {
-        return this.#client.getPins.call(this.#client, this.id);
+    getPins(options) {
+        return this.#client.getPins.call(this.#client, this.id, options);
     }
 
     /**

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -158,7 +158,7 @@ class PrivateChannel extends Channel {
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
      * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -156,7 +156,7 @@ class PrivateChannel extends Channel {
      * Get all the pins in a text channel
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
-     * @param {Number} [options.limit=50] The maximum number of pins to get (1-500)
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
      * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
      * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} if options are passed.
      */

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -289,11 +289,15 @@ class TextChannel extends GuildChannel {
     }
 
     /**
-     * Get all the pins in the channel
-     * @returns {Promise<Array<Message>>}
+     * Get pins in the channel
+     * @param {Object} [options] Options for fetching the pins
+     * @param {Date} [options.before] Get pins before this timestamp
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
+     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
      */
-    getPins() {
-        return this.#client.getPins.call(this.#client, this.id);
+    getPins(options) {
+        return this.#client.getPins.call(this.#client, this.id, options);
     }
 
     /**

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -294,7 +294,7 @@ class TextChannel extends GuildChannel {
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
      * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -293,8 +293,8 @@ class TextChannel extends GuildChannel {
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
-     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
+     * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -233,11 +233,15 @@ class ThreadChannel extends GuildChannel {
     }
 
     /**
-     * Get all the pins in the channel
-     * @returns {Promise<Array<Message>>}
+     * Get pins in the channel
+     * @param {Object} [options] Options for fetching the pins
+     * @param {Date} [options.before] Get pins before this timestamp
+     * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
+     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
      */
-    getPins() {
-        return this.#client.getPins.call(this.#client, this.id);
+    getPins(options) {
+        return this.#client.getPins.call(this.#client, this.id, options);
     }
 
     /**

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -237,8 +237,8 @@ class ThreadChannel extends GuildChannel {
      * @param {Object} [options] Options for fetching the pins
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
-     * @returns {Promise<Array<Message>>} if options is null. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options is provided.
+     * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -238,7 +238,7 @@ class ThreadChannel extends GuildChannel {
      * @param {Date} [options.before] Get pins before this timestamp
      * @param {Number} [options.limit=50] The maximum number of pins to get (1-50)
      * @returns {Promise<Array<Message>>} if options are not passed. This is deprecated and will be turned into the lower form in a newer version.
-     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Date, message: Message}>}>} if options are passed.
+     * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} if options are passed.
      */
     getPins(options) {
         return this.#client.getPins.call(this.#client, this.id, options);

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -4,7 +4,8 @@ const warningMessages = {
     CHANNEL_CLIENT: "Accessing the client reference via Channel#client is deprecated and is going to be removed in the next release. Please use your own client reference instead.",
     NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated as built-in sticker packs are free for everyone. Please use Client#getStickerPacks instead.",
     INTERACTIONS_REQUIRE_PREMIUM: "Interaction#requirePremium is deprecated by Discord. Please use premium buttons instead.",
-    PRIVATE_CHANNEL_RECIPIENT: "Accessing a private channel recipient via PrivateChannel#recipient is deprecated. Use PrivateChannel#recipients instead."
+    PRIVATE_CHANNEL_RECIPIENT: "Accessing a private channel recipient via PrivateChannel#recipient is deprecated. Use PrivateChannel#recipients instead.",
+    CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, use Client#getPinsPaginated."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -5,7 +5,7 @@ const warningMessages = {
     NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated as built-in sticker packs are free for everyone. Please use Client#getStickerPacks instead.",
     INTERACTIONS_REQUIRE_PREMIUM: "Interaction#requirePremium is deprecated by Discord. Please use premium buttons instead.",
     PRIVATE_CHANNEL_RECIPIENT: "Accessing a private channel recipient via PrivateChannel#recipient is deprecated. Use PrivateChannel#recipients instead.",
-    CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, use Client#getPinsPaginated."
+    CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, pass an options object to Client#getPins."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 


### PR DESCRIPTION
To not break compatibility with existing 0.2.x releases, this is exposed under `Client#getPinsPaginated`. In 0.3.x, `Client#getPinsPaginated` will be renamed back to `Client#getPins`.

Ref: https://github.com/discord/discord-api-docs/commit/404b074d08cd36ec21ab3c0d7ba7673a4a7e874a
Ref: https://github.com/discord/discord-api-docs/commit/8ef03803f28fd93ce5970225266abab9e7b2aa6c