### PR TITLE
chore: deprecate code paths involving bot user guild ownership

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3213,7 +3213,6 @@ declare namespace Dysnomia {
     editChannelPositions(guildID: string, channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandStructure>(commandID: string, command: Omit<ApplicationCommandStructure, "type">): Promise<ApplicationCommandStructureConversion<T, true>>;
     editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[]): Promise<GuildApplicationCommandPermissions>;
-    /** @deprecated */
     editGuild(guildID: string, options: GuildOptions, reason?: string): Promise<Guild>;
     editGuildCommand<T extends ApplicationCommandStructure>(guildID: string, commandID: string, command: Omit<T, "type">): Promise<ApplicationCommandStructureConversion<T, true>>;
     editGuildEmoji(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1133,6 +1133,7 @@ declare namespace Dysnomia {
     features?: GuildFeatures[]; // Though only some are editable?
     icon?: string;
     name?: string;
+    /** @deprecated */
     ownerID?: string;
     preferredLocale?: string;
     premiumProgressBarEnabled?: boolean;
@@ -3149,9 +3150,11 @@ declare namespace Dysnomia {
       reason?: string
     ): Promise<Webhook>;
     createCommand<T extends ApplicationCommandStructure>(command: T): Promise<ApplicationCommandStructureConversion<T, true>>;
+    /** @deprecated */
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
     createGuildCommand<T extends ApplicationCommandStructure>(guildID: string, command: T): Promise<ApplicationCommandStructureConversion<T, true>>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
+    /** @deprecated */
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, event: GuildScheduledEventOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     createGuildSoundboardSound(guildID: string, sound: GuildSoundboardSoundCreate, reason?: string): Promise<SoundboardSound>;
@@ -3171,6 +3174,7 @@ declare namespace Dysnomia {
     deleteChannel(channelID: string, reason?: string): Promise<void>;
     deleteChannelPermission(channelID: string, overwriteID: string, reason?: string): Promise<void>;
     deleteCommand(commandID: string): Promise<void>;
+    /** @deprecated */
     deleteGuild(guildID: string): Promise<void>;
     deleteGuildCommand(guildID: string, commandID: string): Promise<void>;
     deleteGuildEmoji(guildID: string, emojiID: string, reason?: string): Promise<void>;
@@ -3209,6 +3213,7 @@ declare namespace Dysnomia {
     editChannelPositions(guildID: string, channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandStructure>(commandID: string, command: Omit<ApplicationCommandStructure, "type">): Promise<ApplicationCommandStructureConversion<T, true>>;
     editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[]): Promise<GuildApplicationCommandPermissions>;
+    /** @deprecated */
     editGuild(guildID: string, options: GuildOptions, reason?: string): Promise<Guild>;
     editGuildCommand<T extends ApplicationCommandStructure>(guildID: string, commandID: string, command: Omit<T, "type">): Promise<ApplicationCommandStructureConversion<T, true>>;
     editGuildEmoji(
@@ -3220,6 +3225,7 @@ declare namespace Dysnomia {
     editGuildIncidentActions(guildID: string, options: EditGuildIncidentActionsOptions): Promise<GuildIncidentsData>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
     editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
+    /** @deprecated */
     editGuildMFALevel(guildID: string, options: EditGuildMFALevelOptions): Promise<MFALevel>;
     editGuildOnboarding(guildID: string, options: EditGuildOnboardingOptions): Promise<GuildOnboarding>;
     editGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, eventID: string, event: GuildScheduledEventEditOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
@@ -3576,6 +3582,7 @@ declare namespace Dysnomia {
     createSoundboardSound(sound: GuildSoundboardSoundCreate, reason?: string): Promise<SoundboardSound>;
     createSticker(options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createTemplate(name: string, description?: string | null): Promise<GuildTemplate>;
+    /** @deprecated */
     delete(): Promise<void>;
     deleteAutoModerationRule(ruleID: string, reason?: string): Promise<void>;
     deleteCommand(commandID: string): Promise<void>;
@@ -3599,6 +3606,7 @@ declare namespace Dysnomia {
     editIncidentActions(options: EditGuildIncidentActionsOptions): Promise<GuildIncidentsData>;
     editIntegration(integrationID: string, options: IntegrationOptions): Promise<void>;
     editMember(memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
+    /** @deprecated */
     editMFALevel(options: EditGuildMFALevelOptions): Promise<MFALevel>;
     editOnboarding(options: EditGuildOnboardingOptions): Promise<GuildOnboarding>;
     editRole(roleID: string, options: RoleOptions): Promise<Role>;
@@ -3785,6 +3793,7 @@ declare namespace Dysnomia {
     updatedAt: number;
     usageCount: number;
     constructor(data: BaseData, client: Client);
+    /** @deprecated */
     createGuild(name: string, icon?: string): Promise<Guild>;
     delete(): Promise<GuildTemplate>;
     edit(options: GuildTemplateOptions): Promise<GuildTemplate>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -633,6 +633,7 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild
+     * @deprecated Bots cannot create guilds any longer.
      * @param {String} name The name of the guild
      * @param {Object} options The properties of the guild
      * @param {String} [options.afkChannelID] The ID of the AFK voice channel
@@ -648,6 +649,7 @@ class Client extends EventEmitter {
      * @returns {Promise<Guild>}
      */
     createGuild(name, options) {
+        emitDeprecation("BOT_GUILD_OWNERSHIP");
         if(this.guilds.size > 9) {
             throw new Error("This method can't be used when in 10 or more guilds.");
         }
@@ -711,12 +713,14 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild based on a template. This can only be used with bots in less than 10 guilds
+     * @deprecated Bots cannot create guilds any longer.
      * @param {String} code The template code
      * @param {String} name The name of the guild
      * @param {String} [icon] The 128x128 icon as a base64 data URI
      * @returns {Promise<Guild>}
      */
     createGuildFromTemplate(code, name, icon) {
+        emitDeprecation("BOT_GUILD_OWNERSHIP");
         return this.requestHandler.request("POST", Endpoints.GUILD_TEMPLATE(code), true, {
             name,
             icon
@@ -1124,10 +1128,12 @@ class Client extends EventEmitter {
 
     /**
      * Delete a guild (bot user must be owner)
+     * @deprecated Bot users cannot own guilds any longer
      * @param {String} guildID The ID of the guild
      * @returns {Promise}
      */
     deleteGuild(guildID) {
+        emitDeprecation("BOT_GUILD_OWNERSHIP");
         return this.requestHandler.request("DELETE", Endpoints.GUILD(guildID), true);
     }
 
@@ -1606,7 +1612,7 @@ class Client extends EventEmitter {
      * @param {Array<String>} [options.features] The enabled features for the guild. Note that only certain features can be toggled with the API
      * @param {String} [options.icon] The guild icon as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
      * @param {String} [options.name] The name of the guild
-     * @param {String} [options.ownerID] The ID of the user to transfer server ownership to (bot user must be owner)
+     * @param {String} [options.ownerID] The ID of the user to transfer server ownership to (bot user must be owner) [DEPRECATED] - bot users cannot own guilds any longer
      * @param {String} [options.preferredLocale] Preferred "COMMUNITY" guild language used in server discovery and notices from Discord, and sent in interactions
      * @param {Boolean} [options.premiumProgressBarEnabled] If the boost progress bar is enabled
      * @param {String} [options.publicUpdatesChannelID] The id of the channel where admins and moderators of "COMMUNITY" guilds receive notices from Discord
@@ -1620,6 +1626,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Guild>}
      */
     editGuild(guildID, options, reason) {
+        if(options.ownerID !== undefined) {
+            emitDeprecation("BOT_GUILD_OWNERSHIP");
+        }
         return this.requestHandler.request("PATCH", Endpoints.GUILD(guildID), true, {
             name: options.name,
             icon: options.icon,
@@ -1735,6 +1744,7 @@ class Client extends EventEmitter {
 
     /**
      * Edits the guild's MFA level. Requires the guild to be owned by the bot user
+     * @deprecated Bot users cannot own guilds any longer
      * @param {String} guildID The guild ID to edit the MFA level in
      * @param {Object} options The options for the request
      * @param {Number} options.level The new MFA level
@@ -1742,6 +1752,7 @@ class Client extends EventEmitter {
      * @returns {Promise<Number>} Returns the new MFA level
      */
     editGuildMFALevel(guildID, options) {
+        emitDeprecation("BOT_GUILD_OWNERSHIP");
         return this.requestHandler.request("POST", Endpoints.GUILD_MFA_LEVEL(guildID), true, options).then((data) => data.level);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -633,7 +633,7 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild
-     * @deprecated Bots cannot create guilds any longer.
+     * @deprecated Bot users cannot create guilds any longer.
      * @param {String} name The name of the guild
      * @param {Object} options The properties of the guild
      * @param {String} [options.afkChannelID] The ID of the AFK voice channel
@@ -713,7 +713,7 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild based on a template. This can only be used with bots in less than 10 guilds
-     * @deprecated Bots cannot create guilds any longer.
+     * @deprecated Bot users cannot create guilds any longer.
      * @param {String} code The template code
      * @param {String} name The name of the guild
      * @param {String} [icon] The 128x128 icon as a base64 data URI

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -633,7 +633,7 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild
-     * @deprecated Bot users cannot create guilds any longer.
+     * @deprecated Bot users cannot own guilds any longer.
      * @param {String} name The name of the guild
      * @param {Object} options The properties of the guild
      * @param {String} [options.afkChannelID] The ID of the AFK voice channel
@@ -713,7 +713,7 @@ class Client extends EventEmitter {
 
     /**
      * Create a guild based on a template. This can only be used with bots in less than 10 guilds
-     * @deprecated Bot users cannot create guilds any longer.
+     * @deprecated Bot users cannot own guilds any longer.
      * @param {String} code The template code
      * @param {String} name The name of the guild
      * @param {String} [icon] The 128x128 icon as a base64 data URI

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -737,6 +737,7 @@ class Guild extends Base {
 
     /**
      * Delete the guild (bot user must be owner)
+     * @deprecated Bot users cannot own guilds any longer
      * @returns {Promise}
      */
     delete() {
@@ -882,7 +883,7 @@ class Guild extends Base {
      * @param {Array<String>} [options.features] The enabled features for the guild. Note that only certain features can be toggled with the API
      * @param {String} [options.icon] The guild icon as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
      * @param {String} [options.name] The name of the guild
-     * @param {String} [options.ownerID] The ID of the member to transfer guild ownership to (bot user must be owner)
+     * @param {String} [options.ownerID] The ID of the member to transfer guild ownership to (bot user must be owner) [DEPRECATED] - bot users cannot own guilds any longer
      * @param {String} [options.preferredLocale] Preferred "COMMUNITY" guild language used in server discovery and notices from Discord, and sent in interactions
      * @param {Boolean} [options.premiumProgressBarEnabled] If the boost progress bar is enabled
      * @param {String?} [options.publicUpdatesChannelID] The id of the channel where admins and moderators of "COMMUNITY" guilds receive notices from Discord
@@ -1000,6 +1001,7 @@ class Guild extends Base {
 
     /**
      * Edits the guild's MFA level. Requires the guild to be owned by the bot user
+     * @deprecated Bot users cannot own guilds anymore
      * @param {Object} options The options for the request
      * @param {Number} options.level The new MFA level
      * @param {String} [options.reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1001,7 +1001,7 @@ class Guild extends Base {
 
     /**
      * Edits the guild's MFA level. Requires the guild to be owned by the bot user
-     * @deprecated Bot users cannot own guilds anymore
+     * @deprecated Bot users cannot own guilds any longer
      * @param {Object} options The options for the request
      * @param {Number} options.level The new MFA level
      * @param {String} [options.reason] The reason to be displayed in audit logs

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -64,7 +64,7 @@ class GuildTemplate {
 
     /**
      * Create a guild based on this template. This can only be used with bots in less than 10 guilds
-     * @deprecated Bot users cannot create guilds any longer.
+     * @deprecated Bot users cannot own guilds any longer.
      * @param {String} name The name of the guild
      * @param {String} [icon] The 128x128 icon as a base64 data URI
      * @returns {Promise<Guild>}

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -64,6 +64,7 @@ class GuildTemplate {
 
     /**
      * Create a guild based on this template. This can only be used with bots in less than 10 guilds
+     * @deprecated Bot users cannot create guilds any longer.
      * @param {String} name The name of the guild
      * @param {String} [icon] The 128x128 icon as a base64 data URI
      * @returns {Promise<Guild>}

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -6,7 +6,7 @@ const warningMessages = {
     INTERACTIONS_REQUIRE_PREMIUM: "Interaction#requirePremium is deprecated by Discord. Please use premium buttons instead.",
     PRIVATE_CHANNEL_RECIPIENT: "Accessing a private channel recipient via PrivateChannel#recipient is deprecated. Use PrivateChannel#recipients instead.",
     CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, pass an options object to Client#getPins.",
-    BOT_GUILD_OWNERSHIP: "Bots cannot own guilds any longer. As such, any API calls that involve bot ownership of a guild are deprecated."
+    BOT_GUILD_OWNERSHIP: "Bot users cannot own guilds any longer. As such, any API calls that involve bot ownership of a guild are deprecated."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -5,7 +5,8 @@ const warningMessages = {
     NITRO_STICKER_PACKS: "Client#getNitroStickerPacks is deprecated as built-in sticker packs are free for everyone. Please use Client#getStickerPacks instead.",
     INTERACTIONS_REQUIRE_PREMIUM: "Interaction#requirePremium is deprecated by Discord. Please use premium buttons instead.",
     PRIVATE_CHANNEL_RECIPIENT: "Accessing a private channel recipient via PrivateChannel#recipient is deprecated. Use PrivateChannel#recipients instead.",
-    CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, pass an options object to Client#getPins."
+    CHANNEL_PINS_NEW: "Returning the pinned messages of a channel as an array of messages in Client#getPins is deprecated. To opt into the new form, pass an options object to Client#getPins.",
+    BOT_GUILD_OWNERSHIP: "Bots cannot own guilds any longer. As such, any API calls that involve bot ownership of a guild are deprecated."
 };
 const unknownCodeMessage = "You have triggered a deprecated behavior whose warning was implemented improperly. Please report this issue.";
 


### PR DESCRIPTION
Will be removed in 0.3.x line. 🫡

Ref: https://github.com/discord/discord-api-docs/commit/74244a1d91786450cb4b05fdce2c353e788d91d1
Ref: https://github.com/discord/discord-api-docs/commit/1d2b9c2b8db8cbb60616097433aeb797a80c98a4
Ref: https://github.com/discord/discord-api-docs/commit/a5cb8e55fbf1193eba62e1fd60b68055ccf7da06