### PR TITLE
refactor(Shard): simplify incoming WS message processing

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2799,9 +2799,7 @@ class Shard extends EventEmitter {
     #onWSMessageUnbound(data) {
         try {
             if(data instanceof ArrayBuffer) {
-                if(this.client.shards.options.compress || Erlpack) {
-                    data = Buffer.from(data);
-                }
+                data = Buffer.from(data);
             } else if(Array.isArray(data)) { // Fragmented messages
                 data = Buffer.concat(data); // Copyfull concat is slow, but no alternative
             }
@@ -2814,27 +2812,24 @@ class Shard extends EventEmitter {
                     }
 
                     data = Buffer.from(this.#zlibSync.result);
-
-                    try {
-                        if(Erlpack) {
-                            data = Erlpack.unpack(data);
-                        } else {
-                            data = JSON.parse(data.toString());
-                        }
-                    } catch(err) {
-                        this.emit("error", Error(`parsing error: ${err.message}`));
-                        return;
-                    }
-
-                    return this.onPacket(data);
                 } else {
                     this.#zlibSync.push(data, false);
+                    return;
                 }
-            } else if(Erlpack) {
-                return this.onPacket(Erlpack.unpack(data));
-            } else {
-                return this.onPacket(JSON.parse(data.toString()));
             }
+
+            try {
+                if(Erlpack) {
+                    data = Erlpack.unpack(data);
+                } else {
+                    data = JSON.parse(data.toString());
+                }
+            } catch(err) {
+                this.emit("error", new Error(`parsing error: ${err.message}`, {cause: err}));
+                return;
+            }
+
+            return this.onPacket(data);
         } catch(err) {
             this.emit("error", err, this.id);
         }


### PR DESCRIPTION
- Removes duplicate JSON/ETF parse code from the compressed data pipeline, making the code easier to read.
- Forces ArrayBuffers converesion to Node buffers unconditionally.