### PR TITLE
feat: automatically populate missing `Client#application` for methods that need it

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -341,7 +341,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Array<Object>>} Returns an array of [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) objects.
      */
     bulkEditCommandPermissions(guildID, permissions) {
-        return this.requestHandler.request("PUT", Endpoints.GUILD_COMMAND_PERMISSIONS(this.application.id, guildID), true, permissions);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PUT", Endpoints.GUILD_COMMAND_PERMISSIONS(application.id, guildID), true, permissions)
+        );
     }
 
     /**
@@ -363,7 +365,9 @@ class Client extends EventEmitter {
             command.name_localizations = command.nameLocalizations;
             command.integration_types = command.integrationTypes;
         }
-        return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PUT", Endpoints.COMMANDS(application.id), true, commands).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)))
+        );
     }
 
     /**
@@ -384,7 +388,9 @@ class Client extends EventEmitter {
             command.description_localizations = command.descriptionLocalizations;
             command.name_localizations = command.nameLocalizations;
         }
-        return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(application.id, guildID), true, commands).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)))
+        );
     }
 
     /**
@@ -463,7 +469,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     consumeEntitlement(entitlementID) {
-        return this.requestHandler.request("POST", Endpoints.ENTITLEMENT_CONSUME(this.application.id, entitlementID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("POST", Endpoints.ENTITLEMENT_CONSUME(application.id, entitlementID), true)
+        );
     }
 
     /**
@@ -474,7 +482,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object>} An application emoji object
      */
     createApplicationEmoji(options) {
-        return this.requestHandler.request("POST", Endpoints.APPLICATION_EMOJIS(this.application.id), true, options);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("POST", Endpoints.APPLICATION_EMOJIS(application.id), true, options)
+        );
     }
 
     /**
@@ -645,7 +655,9 @@ class Client extends EventEmitter {
         command.description_localizations = command.descriptionLocalizations;
         command.name_localizations = command.nameLocalizations;
         command.integration_types = command.integrationTypes;
-        return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("POST", Endpoints.COMMANDS(application.id), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -672,7 +684,9 @@ class Client extends EventEmitter {
         command.default_member_permissions = command.defaultMemberPermissions;
         command.description_localizations = command.descriptionLocalizations;
         command.name_localizations = command.nameLocalizations;
-        return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(application.id, guildID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -955,7 +969,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Entitlement>}
      */
     createTestEntitlement(options) {
-        return this.requestHandler.request("POST", Endpoints.ENTITLEMENTS(this.application.id), true, options).then((entitlement) => new Entitlement(entitlement, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("POST", Endpoints.ENTITLEMENTS(application.id), true, options).then((entitlement) => new Entitlement(entitlement, this))
+        );
     }
 
     /**
@@ -1045,7 +1061,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     deleteApplicationEmoji(emojiID) {
-        return this.requestHandler.request("DELETE", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("DELETE", Endpoints.APPLICATION_EMOJI(application.id, emojiID), true)
+        );
     }
 
     /**
@@ -1092,7 +1110,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     deleteCommand(commandID) {
-        return this.requestHandler.request("DELETE", Endpoints.COMMAND(this.application.id, commandID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("DELETE", Endpoints.COMMAND(application.id, commandID), true)
+        );
     }
 
     /**
@@ -1102,7 +1122,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     deleteGuildCommand(guildID, commandID) {
-        return this.requestHandler.request("DELETE", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("DELETE", Endpoints.GUILD_COMMAND(application.id, guildID, commandID), true)
+        );
     }
 
     /**
@@ -1258,7 +1280,9 @@ class Client extends EventEmitter {
      * @returns {Promise}
      */
     deleteTestEntitlement(entitlementID) {
-        return this.requestHandler.request("DELETE", Endpoints.ENTITLEMENT(this.application.id, entitlementID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("DELETE", Endpoints.ENTITLEMENT(application.id, entitlementID), true)
+        );
     }
 
     /**
@@ -1330,7 +1354,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object>} An application emoji object
      */
     editApplicationEmoji(emojiID, options) {
-        return this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true, options);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(application.id, emojiID), true, options)
+        );
     }
 
     /**
@@ -1552,7 +1578,9 @@ class Client extends EventEmitter {
         command.description_localizations = command.descriptionLocalizations;
         command.name_localizations = command.nameLocalizations;
         command.integration_types = command.integrationTypes;
-        return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PATCH", Endpoints.COMMAND(application.id, commandID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -1564,7 +1592,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object>} Resolves with a [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) object.
      */
     editCommandPermissions(guildID, commandID, permissions) {
-        return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, {permissions});
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(application.id, guildID, commandID), true, {permissions})
+        );
     }
 
     /**
@@ -1640,7 +1670,9 @@ class Client extends EventEmitter {
         command.default_member_permissions = command.defaultMemberPermissions;
         command.description_localizations = command.descriptionLocalizations;
         command.name_localizations = command.nameLocalizations;
-        return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(application.id, guildID, commandID), true, command).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -1982,11 +2014,13 @@ class Client extends EventEmitter {
             meta.name_localizations = meta.nameLocalizations;
             meta.description_localizations = meta.descriptionLocalizations;
         }
-        return this.requestHandler.request("PUT", Endpoints.ROLE_CONNECTION_METADATA(this.application.id), true, metadata).then((metadata) => metadata.map((meta) => ({
-            ...meta,
-            nameLocalizations: meta.name_localizations,
-            descriptionLocalizations: meta.description_localizations
-        })));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("PUT", Endpoints.ROLE_CONNECTION_METADATA(application.id), true, metadata).then((metadata) => metadata.map((meta) => ({
+                ...meta,
+                nameLocalizations: meta.name_localizations,
+                descriptionLocalizations: meta.description_localizations
+            })))
+        );
     }
 
     /**
@@ -2279,7 +2313,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object>} An emoji object with creator data
      */
     getApplicationEmoji(emojiID) {
-        return this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJI(application.id, emojiID), true)
+        );
     }
 
     /**
@@ -2287,7 +2323,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object[]>} An array of emoji objects with creator data
      */
     getApplicationEmojis() {
-        return this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJIS(this.application.id), true).then((data) => data.items);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.APPLICATION_EMOJIS(application.id), true).then((data) => data.items)
+        );
     }
 
     /**
@@ -2397,7 +2435,9 @@ class Client extends EventEmitter {
         if(withLocalizations) {
             qs += "&with_localizations=true";
         }
-        return this.requestHandler.request("GET", Endpoints.COMMAND(this.application.id, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.COMMAND(application.id, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -2407,7 +2447,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Object>} Resolves with a guild application command permissions object.
      */
     getCommandPermissions(guildID, commandID) {
-        return this.requestHandler.request("GET", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.COMMAND_PERMISSIONS(application.id, guildID, commandID), true)
+        );
     }
 
     /**
@@ -2420,7 +2462,9 @@ class Client extends EventEmitter {
         if(withLocalizations) {
             qs += "&with_localizations=true";
         }
-        return this.requestHandler.request("GET", Endpoints.COMMANDS(this.application.id) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.COMMANDS(application.id) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)))
+        );
     }
 
     /**
@@ -2454,7 +2498,9 @@ class Client extends EventEmitter {
         options.sku_ids = options.skuIDs;
         options.guild_id = options.guildID;
         options.exclude_ended = options.excludeEnded;
-        return this.requestHandler.request("GET", Endpoints.ENTITLEMENTS(this.application.id), true, options).then((entitlements) => entitlements.map((entitlement) => new Entitlement(entitlement, this)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.ENTITLEMENTS(application.id), true, options).then((entitlements) => entitlements.map((entitlement) => new Entitlement(entitlement, this)))
+        );
     }
 
     /**
@@ -2567,7 +2613,9 @@ class Client extends EventEmitter {
         if(withLocalizations) {
             qs += "&with_localizations=true";
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.GUILD_COMMAND(application.id, guildID, commandID) + (qs ? "?" + qs : ""), true).then((applicationCommand) => new ApplicationCommand(applicationCommand, this))
+        );
     }
 
     /**
@@ -2576,7 +2624,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Array<Object>>} Resolves with an array of guild application command permissions objects.
      */
     getGuildCommandPermissions(guildID) {
-        return this.requestHandler.request("GET", Endpoints.GUILD_COMMAND_PERMISSIONS(this.application.id, guildID), true);
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.GUILD_COMMAND_PERMISSIONS(application.id, guildID), true)
+        );
     }
 
     /**
@@ -2590,7 +2640,9 @@ class Client extends EventEmitter {
         if(withLocalizations) {
             qs += "&with_localizations=true";
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD_COMMANDS(this.application.id, guildID) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.GUILD_COMMANDS(application.id, guildID) + (qs ? "?" + qs : ""), true).then((applicationCommands) => applicationCommands.map((applicationCommand) => new ApplicationCommand(applicationCommand, this)))
+        );
     }
 
     /**
@@ -3165,11 +3217,13 @@ class Client extends EventEmitter {
      * @returns {Promise<Object[]>}
      */
     getRoleConnectionMetadata() {
-        return this.requestHandler.request("GET", Endpoints.ROLE_CONNECTION_METADATA(this.application.id), true).then((metadata) => metadata.map((meta) => ({
-            ...meta,
-            nameLocalizations: meta.name_localizations,
-            descriptionLocalizations: meta.description_localizations
-        })));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.ROLE_CONNECTION_METADATA(application.id), true).then((metadata) => metadata.map((meta) => ({
+                ...meta,
+                nameLocalizations: meta.name_localizations,
+                descriptionLocalizations: meta.description_localizations
+            })))
+        );
     }
 
     /**
@@ -3185,7 +3239,9 @@ class Client extends EventEmitter {
      * @returns {Promise<Array<SKU>>} An array of SKU objects
      */
     getSKUs() {
-        return this.requestHandler.request("GET", Endpoints.SKUS(this.application.id), true).then((data) => data.map((sku) => new SKU(sku)));
+        return this.#ensureApplication().then((application) =>
+            this.requestHandler.request("GET", Endpoints.SKUS(application.id), true).then((data) => data.map((sku) => new SKU(sku)))
+        );
     }
 
     /**
@@ -3802,6 +3858,11 @@ class Client extends EventEmitter {
             files: files.length ? files : undefined,
             attachments: resultAttachments
         };
+    }
+
+    // Ensures this.application is populated, or fetches the application data from the API and resolves with the application data
+    async #ensureApplication() {
+        return this.application ??= await this.getApplication();
     }
 
     toString() {


### PR DESCRIPTION
Automatically ensures `Client#application` is present for methods that need the data from it to function.

This enables more seamless usage in REST-only scripts to set commands up, for example. However, if desired, `Client#application` can be still populated with known data to avoid a roundtrip to the API.