### PR TITLE
fix(GuildScheduledEvent): correctly pass the client instance when constructing the creator

### DIFF
--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -22,7 +22,7 @@ class GuildScheduledEvent extends Base {
              * The user that created the scheduled event. For events created before October 25 2021, this will be null. Please see the relevant Discord documentation for more details
              * @type {User?}
              */
-            this.creator = client.users.update(data.creator, this.client);
+            this.creator = client.users.update(data.creator, client);
         } else {
             this.creator = null;
         }


### PR DESCRIPTION
Could cause issues with a "missing client" if the creator of the event isn't cached.