### PR TITLE
fix(voice): correct padding amount calculation

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -964,7 +964,7 @@ class VoiceConnection extends EventEmitter {
 
             // RFC3550 5.1: Padding (may need testing)
             if(hasPadding) {
-                const paddingAmount = data.subarray(0, data.length - 1);
+                const paddingAmount = data[data.length - 1];
                 if(paddingAmount < data.length) {
                     data = data.subarray(0, data.length - paddingAmount);
                 }


### PR DESCRIPTION
Fixes an incorrect calculation of voice padding introduced with https://github.com/projectdysnomia/dysnomia/commit/618f3065717cece5f74bb4bf05a79ee697b1fad0, where the last byte was incorrectly unwrapped into a typed array.

Ref: https://github.com/abalabahaha/eris/pull/1558#discussion_r2384245527
Ref: https://datatracker.ietf.org/doc/html/rfc3550#section-5.1