### PR TITLE
chore: add missing guild ID hints to internal `getChannel()` usages

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -926,7 +926,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "VOICE_CHANNEL_STATUS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id) ?? {id: packet.d.id};
+                const channel = this.client.getChannel(packet.d.id, packet.d.guild_id) ?? {id: packet.d.id};
                 const guild = this.client.guilds.get(packet.d.guild_id) ?? {id: packet.d.guild_id};
                 /**
                  * Fired when a user sets a voice channel status
@@ -944,7 +944,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "VOICE_CHANNEL_START_TIME_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id) ?? {id: packet.d.id};
+                const channel = this.client.getChannel(packet.d.id, packet.d.guild_id) ?? {id: packet.d.id};
                 const guild = this.client.guilds.get(packet.d.guild_id) ?? {id: packet.d.guild_id};
                 /**
                  * Fired when a voice channel's start time updates

--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -51,7 +51,7 @@ class Interaction extends Base {
              * The channel the interaction was created in. Can be partial with only the id and type if the channel is not cached.
              * @type {(PrivateChannel | TextChannel | NewsChannel)?}
              */
-            this.channel = this.#client.getChannel(data.channel.id) || data.channel;
+            this.channel = this.#client.getChannel(data.channel.id, data.guild?.id) || data.channel;
         }
 
         if(data.data !== undefined) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -45,7 +45,7 @@ class Message extends Base {
          * The channel the message is in. Can be partial with only the id and type if the channel is not cached.
          * @type {PrivateChannel | TextChannel | NewsChannel}
          */
-        this.channel = this.#client.getChannel(data.channel_id) || {
+        this.channel = this.#client.getChannel(data.channel_id, data.guild_id) || {
             id: data.channel_id,
             type: data.channel_type
         };
@@ -103,7 +103,9 @@ class Message extends Base {
             }
         }
         if(data.referenced_message) {
-            const channel = this.#client.getChannel(data.referenced_message.channel_id);
+            // Assuming referenced message and message reference point to the same message
+            data.referenced_message.guild_id ??= data.message_reference?.guild_id;
+            const channel = this.#client.getChannel(data.referenced_message.channel_id, data.referenced_message.guild_id);
             if(channel) {
                 /**
                  * The message that was replied to. If undefined, message data was not received. If null, the message was deleted.

--- a/lib/structures/StageInstance.js
+++ b/lib/structures/StageInstance.js
@@ -18,7 +18,7 @@ class StageInstance extends Base {
          * The associated stage channel
          * @type {StageChannel}
          */
-        this.channel = client.getChannel(data.channel_id) || {id: data.channel_id};
+        this.channel = client.getChannel(data.channel_id, data.guild_id) || {id: data.channel_id};
         /**
          * The guild of the associated stage channel
          * @type {Guild}


### PR DESCRIPTION
Adds guild ID hints to `getChannel()` usages inside the library that have been left out.