### PR TITLE
refactor: decouple voice state updates from member object

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -22,6 +22,7 @@ const StageInstance = require("../structures/StageInstance");
 const Subscription = require("../structures/Subscription");
 const ThreadChannel = require("../structures/ThreadChannel");
 const User = require("../structures/User");
+const VoiceState = require("../structures/VoiceState");
 
 const WebSocket = typeof window !== "undefined" ? require("../util/BrowserWebSocket") : require("ws");
 
@@ -801,6 +802,13 @@ class Shard extends EventEmitter {
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
+                    this.emit("voiceStateUpdate", {
+                        id: packet.d.user_id,
+                        guild: {
+                            id: packet.d.guild_id
+                        },
+                        voiceState: new VoiceState(packet.d, this.client)
+                    }, null);
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user_id);
@@ -808,14 +816,8 @@ class Shard extends EventEmitter {
                     if(!packet.d.member) {
                         this.emit("voiceStateUpdate", {
                             id: packet.d.user_id,
-                            voiceState: {
-                                deaf: packet.d.deaf,
-                                mute: packet.d.mute,
-                                selfDeaf: packet.d.self_deaf,
-                                selfMute: packet.d.self_mute,
-                                selfStream: packet.d.self_stream,
-                                selfVideo: packet.d.self_video
-                            }
+                            guild: guild,
+                            voiceState: new VoiceState(packet.d, this.client)
                         }, null);
                         break;
                     }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -841,7 +841,7 @@ class Shard extends EventEmitter {
                 const oldChannelID = member.voiceState.channelID;
                 const state = guild.voiceStates.get(packet.d.id);
                 if(packet.d.channel_id === null && !packet.d.mute && !packet.d.deaf) {
-                    guild.voiceStates.delete(this.id);
+                    guild.voiceStates.delete(packet.d.id);
                 } else if(state) {
                     state.update(packet.d);
                 } else if(packet.d.channel_id || packet.d.mute || packet.d.deaf || packet.d.suppress) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -894,7 +894,7 @@ class Shard extends EventEmitter {
                     /**
                      * Fired when a guild member's voice state changes
                      * @event Client#voiceStateUpdate
-                     * @prop {Member | Object} member The member. If the member is not cached and Discord doesn't send a member payload, this will be an object with `id` and `voiceState` keys. No other property is guaranteed
+                     * @prop {Member | Object} member The member. If the member is not cached and Discord doesn't send a member payload, this will be an object with `id`, `guild`, and `voiceState` keys. No other property is guaranteed
                      * @prop {Object?} oldState The old voice state of the member. If the above caveat applies, this will be null
                      * @prop {Boolean} oldState.deaf The previous server deaf status
                      * @prop {Boolean} oldState.mute The previous server mute status

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -797,9 +797,8 @@ class Shard extends EventEmitter {
                         }
                     }
                 }
-                if(packet.d.self_stream === undefined) {
-                    packet.d.self_stream = false;
-                }
+                packet.d.self_stream ??= false;
+                packet.d.id ??= packet.d.user_id;
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("voiceStateUpdate", {
@@ -807,7 +806,7 @@ class Shard extends EventEmitter {
                         guild: {
                             id: packet.d.guild_id
                         },
-                        voiceState: new VoiceState(packet.d, this.client)
+                        voiceState: new VoiceState(packet.d)
                     }, null);
                     break;
                 }
@@ -817,7 +816,7 @@ class Shard extends EventEmitter {
                         this.emit("voiceStateUpdate", {
                             id: packet.d.user_id,
                             guild: guild,
-                            voiceState: new VoiceState(packet.d, this.client)
+                            voiceState: new VoiceState(packet.d)
                         }, null);
                         break;
                     }
@@ -840,7 +839,17 @@ class Shard extends EventEmitter {
                     selfVideo: member.voiceState.selfVideo
                 };
                 const oldChannelID = member.voiceState.channelID;
-                member.update(packet.d, this.client);
+                const state = guild.voiceStates.get(packet.d.id);
+                if(packet.d.channel_id === null && !packet.d.mute && !packet.d.deaf) {
+                    guild.voiceStates.delete(this.id);
+                } else if(state) {
+                    state.update(packet.d);
+                } else if(packet.d.channel_id || packet.d.mute || packet.d.deaf || packet.d.suppress) {
+                    guild.voiceStates.update(packet.d);
+                }
+                if(packet.d.member) {
+                    member.update(packet.d.member, this.client);
+                }
                 if(oldChannelID !== packet.d.channel_id) {
                     let oldChannel, newChannel;
                     if(oldChannelID) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -199,14 +199,14 @@ class Guild extends Base {
 
         if(data.voice_states) {
             for(const voiceState of data.voice_states) {
-                if(!this.members.get(voiceState.user_id)) {
-                    continue;
-                }
                 voiceState.id = voiceState.user_id;
                 try {
+                    this.voiceStates.add(voiceState);
                     const channel = this.channels.get(voiceState.channel_id);
-                    const member = this.members.update(voiceState);
-                    channel?.voiceMembers?.add(member);
+                    const member = this.members.get(voiceState.id);
+                    if(member) {
+                        channel?.voiceMembers?.add(member);
+                    }
                 } catch(err) {
                     client.emit("error", err, this.shard.id);
                     continue;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -64,21 +64,6 @@ class Member extends Base {
     }
 
     update(data) {
-        // Handle updates from voice states
-        if(Object.hasOwn(data, "channel_id") && this.guild) {
-            const state = this.guild.voiceStates.get(this.id);
-            if(data.channel_id === null && !data.mute && !data.deaf) {
-                this.guild.voiceStates.delete(this.id);
-            } else if(state) {
-                state.update(data);
-            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
-                this.guild.voiceStates.update(data);
-            }
-            if(Object.hasOwn(data, "member")) {
-                data = data.member;
-            }
-        }
-
         if(data.status !== undefined) {
             /**
              * The member's status. Either "online", "idle", "dnd", or "offline"


### PR DESCRIPTION
Decouples voice state updates from the Member object as they're a standalone collection in the Guild object.