### PR TITLE
chore: default the image format to WEBP, add missing dynamic image methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3760,7 +3760,7 @@ declare namespace Dysnomia {
     ownerID: string;
     recipients: Collection<User>;
     type: Constants["ChannelTypes"]["GROUP_DM"];
-    dynamicIconURL(format?: ImageFormat, size?: number): string | null;
+    dynamicIconURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
   }
 
   export class Guild extends Base {
@@ -3854,10 +3854,10 @@ declare namespace Dysnomia {
     deleteSoundboardSound(soundID: string, reason?: string): Promise<void>;
     deleteSticker(stickerID: string, reason?: string): Promise<void>;
     deleteTemplate(code: string): Promise<GuildTemplate>;
-    dynamicBannerURL(format?: ImageFormat, size?: number): string | null;
-    dynamicDiscoverySplashURL(format?: ImageFormat, size?: number): string | null;
-    dynamicIconURL(format?: ImageFormat, size?: number): string | null;
-    dynamicSplashURL(format?: ImageFormat, size?: number): string | null;
+    dynamicBannerURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
+    dynamicDiscoverySplashURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
+    dynamicIconURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
+    dynamicSplashURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
     edit(options: GuildOptions, reason?: string): Promise<Guild>;
     editAutoModerationRule(ruleID: string, options: EditAutoModerationRuleOptions): Promise<AutoModerationRule>;
     editChannelPositions(channelPositions: ChannelPosition[]): Promise<void>;
@@ -4039,9 +4039,9 @@ declare namespace Dysnomia {
     splashURL: string | null;
     stickers: Sticker[];
     constructor(data: BaseData, client: Client);
-    dynamicDiscoverySplashURL(format?: ImageFormat, size?: number): string | null;
-    dynamicIconURL(format?: ImageFormat, size?: number): string | null;
-    dynamicSplashURL(format?: ImageFormat, size?: number): string | null;
+    dynamicDiscoverySplashURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
+    dynamicIconURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
+    dynamicSplashURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
   }
 
   export class GuildTemplate {
@@ -4197,8 +4197,8 @@ declare namespace Dysnomia {
     constructor(data: BaseData, guild?: Guild, client?: Client);
     addRole(roleID: string, reason?: string): Promise<void>;
     ban(options?: BanMemberOptions): Promise<void>;
-    dynamicAvatarURL(format?: ImageFormat, size?: number): string;
-    dynamicBannerURL(format?: ImageFormat, size?: number): string | null;
+    dynamicAvatarURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string;
+    dynamicBannerURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
     edit(options: MemberOptions, reason?: string): Promise<void>;
     kick(reason?: string): Promise<void>;
     removeRole(roleID: string, reason?: string): Promise<void>;
@@ -4738,8 +4738,8 @@ declare namespace Dysnomia {
     system: boolean;
     username: string;
     constructor(data: BaseData, client: Client);
-    dynamicAvatarURL(format?: ImageFormat, size?: number): string;
-    dynamicBannerURL(format?: ImageFormat, size?: number): string | null;
+    dynamicAvatarURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string;
+    dynamicBannerURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
     getDMChannel(): Promise<PrivateChannel>;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4416,6 +4416,7 @@ declare namespace Dysnomia {
     unicodeEmoji: string | null;
     constructor(data: BaseData, guild: Guild);
     delete(reason?: string): Promise<void>;
+    dynamicIconURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
     edit(options: RoleOptions, reason?: string): Promise<Role>;
     editPosition(position: number): Promise<void>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3994,6 +3994,7 @@ declare namespace Dysnomia {
     status: GuildScheduledEventStatus;
     userCount?: number;
     delete(): Promise<void>;
+    dynamicImageURL(format?: ImageFormat, size?: number, forceStatic?: boolean): string | null;
     edit<U extends GuildScheduledEventEntityTypes>(event: GuildScheduledEventEditOptions<U>, reason?: string): Promise<GuildScheduledEvent<U>>;
     getUsers(options?: GetGuildScheduledEventUsersOptions): Promise<GuildScheduledEventUser[]>;
   }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -128,7 +128,7 @@ class Client extends EventEmitter {
      * @param {Boolean | Array<String>} [options.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow
      * @param {Boolean | Array<String>} [options.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow
      * @param {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
-     * @param {String} [options.defaultImageFormat="jpg"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"
+     * @param {String} [options.defaultImageFormat="webp"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"
      * @param {Number} [options.defaultImageSize=128] The default size to return user avatars, guild icons, banners, splashes, and group icons. Can be any power of two between 16 and 2048. If the height and width are different, the width will be the value specified, and the height relative to that
      * @param {Object} [options.gateway] Options for gateway connections
      * @param {Boolean} [options.gateway.autoreconnect=true] Have Dysnomia autoreconnect when connection is lost
@@ -181,7 +181,7 @@ class Client extends EventEmitter {
                 roles: true
             },
             caching: {},
-            defaultImageFormat: "jpg",
+            defaultImageFormat: "webp",
             defaultImageSize: 128,
             messageLimit: 100,
             rest: {},
@@ -3819,7 +3819,7 @@ class Client extends EventEmitter {
         return result;
     }
 
-    _formatImage(url, format, size) {
+    _formatImage(url, format, size, forceStatic = false) {
         const isAnimated = url.includes("/a_");
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
             format = isAnimated ? "webp" : this.options.defaultImageFormat;
@@ -3827,7 +3827,7 @@ class Client extends EventEmitter {
         if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
             size = this.options.defaultImageSize;
         }
-        return `${Endpoints.CDN_URL}${url}.${format}?size=${size}${isAnimated && format === "webp" ? "&animated=true" : ""}`;
+        return `${Endpoints.CDN_URL}${url}.${format}?size=${size}${isAnimated && !forceStatic && format === "webp" ? "&animated=true" : ""}`;
     }
 
     _processAttachments(attachments) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3820,13 +3820,14 @@ class Client extends EventEmitter {
     }
 
     _formatImage(url, format, size) {
+        const isAnimated = url.includes("/a_");
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
-            format = url.includes("/a_") ? "gif" : this.options.defaultImageFormat;
+            format = isAnimated ? "webp" : this.options.defaultImageFormat;
         }
         if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
             size = this.options.defaultImageSize;
         }
-        return `${Endpoints.CDN_URL}${url}.${format}?size=${size}`;
+        return `${Endpoints.CDN_URL}${url}.${format}?size=${size}${isAnimated && format === "webp" ? "&animated=true" : ""}`;
     }
 
     _processAttachments(attachments) {

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -48,10 +48,11 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
      * Get the group's icon with the given format and size
      * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the icon to be static even if it is animated
      * @returns {String?}
      */
-    dynamicIconURL(format, size) {
-        return this.icon ? this.#client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
+    dynamicIconURL(format, size, forceStatic) {
+        return this.icon ? this.#client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size, forceStatic) : null;
     }
 
     toJSON(props = []) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -828,42 +828,46 @@ class Guild extends Base {
 
     /**
      * Get the guild's banner with the given format and size
-     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
-     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {String} [format] The filetype of the banner ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the banner (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the banner to be static even if it is animated
      * @returns {String?}
      */
-    dynamicBannerURL(format, size) {
-        return this.banner ? this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size) : null;
+    dynamicBannerURL(format, size, forceStatic) {
+        return this.banner ? this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size, forceStatic) : null;
     }
 
     /**
      * Get the guild's discovery splash with the given format and size
-     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
-     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {String} [format] The filetype of the discovery splash ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the discovery splash (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the discovery splash to be static even if it is animated
      * @returns {String?}
      */
-    dynamicDiscoverySplashURL(format, size) {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size) : null;
+    dynamicDiscoverySplashURL(format, size, forceStatic) {
+        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size, forceStatic) : null;
     }
 
     /**
      * Get the guild's icon with the given format and size
      * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the icon to be static even if it is animated
      * @returns {String?}
      */
-    dynamicIconURL(format, size) {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
+    dynamicIconURL(format, size, forceStatic) {
+        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size, forceStatic) : null;
     }
 
     /**
      * Get the guild's splash with the given format and size
-     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
-     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {String} [format] The filetype of the splash ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the splash (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the splash to be static even if it is animated
      * @returns {String?}
      */
-    dynamicSplashURL(format, size) {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
+    dynamicSplashURL(format, size, forceStatic) {
+        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size, forceStatic) : null;
     }
 
     /**

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -94,33 +94,36 @@ class GuildPreview extends Base {
     }
 
     /**
-     * Get the guild's splash with the given format and size
-     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
-     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * Get the guild's discovery splash with the given format and size
+     * @param {String} [format] The filetype of the discovery splash ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the discovery splash (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the discovery splash to be static even if it is animated
      * @returns {String?}
      */
-    dynamicDiscoverySplashURL(format, size) {
-        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size) : null;
+    dynamicDiscoverySplashURL(format, size, forceStatic) {
+        return this.discoverySplash ? this.#client._formatImage(Endpoints.GUILD_DISCOVERY_SPLASH(this.id, this.discoverySplash), format, size, forceStatic) : null;
     }
 
     /**
      * Get the guild's icon with the given format and size
      * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the icon to be static even if it is animated
      * @returns {String?}
      */
-    dynamicIconURL(format, size) {
-        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
+    dynamicIconURL(format, size, forceStatic) {
+        return this.icon ? this.#client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size, forceStatic) : null;
     }
 
     /**
      * Get the guild's splash with the given format and size
-     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
-     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {String} [format] The filetype of the splash ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the splash (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the splash to be static even if it is animated
      * @returns {String?}
      */
-    dynamicSplashURL(format, size) {
-        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
+    dynamicSplashURL(format, size, forceStatic) {
+        return this.splash ? this.#client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size, forceStatic) : null;
     }
 
     toJSON(props = []) {

--- a/lib/structures/GuildScheduledEvent.js
+++ b/lib/structures/GuildScheduledEvent.js
@@ -165,6 +165,17 @@ class GuildScheduledEvent extends Base {
     }
 
     /**
+     * Get the image of the event with the given format and size
+     * @param {String} [format] The filetype of the event image ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the event image (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the event image to be static even if it is animated
+     * @returns {String?}
+     */
+    dynamicImageURL(format, size, forceStatic) {
+        return this.image ? this.#client._formatImage(Endpoints.GUILD_SCHEDULED_EVENT_COVER(this.id, this.image), format, size, forceStatic) : null;
+    }
+
+    /**
      * Edit this scheduled event
      * @param {Object} event The new guild scheduled event object
      * @param {String} [event.channelID] The channel ID of the event. If updating `entityType` to `3` (external), this **must** be set to `null`

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -169,7 +169,7 @@ class Member extends Base {
     }
 
     /**
-     * The URL of the user's avatar which can be either a JPG or GIF
+     * The URL of the user's avatar either as a static image in the preferred format (or a PNG for default avatars), or an animated WEBP image
      * @type {String}
      */
     get avatarURL() {
@@ -273,7 +273,7 @@ class Member extends Base {
     }
 
     /**
-     * The URL of the user's avatar (always a JPG)
+     * The URL of the user's avatar (always a static WEBP)
      * @type {String}
      */
     get staticAvatarURL() {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -273,7 +273,7 @@ class Member extends Base {
     }
 
     /**
-     * The URL of the user's avatar (always a static WEBP)
+     * The URL of the user's avatar (always a static WEBP, or a PNG for default avatars)
      * @type {String}
      */
     get staticAvatarURL() {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -330,26 +330,28 @@ class Member extends Base {
      * Get the member's avatar with the given format and size
      * @param {String} [format] The filetype of the avatar ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the avatar (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the avatar to be static even if it is animated
      * @returns {String}
      */
-    dynamicAvatarURL(format, size) {
+    dynamicAvatarURL(format, size, forceStatic) {
         if(!this.avatar) {
-            return this.user.dynamicAvatarURL(format, size);
+            return this.user.dynamicAvatarURL(format, size, forceStatic);
         }
-        return this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size);
+        return this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size, forceStatic);
     }
 
     /**
      * Get the user's banner with the given format and size
      * @param {String} [format] The filetype of the banner ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the banner (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the banner to be static even if it is animated
      * @returns {String?}
      */
-    dynamicBannerURL(format, size) {
+    dynamicBannerURL(format, size, forceStatic) {
         if(!this.banner) {
-            return this.user.dynamicBannerURL(format, size);
+            return this.user.dynamicBannerURL(format, size, forceStatic);
         }
-        return this.guild.shard.client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size);
+        return this.guild.shard.client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size, forceStatic);
     }
 
     /**

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -164,6 +164,17 @@ class Role extends Base {
     }
 
     /**
+     * Get the role's icon with the given format and size
+     * @param {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the role icon to be static even if it is animated
+     * @returns {String?}
+     */
+    dynamicIconURL(format, size, forceStatic) {
+        return this.icon ? this.guild.shard.client._formatImage(Endpoints.ROLE_ICON(this.id, this.icon), format, size, forceStatic) : null;
+    }
+
+    /**
      * Edit the guild role
      * @param {Object} options The properties to edit
      * @param {Number} [options.color] The hex color of the role, in number form (ex: 0x3da5b3 or 4040115)

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -183,46 +183,48 @@ class User extends Base {
     }
 
     /**
-     * The URL of the user's avatar (always a JPG)
+     * The URL of the user's avatar (always a static WEBP)
      * @type {String}
      */
     get staticAvatarURL() {
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "jpg") : this.defaultAvatarURL;
+        return this.avatar ? this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), "webp", null, true) : this.defaultAvatarURL;
     }
 
     /**
      * Get the user's avatar with the given format and size
      * @param {String} [format] The filetype of the avatar ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the avatar (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the avatar to be static even if it is animated
      * @returns {String}
      */
-    dynamicAvatarURL(format, size) {
+    dynamicAvatarURL(format, size, forceStatic) {
         if(!this.avatar) {
             return this.defaultAvatarURL;
         }
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size);
+        return this.#client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size, forceStatic);
     }
 
     /**
      * Get the user's banner with the given format and size
      * @param {String} [format] The filetype of the banner ("jpg", "jpeg", "png", "gif", or "webp")
      * @param {Number} [size] The size of the banner (any power of two between 16 and 4096)
+     * @param {Boolean} [forceStatic=false] Whether to force the banner to be static even if it is animated
      * @returns {String?}
      */
-    dynamicBannerURL(format, size) {
+    dynamicBannerURL(format, size, forceStatic) {
         if(!this.banner) {
             return null;
         }
         if(this.#missingClientError) {
             throw this.#missingClientError;
         }
-        return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size);
+        return this.#client._formatImage(Endpoints.BANNER(this.id, this.banner), format, size, forceStatic);
     }
 
     /**

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -183,7 +183,7 @@ class User extends Base {
     }
 
     /**
-     * The URL of the user's avatar (always a static WEBP)
+     * The URL of the user's avatar (always a static WEBP, or a PNG for default avatars)
      * @type {String}
      */
     get staticAvatarURL() {

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -119,7 +119,7 @@ class User extends Base {
     }
 
     /**
-     * The URL of the user's avatar which can be either a JPG or an animated WEBP image
+     * The URL of the user's avatar either as a static image in the preferred format (or a PNG for default avatars), or an animated WEBP image
      * @type {String}
      */
     get avatarURL() {

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -119,7 +119,7 @@ class User extends Base {
     }
 
     /**
-     * The URL of the user's avatar which can be either a JPG or GIF
+     * The URL of the user's avatar which can be either a JPG or an animated WEBP image
      * @type {String}
      */
     get avatarURL() {


### PR DESCRIPTION
- Makes .webp the default image format for both static and animated images
  - Discord documentation states that assets uploaded as animated .webp/.avif aren't converted to other formats. (see ref)
  - Although static .webp is still converted to other formats, using a single image format makes matters a bit more consistent
  - This is obviously a breaking change for users that expect to get a .jpg/.gif out of the URL getters. Most reasonably modern image processing toolkits should be able to take .webp media just fine though.
- .webp links will now contain the `?animated=true` query string parameter for animated images
  - An additional boolean parameter has been added to `dynamic[...]URL()` APIs to exclude the parameter, forcing a static version of the image.
- Added some missing dynamic URL APIs, namely `Role#dynamicIconURL` and `GuildScheduledEvent#dynamicImageURL`

Ref: https://github.com/discord/discord-api-docs/commit/ab3ea3c8d7a7c5ddc6b991f409355b4fa86bc9b3