### PR TITLE
fix(voice): handle errors from MLS proposals

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -313,11 +313,21 @@ class VoiceConnection extends EventEmitter {
                     case VoiceOPCodes.MLS_PROPOSALS: {
                         /** @type {import("@snazzah/davey").ProposalsOperationType} */
                         const optype = m.readUInt8(3);
-                        const {commit, welcome} = this.daveSession.processProposals(optype, m.subarray(4), [...this.#clientsConnected]);
-                        if(commit) {
-                            this.sendWSBinary(VoiceOPCodes.MLS_COMMIT_WELCOME, welcome ? Buffer.concat([commit, welcome]) : commit);
+                        try {
+                            const {commit, welcome} = this.daveSession.processProposals(optype, m.subarray(4), [...this.#clientsConnected]);
+                            if(commit) {
+                                this.sendWSBinary(VoiceOPCodes.MLS_COMMIT_WELCOME, welcome ? Buffer.concat([commit, welcome]) : commit);
+                            }
+                            this.emit("debug", "MLS proposals processed");
+                        } catch(e) {
+                            this.emit("warn", `MLS proposals errored: ${e}`);
+                            if(this.lastTransitionID) {
+                                this.recoverFromInvalidTransition(this.lastTransitionID);
+                            } else {
+                                // I have no idea how to recover from this properly, panic and die until I have a clearer solution from staff
+                                this.disconnect(new Error("Failed to process MLS proposals"));
+                            }
                         }
-                        this.emit("debug", "MLS proposals processed");
                         break;
                     }
                     case VoiceOPCodes.MLS_ANNOUNCE_COMMIT_TRANSITION: {

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -321,7 +321,7 @@ class VoiceConnection extends EventEmitter {
                             this.emit("debug", "MLS proposals processed");
                         } catch(e) {
                             this.emit("warn", `MLS proposals errored: ${e}`);
-                            if(this.lastTransitionID) {
+                            if(this.lastTransitionID !== null) {
                                 this.recoverFromInvalidTransition(this.lastTransitionID);
                             } else {
                                 // I have no idea how to recover from this properly, panic and die until I have a clearer solution from staff


### PR DESCRIPTION
Had this crash on a bot due to it getting a wrong epoch in the message. Don't know if thats a davey bug or not, but the library should try to recover if it can. I'm asking Discord staff whats the optional way to mitigate this later.