### PR TITLE
fix(Constants): swap SubscriptionStatus#{INACTIVE,ENDING}

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3066,8 +3066,8 @@ declare namespace Dysnomia {
     };
     SubscriptionStatus: {
       ACTIVE:   0;
-      ENDING:   1;
-      INACTIVE: 2;
+      INACTIVE: 1;
+      ENDING:   2;
     };
     SystemChannelFlags: {
       SUPPRESS_JOIN_NOTIFICATIONS:                              1;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -841,8 +841,8 @@ module.exports.StickerTypes = {
 
 module.exports.SubscriptionStatus = {
     ACTIVE:   0,
-    ENDING:   1,
-    INACTIVE: 2
+    INACTIVE: 1,
+    ENDING:   2
 };
 
 module.exports.SystemChannelFlags = {


### PR DESCRIPTION
Swaps `SubscriptionStatus#{INACTIVE,ENDING}` as those were swapped in the original docs, and thus have incorrect values here as well.

Ref: https://github.com/discord/discord-api-docs/commit/7aaa911a4eb2ec34f20ac7302988cfb33efc6e56
