### PR TITLE
feat: various caching & memory optimizations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -514,6 +514,7 @@ declare namespace Dysnomia {
   // Client
   interface ClientOptions {
     allowedMentions?: AllowedMentions;
+    caching?: CachingOptions;
     defaultImageFormat?: string;
     defaultImageSize?: number;
     gateway?: GatewayOptions;
@@ -543,7 +544,9 @@ declare namespace Dysnomia {
     udpTimeout?: number;
     ws?: unknown;
   }
-
+  interface CachingOptions {
+    disableChannelMaps?: boolean;
+  }
   interface EditSelfOptions {
     avatar?: string | null;
     banner?: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -560,7 +560,7 @@ declare namespace Dysnomia {
     ws?: unknown;
   }
   interface CachingOptions {
-    disableChannelMaps?: boolean;
+    disableMaps?: boolean;
   }
   interface EditSelfOptions {
     avatar?: string | null;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -184,6 +184,7 @@ class Client extends EventEmitter {
                 users: true,
                 roles: true
             },
+            caching: {},
             defaultImageFormat: "jpg",
             defaultImageSize: 128,
             messageLimit: 100,
@@ -1513,10 +1514,15 @@ class Client extends EventEmitter {
      * @param {Object} [options] Additional options when editing position
      * @param {Boolean} [options.lockPermissions] Whether to sync the channel's permissions with the new parent, if changing parents
      * @param {String} [options.parentID] The new parent ID (category channel) for the channel that is moved
+     * @param {String} [options.guildIDHint] The ID of the guild that is hinted to have the channel, if channel maps are disabled, this is used to avoid searching for the channel
      * @returns {Promise}
      */
     editChannelPosition(channelID, position, options = {}) {
-        let channels = this.guilds.get(this.channelGuildMap[channelID]).channels;
+        let channels = this.options.caching.disableChannelMaps ? this.getChannel(channelID, options?.guildIDHint)?.guild?.channels : this.guilds.get(this.channelGuildMap[channelID])?.channels;
+        if(!channels) {
+            return Promise.reject(new Error(`Channel ${channelID} not found`));
+        }
+
         const channel = channels.get(channelID);
         if(!channel) {
             return Promise.reject(new Error(`Channel ${channelID} not found`));
@@ -2371,17 +2377,27 @@ class Client extends EventEmitter {
     /**
      * Get a Channel object from a channel ID
      * @param {String} channelID The ID of the channel
+     * @param {String} [guildIDHint] The ID of the guild that is hinted to have the channel, if channel maps are disabled, this is used to avoid searching for the channel
      * @returns {CategoryChannel | PrivateChannel | TextChannel | TextVoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel}
      */
-    getChannel(channelID) {
+    getChannel(channelID, guildIDHint) {
         if(!channelID) {
             throw new Error(`Invalid channel ID: ${channelID}`);
         }
 
-        if(this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
+        if(this.options.caching.disableChannelMaps) {
+            const guild = guildIDHint ? this.guilds.get(guildIDHint) : this.guilds.find((g) => g.channels.has(channelID));
+            const channel = guild?.channels.get(channelID);
+            if(channel) {
+                return channel;
+            }
+            const thread = guild?.threads.get(channelID);
+            if(thread) {
+                return thread;
+            }
+        } else if(this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
             return this.guilds.get(this.channelGuildMap[channelID]).channels.get(channelID);
-        }
-        if(this.threadGuildMap[channelID] && this.guilds.get(this.threadGuildMap[channelID])) {
+        } else if(this.threadGuildMap[channelID] && this.guilds.get(this.threadGuildMap[channelID])) {
             return this.guilds.get(this.threadGuildMap[channelID]).threads.get(channelID);
         }
         return this.privateChannels.get(channelID);
@@ -3332,23 +3348,24 @@ class Client extends EventEmitter {
      * @param {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
      * @param {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not
      * @param {Object} [options.ws] Additional options for the WebSocket connection, defaults to the options set in the client
+     * @param {String} [options.guildIDHint] The ID of the guild hinted to have this channel
      * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
      */
     joinVoiceChannel(channelID, options = {}) {
-        const channel = this.getChannel(channelID);
+        const channel = this.getChannel(channelID, options?.guildIDHint);
         if(!channel) {
             return Promise.reject(new Error("Channel not found"));
         }
         if(channel.guild?.members.has(this.user.id) && !(channel.permissionsOf(this.user.id).allow & Constants.Permissions.voiceConnect)) {
             return Promise.reject(new Error("Insufficient permission to connect to voice channel"));
         }
-        this.shards.get(this.guildShardMap[this.channelGuildMap[channelID]] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
-            guild_id: this.channelGuildMap[channelID] || null,
+        this.shards.get(this.guildShardMap[channel.guild.id] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
+            guild_id: channel.guild.id || null,
             channel_id: channelID || null,
             self_mute: options.selfMute || false,
             self_deaf: options.selfDeaf || false
         });
-        return this.voiceConnections.join(this.channelGuildMap[channelID], channelID, options);
+        return this.voiceConnections.join(channel.guild.id, channelID, options);
     }
 
     /**
@@ -3386,9 +3403,21 @@ class Client extends EventEmitter {
     /**
      * Leaves a voice channel
      * @param {String} channelID The ID of the voice channel
+     * @param {String} [guildIDHint] The ID of the guild that is hinted to have the channel
      */
-    leaveVoiceChannel(channelID) {
-        if(!channelID || !this.channelGuildMap[channelID]) {
+    leaveVoiceChannel(channelID, guildIDHint) {
+        if(!channelID) {
+            return;
+        }
+
+        if(this.options.caching.disableChannelMaps) {
+            const guildID = this.getChannel(channelID, guildIDHint)?.guild?.id;
+            if(guildID) {
+                return this.closeVoiceConnection(guildID);
+            }
+        }
+
+        if(!this.channelGuildMap[channelID]) {
             return;
         }
         this.closeVoiceConnection(this.channelGuildMap[channelID]);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1456,7 +1456,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     editChannelPosition(channelID, position, options = {}) {
-        let channels = this.options.caching.disableMaps ? this.getChannel(channelID, options?.guildIDHint)?.guild?.channels : this.guilds.get(this.channelGuildMap[channelID])?.channels;
+        let channels = this.options.caching.disableMaps
+            ? this.getChannel(channelID, options?.guildIDHint)?.guild?.channels
+            : this.guilds.get(this.channelGuildMap[channelID])?.channels;
         if(!channels) {
             return Promise.reject(new Error(`Channel ${channelID} not found`));
         }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2377,7 +2377,7 @@ class Client extends EventEmitter {
     /**
      * Get a Channel object from a channel ID
      * @param {String} channelID The ID of the channel
-     * @param {String} [guildIDHint] The ID of the guild that is hinted to have the channel, if channel maps are disabled, this is used to avoid searching for the channel
+     * @param {String} [guildIDHint] The ID of the guild that is hinted to have the channel, if channel maps are disabled, this is used to avoid searching for the channel. Will fall back to linear search if not found in the provided guild.
      * @returns {CategoryChannel | PrivateChannel | TextChannel | TextVoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel}
      */
     getChannel(channelID, guildIDHint) {
@@ -2386,14 +2386,17 @@ class Client extends EventEmitter {
         }
 
         if(this.options.caching.disableChannelMaps) {
-            const guild = guildIDHint ? this.guilds.get(guildIDHint) : this.guilds.find((g) => g.channels.has(channelID));
-            const channel = guild?.channels.get(channelID);
-            if(channel) {
-                return channel;
+            let channel;
+            if(guildIDHint) {
+                const guild = this.guilds.get(guildIDHint);
+                if(guild && (channel = guild.channels.get(channelID) ?? guild.threads.get(channelID))) {
+                    return channel;
+                }
             }
-            const thread = guild?.threads.get(channelID);
-            if(thread) {
-                return thread;
+            for(const guild of this.guilds.values()) {
+                if((channel = guild.channels.get(channelID) ?? guild.threads.get(channelID))) {
+                    return channel;
+                }
             }
         } else if(this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
             return this.guilds.get(this.channelGuildMap[channelID]).channels.get(channelID);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -399,7 +399,7 @@ class Client extends EventEmitter {
      * @param {String} guildID The ID of the guild
      */
     closeVoiceConnection(guildID) {
-        this.shards.get(this.guildShardMap[guildID] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
+        this.shards.get(this.guildShardMap[guildID] || this.shards.resolveFromGuild(guildID)).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
             guild_id: guildID || null,
             channel_id: null,
             self_mute: false,
@@ -1519,7 +1519,7 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     editChannelPosition(channelID, position, options = {}) {
-        let channels = this.options.caching.disableChannelMaps ? this.getChannel(channelID, options?.guildIDHint)?.guild?.channels : this.guilds.get(this.channelGuildMap[channelID])?.channels;
+        let channels = this.options.caching.disableMaps ? this.getChannel(channelID, options?.guildIDHint)?.guild?.channels : this.guilds.get(this.channelGuildMap[channelID])?.channels;
         if(!channels) {
             return Promise.reject(new Error(`Channel ${channelID} not found`));
         }
@@ -2392,7 +2392,7 @@ class Client extends EventEmitter {
             throw new Error(`Invalid channel ID: ${channelID}`);
         }
 
-        if(this.options.caching.disableChannelMaps) {
+        if(this.options.caching.disableMaps) {
             let channel;
             if(guildIDHint) {
                 const guild = this.guilds.get(guildIDHint);
@@ -3370,7 +3370,7 @@ class Client extends EventEmitter {
         if(channel.guild?.members.has(this.user.id) && !(channel.permissionsOf(this.user.id).allow & Constants.Permissions.voiceConnect)) {
             return Promise.reject(new Error("Insufficient permission to connect to voice channel"));
         }
-        this.shards.get(this.guildShardMap[channel.guild.id] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
+        this.shards.get(this.guildShardMap[channel.guild.id] || this.shards.resolveFromGuild(channel.guild.id)).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
             guild_id: channel.guild.id || null,
             channel_id: channelID || null,
             self_mute: options.selfMute || false,
@@ -3421,7 +3421,7 @@ class Client extends EventEmitter {
             return;
         }
 
-        if(this.options.caching.disableChannelMaps) {
+        if(this.options.caching.disableMaps) {
             const guildID = this.getChannel(channelID, guildIDHint)?.guild?.id;
             if(guildID) {
                 return this.closeVoiceConnection(guildID);

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -116,7 +116,9 @@ class Shard extends EventEmitter {
     }
 
     createGuild(_guild) {
-        this.client.guildShardMap[_guild.id] = this.id;
+        if(!this.client.options.caching.disableMaps) {
+            this.client.guildShardMap[_guild.id] = this.id;
+        }
         const guild = this.client.guilds.add(_guild, this.client, true);
         if(this.client.shards.options.getAllUsers && guild.members.size < guild.memberCount) {
             this.getAllUsersCount[guild.id] = true;
@@ -1611,7 +1613,7 @@ class Shard extends EventEmitter {
                         break;
                     }
                     channel.guild.channels.add(channel, this.client);
-                    if(!this.client.options.caching.disableChannelMaps) {
+                    if(!this.client.options.caching.disableMaps) {
                         this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
                     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1628,7 +1628,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_UPDATE": {
-                let channel = this.client.getChannel(packet.d.id, packet.id.guild_id);
+                let channel = this.client.getChannel(packet.d.id, packet.d.guild_id);
                 if(!channel) {
                     break;
                 }
@@ -1928,7 +1928,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id, packet.id.guild_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 if(!channel) {
                     this.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1982,7 +1982,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_UPDATE": {
-                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.threads.get(packet.d.id);
                 if(!channel) {
                     const thread = Channel.from(packet.d, this.client);
                     this.emit("threadUpdate", this.client.guilds.get(packet.d.guild_id).threads.add(thread, this.client), null);
@@ -2061,7 +2061,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBER_UPDATE": {
-                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.threads.get(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBER_UPDATE`);
                     break;
@@ -2088,7 +2088,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBERS_UPDATE": {
-                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.threads.get(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBERS_UPDATE`);
                     break;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -875,7 +875,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "VOICE_CHANNEL_EFFECT_SEND": {
-                const channel = this.client.getChannel(packet.d.channel_id) ?? {id: packet.d.channel_id};
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id) ?? {id: packet.d.channel_id};
                 const guild = this.client.guilds.get(packet.d.guild_id) ?? {id: packet.d.guild_id};
                 const user = this.client.users.get(packet.d.user_id) ?? {id: packet.d.user_id};
                 /**
@@ -918,12 +918,12 @@ class Shard extends EventEmitter {
                      * @prop {User | Object} user The user. If the user is not cached, this will be an object with an `id` key. No other property is guaranteed
                      * @prop {Member?} member The guild member, if typing in a guild channel, or `null`, if typing in a PrivateChannel
                      */
-                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
+                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id, packet.d.guild_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
                 }
                 break;
             }
             case "MESSAGE_CREATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 if(channel) { // MESSAGE_CREATE just when deleting o.o
                     channel.lastMessageID = packet.d.id;
                     if(channel instanceof ThreadChannel) {
@@ -942,7 +942,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 if(!channel) {
                     this.emit("messageUpdate", new Message(packet.d, this.client), null);
                     break;
@@ -985,7 +985,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_DELETE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 if(channel instanceof ThreadChannel) {
                     channel.messageCount--;
                 }
@@ -1006,7 +1006,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_DELETE_BULK": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 if(channel instanceof ThreadChannel) {
                     channel.messageCount -= packet.d.ids.length;
                 }
@@ -1026,7 +1026,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_ADD": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 let member;
                 if(channel?.guild) {
@@ -1092,7 +1092,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
@@ -1136,7 +1136,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_ALL": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 if(message) {
                     message.reactions = {};
@@ -1160,7 +1160,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_EMOJI": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
@@ -1560,7 +1560,7 @@ class Shard extends EventEmitter {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_CREATE`);
                     break;
                 }
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = guild.channels.get(packet.d.channel_id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_CREATE`);
                     break;
@@ -1584,7 +1584,7 @@ class Shard extends EventEmitter {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_DELETE`);
                     break;
                 }
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = guild.channels.get(packet.d.channel_id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_DELETE`);
                     break;
@@ -1611,7 +1611,10 @@ class Shard extends EventEmitter {
                         break;
                     }
                     channel.guild.channels.add(channel, this.client);
-                    this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
+                    if(!this.client.options.caching.disableChannelMaps) {
+                        this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
+                    }
+
                     /**
                      * Fired when a channel is created
                      * @event Client#channelCreate
@@ -1625,7 +1628,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_UPDATE": {
-                let channel = this.client.getChannel(packet.d.id);
+                let channel = this.client.getChannel(packet.d.id, packet.id.guild_id);
                 if(!channel) {
                     break;
                 }
@@ -1925,7 +1928,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.id.guild_id);
                 if(!channel) {
                     this.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;
@@ -1963,7 +1966,7 @@ class Shard extends EventEmitter {
                     this.emit("debug", `Received THREAD_CREATE for channel in missing guild ${packet.d.guild_id}`);
                     break;
                 }
-                const parent = this.client.getChannel(packet.d.parent_id);
+                const parent = channel.guild.channels.get(packet.d.parent_id);
                 if(parent instanceof ForumChannel) {
                     parent.lastThreadID = packet.d.id;
                 }
@@ -1979,7 +1982,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
                 if(!channel) {
                     const thread = Channel.from(packet.d, this.client);
                     this.emit("threadUpdate", this.client.guilds.get(packet.d.guild_id).threads.add(thread, this.client), null);
@@ -2058,7 +2061,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBER_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBER_UPDATE`);
                     break;
@@ -2085,7 +2088,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBERS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this.client.guilds.get(packet.d.guild_id)?.channels.get(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBERS_UPDATE`);
                     break;
@@ -2393,7 +2396,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_POLL_VOTE_ADD": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 const user = this.client.users.get(packet.d.user_id);
                 if(!message) {
@@ -2417,7 +2420,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_POLL_VOTE_REMOVE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this.client.getChannel(packet.d.channel_id, packet.d.guild_id);
                 let message = channel?.messages.get(packet.d.message_id);
                 const user = this.client.users.get(packet.d.user_id);
                 if(!message) {

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -79,6 +79,10 @@ class ShardManager extends Collection {
         this.tryConnect();
     }
 
+    resolveFromGuild(guildID) {
+        return Number((BigInt(guildID) >> 22n) % BigInt(this.options.maxShards));
+    }
+
     spawn(id) {
         let shard = this.get(id);
         if(!shard) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -78,7 +78,7 @@ class Guild extends Base {
          * The Shard that owns the guild
          * @type {Shard}
          */
-        this.shard = client.shards.get(client.guildShardMap[this.id] || (Base.getDiscordEpoch(data.id) % client.shards.options.maxShards) || 0);
+        this.shard = client.shards.get(client.guildShardMap[this.id] || client.shards.resolveFromGuild(this.id) || 0);
         /**
          * Whether the guild is unavailable or not
          * @type {Boolean}
@@ -143,7 +143,7 @@ class Guild extends Base {
                 const channel = Channel.from(channelData, client);
                 channel.guild = this;
                 this.channels.add(channel, client);
-                if(!client.options.caching.disableChannelMaps) {
+                if(!client.options.caching.disableMaps) {
                     client.channelGuildMap[channel.id] = this.id;
                 }
             }
@@ -155,7 +155,7 @@ class Guild extends Base {
                 const channel = Channel.from(threadData, client);
                 channel.guild = this;
                 this.threads.add(channel, client);
-                if(!client.options.caching.disableChannelMaps) {
+                if(!client.options.caching.disableMaps) {
                     client.threadGuildMap[channel.id] = this.id;
                 }
             }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -143,7 +143,7 @@ class Guild extends Base {
                 const channel = Channel.from(channelData, client);
                 channel.guild = this;
                 this.channels.add(channel, client);
-                if(!this.client.options.caching.disableChannelMaps) {
+                if(!client.options.caching.disableChannelMaps) {
                     client.channelGuildMap[channel.id] = this.id;
                 }
             }
@@ -155,7 +155,7 @@ class Guild extends Base {
                 const channel = Channel.from(threadData, client);
                 channel.guild = this;
                 this.threads.add(channel, client);
-                if(!this.client.options.caching.disableChannelMaps) {
+                if(!client.options.caching.disableChannelMaps) {
                     client.threadGuildMap[channel.id] = this.id;
                 }
             }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -143,7 +143,9 @@ class Guild extends Base {
                 const channel = Channel.from(channelData, client);
                 channel.guild = this;
                 this.channels.add(channel, client);
-                client.channelGuildMap[channel.id] = this.id;
+                if(!this.client.options.caching.disableChannelMaps) {
+                    client.channelGuildMap[channel.id] = this.id;
+                }
             }
         }
 
@@ -153,7 +155,9 @@ class Guild extends Base {
                 const channel = Channel.from(threadData, client);
                 channel.guild = this;
                 this.threads.add(channel, client);
-                client.threadGuildMap[channel.id] = this.id;
+                if(!this.client.options.caching.disableChannelMaps) {
+                    client.threadGuildMap[channel.id] = this.id;
+                }
             }
         }
 
@@ -208,7 +212,7 @@ class Guild extends Base {
                     continue;
                 }
                 if(client.options.seedVoiceConnections && voiceState.id === client.user.id && !client.voiceConnections.get(this.id)) {
-                    process.nextTick(() => this.#client.joinVoiceChannel(voiceState.channel_id));
+                    process.nextTick(() => this.#client.joinVoiceChannel(voiceState.channel_id, {guildIDHint: this.id}));
                 }
             }
         }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -131,7 +131,10 @@ class GuildChannel extends Channel {
      * @returns {Promise}
      */
     editPosition(position, options) {
-        return this.#client.editChannelPosition.call(this.#client, this.id, position, options);
+        return this.#client.editChannelPosition.call(this.#client, this.id, position, {
+            ...(options || {}),
+            guildIDHint: this.guild.id
+        });
     }
 
     /**

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -37,7 +37,7 @@ class ThreadMember extends Base {
                 data.member.id = this.id;
             }
 
-            const guild = this.options.caching.disableChannelMaps ? this.#client.guilds.find((g) => g.threads.has(this.threadID)) : this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
+            const guild = client.options.caching.disableChannelMaps ? this.#client.guilds.find((g) => g.threads.has(this.threadID)) : this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
             /**
              * The guild member that this thread member belongs to
              * @type {Member?}

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -37,7 +37,7 @@ class ThreadMember extends Base {
                 data.member.id = this.id;
             }
 
-            const guild = client.options.caching.disableChannelMaps ? this.#client.guilds.find((g) => g.threads.has(this.threadID)) : this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
+            const guild = client.options.caching.disableMaps ? this.#client.guilds.find((g) => g.threads.has(this.threadID)) : this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
             /**
              * The guild member that this thread member belongs to
              * @type {Member?}

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -37,7 +37,7 @@ class ThreadMember extends Base {
                 data.member.id = this.id;
             }
 
-            const guild = this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
+            const guild = this.options.caching.disableChannelMaps ? this.#client.guilds.find((g) => g.threads.has(this.threadID)) : this.#client.guilds.get(this.#client.threadGuildMap[this.threadID]);
             /**
              * The guild member that this thread member belongs to
              * @type {Member?}

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -17,7 +17,7 @@ class UnavailableGuild extends Base {
          * The shard that owns this guild
          * @type {Shard}
          */
-        this.shard = client.shards.get(client.guildShardMap[this.id] || client.shards.resolveFromGuild(this.id));
+        this.shard = client.shards.get(client.guildShardMap[this.id] ?? client.shards.resolveFromGuild(this.id));
         /**
          * Whether the guild is unavailable or not
          * @type {Boolean}

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -17,7 +17,7 @@ class UnavailableGuild extends Base {
          * The shard that owns this guild
          * @type {Shard}
          */
-        this.shard = client.shards.get(client.guildShardMap[this.id]);
+        this.shard = client.shards.get(client.guildShardMap[this.id] || client.shards.resolveFromGuild(this.id));
         /**
          * Whether the guild is unavailable or not
          * @type {Boolean}

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -98,14 +98,17 @@ class VoiceChannel extends GuildChannel {
      * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
      */
     join(options) {
-        return this.#client.joinVoiceChannel.call(this.#client, this.id, options);
+        return this.#client.joinVoiceChannel.call(this.#client, this.id, {
+            ...(options || {}),
+            guildIDHint: this.guild.id
+        });
     }
 
     /**
      * Leaves the channel.
      */
     leave() {
-        return this.#client.leaveVoiceChannel.call(this.#client, this.id);
+        return this.#client.leaveVoiceChannel.call(this.#client, this.id, this.guild.id);
     }
 
     /**


### PR DESCRIPTION
This should allow for not using the `Client.channelGuildMap`, `Client.threadGuildMap`, and `Client.guildShardMap` when `caching.disableMaps` is on.

Some caveats:
- Obviously `getChannel` will do linear searching now, but this can be skipped with guild hinting. `getChannel` now has a `guildIDHint` parameter for getting that specific guild rather than searching all of them. Which has some caveats:
  - `editChannelPosition`'s option param has `guildIDHint`, it's channel's corresponding function will use it.
  - Same for `joinVoiceChannel` and `leaveVoiceChannel`, but `leaveVoiceChannel` has it's hinting in a new parameter.
  - `ThreadMember`'s construction to find the guild *will* do linear searching, sad.
- Many of the shard events that use `getChannel` either now hint at the guild or just gets the guild directly.

Not fully tested yet.