### PR TITLE
fix(voice): drop empty all-padding packets

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -982,6 +982,12 @@ class VoiceConnection extends EventEmitter {
 
             const userID = this.ssrcUserMap[msg.readUIntBE(8, 4)];
             let dropPacket = false;
+
+            // Drop the packet if it's empty, this is usually because of the packet being completely padding
+            if(data.length === 0) {
+                return this.emit("warn", "Packet was dropped due to it being an empty packet");
+            }
+
             if(this.daveSession && !data.equals(SILENCE_FRAME)) {
                 if(this.daveSession.ready && !userID) {
                     this.emit("warn", "Packet was dropped due having an undefined user ID during a DAVE session");

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -980,14 +980,13 @@ class VoiceConnection extends EventEmitter {
                 }
             }
 
-            const userID = this.ssrcUserMap[msg.readUIntBE(8, 4)];
-            let dropPacket = false;
-
             // Drop the packet if it's empty, this is usually because of the packet being completely padding
             if(data.length === 0) {
                 return this.emit("warn", "Packet was dropped due to it being an empty packet");
             }
 
+            const userID = this.ssrcUserMap[msg.readUIntBE(8, 4)];
+            let dropPacket = false;
             if(this.daveSession && !data.equals(SILENCE_FRAME)) {
                 if(this.daveSession.ready && !userID) {
                     this.emit("warn", "Packet was dropped due having an undefined user ID during a DAVE session");


### PR DESCRIPTION
This is rare, but sometimes some packets are given with *only* padding inside them, #229 fixed the issue of handling padding properly so that it's not passed to the `data` event, but empty buffers while in a DAVE session leads to failed decryptions. This usually occurs in Cloudflare-ran voice servers.