### PR TITLE
feat(voice): handle 4017 (DAVE required) error code

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -603,7 +603,7 @@ class VoiceConnection extends EventEmitter {
             this.emit("warn", `Voice WS close ${code}: ${reason}`);
             if(this.connecting || this.ready) {
                 let reconnecting = true;
-                if(code === 1000 || code === 4006 || code === 4021) {
+                if(code === 1000 || code === 4006 || code === 4021 || code === 4017) {
                     reconnecting = false;
                 } else if(code === 4014 || code === 4022) {
                     if(this.channelID) {


### PR DESCRIPTION
Handles the 4017 close code by not trying to reconnect when it occurs.

Ref: https://github.com/discord/discord-api-docs/commit/eebfe6dc09bf1c0228bc0206310cf212a7cff71f