### PR TITLE
chore(Constants): deprecate UserFlags.{SPAMMER, ACTIVE_DEVELOPER}

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3020,7 +3020,9 @@ declare namespace Dysnomia {
       VERIFIED_DEVELOPER:           131072;
       CERTIFIED_MODERATOR:          262144;
       BOT_HTTP_INTERACTIONS:        524288;
+      /** @deprecated */
       SPAMMER:                      1048576;
+      /** @deprecated */
       ACTIVE_DEVELOPER:             4194304;
     };
     VerificationLevels: {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -890,8 +890,8 @@ module.exports.UserFlags = {
     VERIFIED_DEVELOPER:       1 << 17,
     CERTIFIED_MODERATOR:      1 << 18,
     BOT_HTTP_INTERACTIONS:    1 << 19,
-    SPAMMER:                  1 << 20,
-    ACTIVE_DEVELOPER:         1 << 22
+    SPAMMER:                  1 << 20, // [DEPRECATED]
+    ACTIVE_DEVELOPER:         1 << 22 // [DEPRECATED]
 };
 
 module.exports.VerificationLevels = {


### PR DESCRIPTION
The active developer flag has been removed in referenced commit, the spammer flag isn't documented.

Ref: https://github.com/discord/discord-api-docs/commit/10f9a02aed744ca62a98a70f5d06cdcd143d749c