### PR TITLE
feat(voice): add DAVE decryption failure tolerance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4570,9 +4570,9 @@ declare namespace Dysnomia {
     bitrate: number;
     channelID: string | null;
     channels: number;
-    consecutiveDecryptionFailures: number;
     connecting: boolean;
     connectionTimeout: NodeJS.Timeout | null;
+    consecutiveDecryptionFailures: number;
     current?: VoiceStreamCurrent | null;
     daveEnabled: boolean;
     daveProtocolVersion?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4570,6 +4570,7 @@ declare namespace Dysnomia {
     bitrate: number;
     channelID: string | null;
     channels: number;
+    consecutiveDecryptionFailures: number;
     connecting: boolean;
     connectionTimeout: NodeJS.Timeout | null;
     current?: VoiceStreamCurrent | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -556,6 +556,7 @@ declare namespace Dysnomia {
     daveEncryption?: boolean;
     opusOnly?: boolean;
     udpTimeout?: number;
+    decryptionFailureTolerance?: number;
     ws?: unknown;
   }
 
@@ -4578,10 +4579,12 @@ declare namespace Dysnomia {
     daveSession: unknown | null;
     ended?: boolean;
     endpoint: URL;
+    failureTolerance: number;
     frameDuration: number;
     frameSize: number;
     heartbeatInterval: NodeJS.Timeout | null;
     id: string;
+    lastTransitionID: number | null;
     mode?: string;
     modes?: string;
     /** Optional dependencies OpusScript (opusscript) or OpusEncoder (@discordjs/opus) */
@@ -4595,6 +4598,7 @@ declare namespace Dysnomia {
     receiveStreamOpus?: VoiceDataStream | null;
     receiveStreamPCM?: VoiceDataStream | null;
     reconnecting: boolean;
+    reinitializing: boolean;
     samplingRate: number;
     secret: Buffer;
     sendHeader: Buffer;
@@ -4616,7 +4620,7 @@ declare namespace Dysnomia {
     ws: BrowserWebSocket | WebSocket | null;
     wsOptions: unknown;
     wsSequence: number;
-    constructor(id: string, options?: { shard?: Shard; shared?: boolean; opusOnly?: boolean; daveEncryption?: boolean });
+    constructor(id: string, options?: { shard?: Shard; shared?: boolean; opusOnly?: boolean; decryptionFailureTolerance?: number; udpTimeout?: number; daveEncryption?: boolean });
     connect(data: VoiceConnectData): NodeJS.Timer | void;
     disconnect(error?: Error, reconnecting?: boolean): void;
     emit<K extends keyof VoiceEvents>(event: K, ...args: VoiceEvents[K]): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4634,6 +4634,7 @@ declare namespace Dysnomia {
     pause(): void;
     play(resource: ReadableStream | string, options?: VoiceResourceOptions): void;
     receive(type: "opus" | "pcm"): VoiceDataStream;
+    recoverFromInvalidTransition(transitionID: number): void;
     registerReceiveEventHandler(): void;
     resume(): void;
     sendAudioFrame(frame: Buffer): void;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -167,6 +167,7 @@ class Client extends EventEmitter {
      * @param {Boolean} [options.voice.daveEncryption=true] Whether to enable DAVE E2EE encryption for voice connections
      * @param {Boolean} [options.voice.opusOnly=false] Whether to suppress the Opus encoder not found error or not
      * @param {Number} [options.voice.udpTimeout=10000] How long the IP discovery from the UDP should take until it times out
+     * @param {Number} [options.voice.decryptionFailureTolerance=24] How many consecutive decryption failures needed to reinitialize the E2EE session to recover
      * @param {Object} [options.voice.ws] An object of WebSocket options to pass to the voice WebSocket constructors
      * @param {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
      */
@@ -3337,6 +3338,7 @@ class Client extends EventEmitter {
      * @param {Object} [options.opusOnly] Skip opus encoder initialization. You should not enable this unless you know what you are doing
      * @param {Object} [options.shared] Whether the VoiceConnection will be part of a SharedStream or not
      * @param {Object} [options.udpTimeout] How long the IP discovery from the UDP should take until it times out
+     * @param {Number} [options.decryptionFailureTolerance] How many consecutive decryption failures needed to reinitialize the E2EE session to recover
      * @param {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
      * @param {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not
      * @param {Object} [options.ws] Additional options for the WebSocket connection, defaults to the options set in the client

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -167,7 +167,7 @@ class Client extends EventEmitter {
      * @param {Boolean} [options.voice.daveEncryption=true] Whether to enable DAVE E2EE encryption for voice connections
      * @param {Boolean} [options.voice.opusOnly=false] Whether to suppress the Opus encoder not found error or not
      * @param {Number} [options.voice.udpTimeout=10000] How long the IP discovery from the UDP should take until it times out
-     * @param {Number} [options.voice.decryptionFailureTolerance=24] How many consecutive decryption failures needed to reinitialize the E2EE session to recover
+     * @param {Number} [options.voice.decryptionFailureTolerance=36] How many consecutive decryption failures needed to reinitialize the E2EE session to recover
      * @param {Object} [options.voice.ws] An object of WebSocket options to pass to the voice WebSocket constructors
      * @param {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
      */

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -92,6 +92,7 @@ class VoiceChannel extends GuildChannel {
      * @param {Object} [options.daveEncryption=true] Whether to enable DAVE E2EE encryption for voice connections
      * @param {Object} [options.opusOnly] Skip opus encoder initialization. You should not enable this unless you know what you are doing
      * @param {Object} [options.udpTimeout] How long the IP discovery from the UDP should take until it times out
+     * @param {Number} [options.decryptionFailureTolerance] How many consecutive decryption failures needed to reinitialize the E2EE session to recover
      * @param {Object} [options.shared] Whether the VoiceConnection will be part of a SharedStream or not
      * @param {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
      * @param {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -78,6 +78,10 @@ class VoiceConnection extends EventEmitter {
      */
     connecting = false;
     connectionTimeout = null;
+    /**
+     * The amount of consecutive failures encountered when decrypting.
+     */
+    consecutiveDecryptionFailures = 0;
     daveEnabled = true;
     /**
      * The DAVE session if there is an active one
@@ -85,6 +89,11 @@ class VoiceConnection extends EventEmitter {
      */
     daveSession = null;
     frameDuration = 20;
+    /**
+     * The ID of the last DAVE transition that was processed
+     * @type {Number?}
+     */
+    lastTransitionID = null;
     /**
      * Whether the voice connection is paused
      * @type {Boolean}
@@ -96,6 +105,8 @@ class VoiceConnection extends EventEmitter {
      */
     ready = false;
     reconnecting = false;
+    reinitializing = false;
+
     samplingRate = 48_000;
     sendBuffer = Buffer.allocUnsafe(16 + 32 + MAX_FRAME_SIZE);
     sendHeader = Buffer.alloc(12);
@@ -107,6 +118,7 @@ class VoiceConnection extends EventEmitter {
     #nonce = 0;
     #nonceBuffer = null;
     #stablelib = null;
+    #userID = null;
     sequence = 0;
     speaking = false;
     ssrcUserMap = {};
@@ -169,6 +181,7 @@ class VoiceConnection extends EventEmitter {
         this.opusOnly = !!options.opusOnly;
         this.wsOptions = options.ws || {};
         this.udpTimeoutAmount = options.udpTimeout || 10000;
+        this.failureTolerance = options.decryptionFailureTolerance || 24;
 
         if(!this.opusOnly && !this.shared) {
             this.opus = {};
@@ -235,6 +248,7 @@ class VoiceConnection extends EventEmitter {
             return;
         }
         this.channelID = data.channel_id;
+        this.#userID = data.user_id;
         const lastEndpoint = this.endpoint?.hostname;
         this.endpoint = new URL(`wss://${data.endpoint}`);
         if(this.endpoint.port === "80") {
@@ -312,11 +326,14 @@ class VoiceConnection extends EventEmitter {
                             if(transitionID !== 0) {
                                 this.#davePendingTransitions.set(transitionID, this.daveProtocolVersion);
                                 this.sendWS(VoiceOPCodes.DAVE_TRANSITION_READY, {transition_id: transitionID});
+                            } else {
+                                this.lastTransitionID = transitionID;
+                                this.reinitializing = false;
                             }
                             this.emit("debug", `MLS commit processed (transition ID: ${transitionID})`);
                         } catch(e) {
                             this.emit("warn", `MLS commit errored: ${e}`);
-                            this.#recoverFromInvalidCommit(transitionID, data.user_id, data.channel_id);
+                            this.#recoverFromInvalidTransition(transitionID, data.user_id, data.channel_id);
                         }
                         break;
                     }
@@ -327,11 +344,14 @@ class VoiceConnection extends EventEmitter {
                             if(transitionID !== 0) {
                                 this.#davePendingTransitions.set(transitionID, this.daveProtocolVersion);
                                 this.sendWS(VoiceOPCodes.DAVE_TRANSITION_READY, {transition_id: transitionID});
+                            } else {
+                                this.lastTransitionID = transitionID;
+                                this.reinitializing = false;
                             }
                             this.emit("debug", `MLS welcome processed (transition ID: ${transitionID})`);
                         } catch(e) {
                             this.emit("warn", `MLS welcome errored: ${e}`);
-                            this.#recoverFromInvalidCommit(transitionID, data.user_id, data.channel_id);
+                            this.#recoverFromInvalidTransition(transitionID, data.user_id, data.channel_id);
                         }
                         break;
                     }
@@ -638,7 +658,13 @@ class VoiceConnection extends EventEmitter {
         }
     }
 
-    #recoverFromInvalidCommit(transitionID, userID, channelID) {
+    #recoverFromInvalidTransition(transitionID, userID, channelID) {
+        if(this.reinitializing) {
+            return;
+        }
+        this.emit("warn", `Invalidating transition ${transitionID}`);
+        this.reinitializing = true;
+        this.consecutiveDecryptionFailures = 0;
         this.sendWS(VoiceOPCodes.MLS_INVALID_COMMIT_WELCOME, {transition_id: transitionID});
         this.#reinitDaveSession(userID, channelID);
     }
@@ -664,6 +690,8 @@ class VoiceConnection extends EventEmitter {
         // In the future we'd want to signal to the DAVESession to transition also, but it only supports v1 at this time
         this.emit("debug", `DAVE transition executed (v${oldVersion} -> v${this.daveProtocolVersion}, ID: ${transitionID})`);
 
+        this.reinitializing = false;
+        this.lastTransitionID = transitionID;
         this.#davePendingTransitions.delete(transitionID);
         return true;
     }
@@ -967,7 +995,21 @@ class VoiceConnection extends EventEmitter {
                             data = this.daveSession.decrypt(userID, Davey.MediaType.AUDIO, data);
                         }
                     } catch{
-                        return this.emit("warn", `Failed to decrypt received E2EE packet from ${userID}`);
+                        if(!this.reinitializing && this.#davePendingTransitions.size === 0) {
+                            this.consecutiveDecryptionFailures++;
+                            this.emit("warn", `Failed to decrypt received E2EE packet from ${userID} (${this.consecutiveDecryptionFailures} consecutive fails)`);
+                            if(this.failureTolerance > 0 && this.lastTransitionID !== null && this.consecutiveDecryptionFailures > this.failureTolerance) {
+                                this.#recoverFromInvalidTransition(this.lastTransitionID, this.#userID, this.channelID);
+                            }
+                        } else if(this.reinitializing) {
+                            this.emit("warn", `Failed to decrypt received E2EE packet from ${userID} (reinitializing session)`);
+                        } else if(this.#davePendingTransitions.size > 0) {
+                            this.emit(
+                                "warn",
+                                `Failed to decrypt received E2EE packet from ${userID} (${this.#davePendingTransitions.size} pending transition[s])`
+                            );
+                        }
+                        return;
                     }
                 }
             }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -80,6 +80,7 @@ class VoiceConnection extends EventEmitter {
     connectionTimeout = null;
     /**
      * The amount of consecutive failures encountered when decrypting.
+     * @type {Number}
      */
     consecutiveDecryptionFailures = 0;
     daveEnabled = true;
@@ -106,7 +107,6 @@ class VoiceConnection extends EventEmitter {
     ready = false;
     reconnecting = false;
     reinitializing = false;
-
     samplingRate = 48_000;
     sendBuffer = Buffer.allocUnsafe(16 + 32 + MAX_FRAME_SIZE);
     sendHeader = Buffer.alloc(12);
@@ -118,9 +118,7 @@ class VoiceConnection extends EventEmitter {
     #nonce = 0;
     #nonceBuffer = null;
     #stablelib = null;
-    /**
-     * @type {String?}
-     */
+    /** @type {String?} */
     #userID = null;
     sequence = 0;
     speaking = false;

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -184,7 +184,7 @@ class VoiceConnection extends EventEmitter {
         this.opusOnly = !!options.opusOnly;
         this.wsOptions = options.ws || {};
         this.udpTimeoutAmount = options.udpTimeout || 10000;
-        this.failureTolerance = options.decryptionFailureTolerance || 24;
+        this.failureTolerance = options.decryptionFailureTolerance ?? 36;
 
         if(!this.opusOnly && !this.shared) {
             this.opus = {};

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -118,6 +118,9 @@ class VoiceConnection extends EventEmitter {
     #nonce = 0;
     #nonceBuffer = null;
     #stablelib = null;
+    /**
+     * @type {String?}
+     */
     #userID = null;
     sequence = 0;
     speaking = false;
@@ -333,7 +336,7 @@ class VoiceConnection extends EventEmitter {
                             this.emit("debug", `MLS commit processed (transition ID: ${transitionID})`);
                         } catch(e) {
                             this.emit("warn", `MLS commit errored: ${e}`);
-                            this.#recoverFromInvalidTransition(transitionID, data.user_id, data.channel_id);
+                            this.recoverFromInvalidTransition(transitionID);
                         }
                         break;
                     }
@@ -351,7 +354,7 @@ class VoiceConnection extends EventEmitter {
                             this.emit("debug", `MLS welcome processed (transition ID: ${transitionID})`);
                         } catch(e) {
                             this.emit("warn", `MLS welcome errored: ${e}`);
-                            this.#recoverFromInvalidTransition(transitionID, data.user_id, data.channel_id);
+                            this.recoverFromInvalidTransition(transitionID);
                         }
                         break;
                     }
@@ -658,56 +661,6 @@ class VoiceConnection extends EventEmitter {
         }
     }
 
-    #recoverFromInvalidTransition(transitionID, userID, channelID) {
-        if(this.reinitializing) {
-            return;
-        }
-        this.emit("warn", `Invalidating transition ${transitionID}`);
-        this.reinitializing = true;
-        this.consecutiveDecryptionFailures = 0;
-        this.sendWS(VoiceOPCodes.MLS_INVALID_COMMIT_WELCOME, {transition_id: transitionID});
-        this.#reinitDaveSession(userID, channelID);
-    }
-
-    #executePendingTransition(transitionID) {
-        if(!this.#davePendingTransitions.has(transitionID)) {
-            return this.emit("warn", `Received execute transition, but we don't have a pending transition for ${transitionID}`);
-        }
-
-        const oldVersion = this.daveProtocolVersion;
-        this.daveProtocolVersion = this.#davePendingTransitions.get(transitionID);
-
-        // Handle upgrades & defer downgrades
-        if(oldVersion !== this.daveProtocolVersion && this.daveProtocolVersion === 0) {
-            this.#daveDowngraded = true;
-            this.emit("debug", "DAVE protocol downgraded");
-        } else if(transitionID > 0 && this.#daveDowngraded) {
-            this.#daveDowngraded = false;
-            this.daveSession?.setPassthroughMode(true, 10);
-            this.emit("debug", "DAVE protocol upgraded");
-        }
-
-        // In the future we'd want to signal to the DAVESession to transition also, but it only supports v1 at this time
-        this.emit("debug", `DAVE transition executed (v${oldVersion} -> v${this.daveProtocolVersion}, ID: ${transitionID})`);
-
-        this.reinitializing = false;
-        this.lastTransitionID = transitionID;
-        this.#davePendingTransitions.delete(transitionID);
-        return true;
-    }
-
-    get #daveReady() {
-        return this.daveProtocolVersion !== 0 && this.daveSession?.ready;
-    }
-
-    /**
-     * The voice privacy code of the current DAVE session.
-     * @type {String?}
-     */
-    get voicePrivacyCode() {
-        return this.daveSession?.voicePrivacyCode ?? undefined;
-    }
-
     disconnect(error, reconnecting) {
         this.connecting = false;
         this.reconnecting = reconnecting;
@@ -908,6 +861,56 @@ class VoiceConnection extends EventEmitter {
         return type === "pcm" ? this.receiveStreamPCM : this.receiveStreamOpus;
     }
 
+    recoverFromInvalidTransition(transitionID) {
+        if(this.reinitializing) {
+            return;
+        }
+        this.emit("warn", `Invalidating transition ${transitionID}`);
+        this.reinitializing = true;
+        this.consecutiveDecryptionFailures = 0;
+        this.sendWS(VoiceOPCodes.MLS_INVALID_COMMIT_WELCOME, {transition_id: transitionID});
+        this.#reinitDaveSession(this.#userID, this.channelID);
+    }
+
+    #executePendingTransition(transitionID) {
+        if(!this.#davePendingTransitions.has(transitionID)) {
+            return this.emit("warn", `Received execute transition, but we don't have a pending transition for ${transitionID}`);
+        }
+
+        const oldVersion = this.daveProtocolVersion;
+        this.daveProtocolVersion = this.#davePendingTransitions.get(transitionID);
+
+        // Handle upgrades & defer downgrades
+        if(oldVersion !== this.daveProtocolVersion && this.daveProtocolVersion === 0) {
+            this.#daveDowngraded = true;
+            this.emit("debug", "DAVE protocol downgraded");
+        } else if(transitionID > 0 && this.#daveDowngraded) {
+            this.#daveDowngraded = false;
+            this.daveSession?.setPassthroughMode(true, 10);
+            this.emit("debug", "DAVE protocol upgraded");
+        }
+
+        // In the future we'd want to signal to the DAVESession to transition also, but it only supports v1 at this time
+        this.emit("debug", `DAVE transition executed (v${oldVersion} -> v${this.daveProtocolVersion}, ID: ${transitionID})`);
+
+        this.reinitializing = false;
+        this.lastTransitionID = transitionID;
+        this.#davePendingTransitions.delete(transitionID);
+        return true;
+    }
+
+    get #daveReady() {
+        return this.daveProtocolVersion !== 0 && this.daveSession?.ready;
+    }
+
+    /**
+     * The voice privacy code of the current DAVE session.
+     * @type {String?}
+     */
+    get voicePrivacyCode() {
+        return this.daveSession?.voicePrivacyCode ?? undefined;
+    }
+
     registerReceiveEventHandler() {
         this.udpSocket.on("message", (msg) => {
             if(msg[1] !== 0x78) { // unknown payload type, ignore
@@ -993,13 +996,14 @@ class VoiceConnection extends EventEmitter {
                         const canDecrypt = this.#daveReady || (this.daveSession.ready && this.daveSession.canPassthrough(userID));
                         if(canDecrypt) {
                             data = this.daveSession.decrypt(userID, Davey.MediaType.AUDIO, data);
+                            this.consecutiveDecryptionFailures = 0;
                         }
                     } catch{
                         if(!this.reinitializing && this.#davePendingTransitions.size === 0) {
                             this.consecutiveDecryptionFailures++;
                             this.emit("warn", `Failed to decrypt received E2EE packet from ${userID} (${this.consecutiveDecryptionFailures} consecutive fails)`);
                             if(this.failureTolerance > 0 && this.lastTransitionID !== null && this.consecutiveDecryptionFailures > this.failureTolerance) {
-                                this.#recoverFromInvalidTransition(this.lastTransitionID, this.#userID, this.channelID);
+                                this.recoverFromInvalidTransition(this.lastTransitionID);
                             }
                         } else if(this.reinitializing) {
                             this.emit("warn", `Failed to decrypt received E2EE packet from ${userID} (reinitializing session)`);

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -11,7 +11,7 @@ class VoiceConnectionManager extends Collection {
             daveEncryption: true,
             opusOnly: false,
             udpTimeout: 10000,
-            decryptionFailureTolerance: 24,
+            decryptionFailureTolerance: 36,
             ws: undefined
         }, options);
     }

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -11,6 +11,7 @@ class VoiceConnectionManager extends Collection {
             daveEncryption: true,
             opusOnly: false,
             udpTimeout: 10000,
+            decryptionFailureTolerance: 24,
             ws: undefined
         }, options);
     }
@@ -86,6 +87,7 @@ class VoiceConnectionManager extends Collection {
                 shard: data.shard,
                 opusOnly: this.pendingGuilds[data.guild_id].options.opusOnly ?? this.options.opusOnly,
                 udpTimeout: this.pendingGuilds[data.guild_id].options.udpTimeout ?? this.options.udpTimeout,
+                decryptionFailureTolerance: this.pendingGuilds[data.guild_id].options.decryptionFailureTolerance ?? this.options.decryptionFailureTolerance,
                 shared: this.pendingGuilds[data.guild_id].options.shared,
                 daveEncryption: this.pendingGuilds[data.guild_id].options.daveEncryption ?? this.options.daveEncryption,
                 ws: this.pendingGuilds[data.guild_id].options.ws ?? this.options.ws


### PR DESCRIPTION
Adds a DAVE decryption failure tolerance option if there is too many consecutive decryptions, similar to how its done here: https://github.com/discordjs/discord.js/pull/10921

```js
/**
 * The amount of packets to allow decryption failure for until we deem the transition bad and re-initialize.
 * Usually 4 packets on a good connection may slip past when entering a new session.
 * After re-initializing, 5-24 packets may fail to decrypt after.
 */
export const DEFAULT_DECRYPTION_FAILURE_TOLERANCE = 36;
```

I've also made `recoverFromInvalidTransition` public so people could manually remake the session if they want. There's also a new `lastTransitionID` and `reinitializing` property to connections.