### PR TITLE
fix(ShardManager): revise shard initial connection flow

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -410,7 +410,7 @@ class Client extends EventEmitter {
             throw new Error(`Invalid token "${this._token}"`);
         }
         try {
-            const data = await (this.shards.options.maxShards === "auto" || (this.shards.options.shardConcurrency === "auto" && this.bot) ? this.getBotGateway() : this.getGateway());
+            const data = await (this.shards.options.maxShards === "auto" || (this.shards.options.maxConcurrency === "auto" && this.bot) ? this.getBotGateway() : this.getGateway());
             if(!data.url || (this.shards.options.maxShards === "auto" && !data.shards)) {
                 throw new Error("Invalid response from gateway REST call");
             }
@@ -438,7 +438,7 @@ class Client extends EventEmitter {
                 this.shards.options.lastShardID ??= data.shards - 1;
             }
 
-            if(this.shards.options.shardConcurrency === "auto" && typeof data.session_start_limit?.max_concurrency === "number") {
+            if(this.shards.options.maxConcurrency === "auto") {
                 this.shards.options.maxConcurrency = data.session_start_limit.max_concurrency;
             }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -137,7 +137,7 @@ class Client extends EventEmitter {
      * @param {Object} [options.gateway.disableEvents] If disableEvents[eventName] is true, the WS event will not be processed. This can cause significant performance increase on large bots. [A full list of the WS event names in Discord's documentation](https://discord.com/developers/docs/topics/gateway-events#receive-events)
      * @param {Number} [options.gateway.firstShardID=0] The ID of the first shard to run for this client
      * @param {Boolean} [options.gateway.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
-     * @param {Number} [options.gateway.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
+     * @param {Number} [options.gateway.guildCreateTimeout=500] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
      * @param {Number | Array<String | Number>} [options.gateway.intents] A list of [intent names](https://github.com/projectdysnomia/dysnomia/blob/dev/lib/Constants.js#L311), pre-shifted intent numbers to add, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
      * @param {Number} [options.gateway.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
      * @param {Number} [options.gateway.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -138,7 +138,7 @@ class Client extends EventEmitter {
      * @param {Object} [options.gateway.disableEvents] If disableEvents[eventName] is true, the WS event will not be processed. This can cause significant performance increase on large bots. [A full list of the WS event names in Discord's documentation](https://discord.com/developers/docs/topics/gateway-events#receive-events)
      * @param {Number} [options.gateway.firstShardID=0] The ID of the first shard to run for this client
      * @param {Boolean} [options.gateway.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
-     * @param {Number} [options.gateway.guildCreateTimeout=500] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
+     * @param {Number} [options.gateway.guildCreateTimeout=1000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
      * @param {Number | Array<String | Number>} [options.gateway.intents] A list of [intent names](https://github.com/projectdysnomia/dysnomia/blob/dev/lib/Constants.js#L311), pre-shifted intent numbers to add, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
      * @param {Number} [options.gateway.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
      * @param {Number} [options.gateway.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -6,6 +6,7 @@ const Base = require("./structures/Base");
 const Channel = require("./structures/Channel");
 const Collection = require("./util/Collection");
 const Constants = require("./Constants");
+const DiscordHTTPError = require("./errors/DiscordHTTPError");
 const Endpoints = require("./rest/Endpoints");
 const Entitlement = require("./structures/Entitlement");
 const ExtendedUser = require("./structures/ExtendedUser");
@@ -455,6 +456,12 @@ class Client extends EventEmitter {
             if(!this.shards.options.autoreconnect) {
                 throw err;
             }
+
+            // Have unauthorized requests fall-through
+            if(err instanceof DiscordHTTPError && err.code === 401) {
+                throw err;
+            }
+
             const reconnectDelay = this.shards.options.reconnectDelay(this.lastReconnectDelay, this.reconnectAttempts);
             await sleep(reconnectDelay);
             this.lastReconnectDelay = reconnectDelay;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -417,7 +417,7 @@ class Client extends EventEmitter {
             throw new Error(`Invalid token "${this._token}"`);
         }
         try {
-            const data = await (this.shards.options.maxShards === "auto" || (this.shards.options.maxConcurrency === "auto" && this.bot) ? this.getBotGateway() : this.getGateway());
+            const data = await (this.shards.options.maxShards === "auto" || this.shards.options.maxConcurrency === "auto" ? this.getBotGateway() : this.getGateway());
             if(!data.url || (this.shards.options.maxShards === "auto" && !data.shards)) {
                 throw new Error("Invalid response from gateway REST call");
             }
@@ -446,7 +446,7 @@ class Client extends EventEmitter {
             }
 
             if(this.shards.options.maxConcurrency === "auto") {
-                this.shards.options.maxConcurrency = data.session_start_limit.max_concurrency;
+                this.shards.options.maxConcurrency = data.session_start_limit?.max_concurrency ?? 1;
             }
 
             for(let i = this.shards.options.firstShardID; i <= this.shards.options.lastShardID; ++i) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -333,6 +333,7 @@ class Shard extends EventEmitter {
             identify.presence = this.presence;
         }
         this.sendWS(Constants.GatewayOPCodes.IDENTIFY, identify);
+        this.client.shards._identifyPacketCB(this.id);
     }
 
     initializeWS() {
@@ -405,11 +406,15 @@ class Shard extends EventEmitter {
                 break;
             }
             case Constants.GatewayOPCodes.INVALID_SESSION: {
-                this.seq = 0;
-                this.sessionID = null;
-                this.resumeURL = null;
-                this.emit("warn", "Invalid session, reidentifying!", this.id);
-                this.identify();
+                if(!packet.d || !this.sessionID) {
+                    this.seq = 0;
+                    this.sessionID = null;
+                    this.resumeURL = null;
+                }
+                this.emit("warn", `Invalid session, ${this.sessionID ? "resuming" : "reidentifying"}!`, this.id);
+                this.disconnect({
+                    reconnect: "auto"
+                });
                 break;
             }
             case Constants.GatewayOPCodes.RECONNECT: {
@@ -1861,7 +1866,6 @@ class Shard extends EventEmitter {
                 this.connectTimeout = null;
                 this.status = "ready";
                 this.presence.status = "online";
-                this.client.shards._readyPacketCB(this.id);
 
                 if(packet.t === "RESUMED") {
                     // Can only heartbeat after resume succeeds, discord/discord-api-docs#1619

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -57,6 +57,7 @@ class Shard extends EventEmitter {
     #onWSOpen;
     #token;
     #zlibSync;
+    #awaitedGuildIDs = new Set();
     constructor(id, client) {
         super();
 
@@ -93,6 +94,7 @@ class Shard extends EventEmitter {
                  * @event Shard#ready
                  */
                 super.emit("ready");
+                this.#awaitedGuildIDs.clear();
             }
         }
     }
@@ -263,7 +265,10 @@ class Shard extends EventEmitter {
         this.connectAttempts = 0;
         this.ws = null;
         this.heartbeatInterval = null;
-        this.guildCreateTimeout = null;
+        if(this.guildCreateTimeout) {
+            clearTimeout(this.guildCreateTimeout);
+            this.guildCreateTimeout = null;
+        }
         this.globalBucket = new Bucket(120, 60000, {reservedTokens: 5});
         this.presenceUpdateBucket = new Bucket(5, 20000);
         this.presence = JSON.parse(JSON.stringify(this.client.presence)); // Fast copy
@@ -556,6 +561,7 @@ class Shard extends EventEmitter {
         this.connecting = false;
         this.ready = false;
         this.preReady = false;
+        this.#awaitedGuildIDs.clear();
         if(this.requestMembersPromise !== undefined) {
             for(const guildID in this.requestMembersPromise) {
                 if(!Object.hasOwn(this.requestMembersPromise, guildID)) {
@@ -586,7 +592,7 @@ class Shard extends EventEmitter {
             this.guildCreateTimeout = null;
         }
         if(!this.ready) {
-            if(this.client.unavailableGuilds.size === 0) {
+            if(this.#awaitedGuildIDs.size === 0) {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
@@ -1380,6 +1386,7 @@ class Shard extends EventEmitter {
                         }
                     } else {
                         this.client.unavailableGuilds.remove(packet.d);
+                        this.#awaitedGuildIDs.delete(packet.d.id);
                         this.restartGuildCreateTimeout();
                     }
                 } else {
@@ -1497,6 +1504,11 @@ class Shard extends EventEmitter {
                      * @prop {Guild} guild The guild
                      */
                     this.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
+
+                    if(!this.ready) {
+                        this.#awaitedGuildIDs.delete(packet.d.id);
+                        this.restartGuildCreateTimeout();
+                    }
                 } else {
                     /**
                      * Fired when a guild is deleted. This happens when:
@@ -1899,10 +1911,12 @@ class Shard extends EventEmitter {
 
                 this.sessionID = packet.d.session_id;
 
+                this.#awaitedGuildIDs.clear();
                 packet.d.guilds.forEach((guild) => {
                     if(guild.unavailable) {
                         this.client.guilds.remove(guild);
                         this.client.unavailableGuilds.add(guild, this.client, true);
+                        this.#awaitedGuildIDs.add(guild.id);
                     } else {
                         this.client.unavailableGuilds.remove(this.createGuild(guild));
                     }
@@ -1918,7 +1932,7 @@ class Shard extends EventEmitter {
                  */
                 this.emit("shardPreReady", this.id);
 
-                if(this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
+                if(this.#awaitedGuildIDs.size > 0 && packet.d.guilds.length > 0) {
                     this.restartGuildCreateTimeout();
                 } else {
                     this.checkReady();

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -597,6 +597,7 @@ class Shard extends EventEmitter {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
+                this.emit("warn", `Not all guilds were found from the READY event (${this.#awaitedGuildIDs.size} missing), continuing...`);
                 this.checkReady();
             }, this.client.shards.options.guildCreateTimeout);
         }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -51,13 +51,14 @@ try {
  * @extends EventEmitter
  */
 class Shard extends EventEmitter {
+    #awaitedGuildIDs = new Set();
     #onWSClose;
     #onWSError;
     #onWSMessage;
     #onWSOpen;
     #token;
     #zlibSync;
-    #awaitedGuildIDs = new Set();
+
     constructor(id, client) {
         super();
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1515,6 +1515,8 @@ class Shard extends EventEmitter {
                      */
                     this.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
                 } else {
+                    this.client.unavailableGuilds.remove(packet.d);
+
                     /**
                      * Fired when a guild is deleted. This happens when:
                      * - the client left the guild
@@ -1526,8 +1528,6 @@ class Shard extends EventEmitter {
                     this.emit("guildDelete", guild || {
                         id: packet.d.id
                     });
-
-                    this.client.unavailableGuilds.remove(packet.d);
                 }
                 break;
             }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -597,7 +597,7 @@ class Shard extends EventEmitter {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
-                this.emit("warn", `Not all guilds were found from the READY event (${this.#awaitedGuildIDs.size} missing), continuing...`);
+                this.emit("warn", `Not all guilds were found from the READY event (${this.#awaitedGuildIDs.size} missing), continuing...`, this.id);
                 this.checkReady();
             }, this.client.shards.options.guildCreateTimeout);
         }
@@ -1499,6 +1499,14 @@ class Shard extends EventEmitter {
                 guild?.channels.forEach((channel) => { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
                     delete this.client.channelGuildMap[channel.id];
                 });
+
+                // A delete event w/o unavailable may fire if the guild will eventually be deleted,
+                // so we just discard the guild completely here
+                if(!this.ready) {
+                    this.#awaitedGuildIDs.delete(packet.d.id);
+                    this.restartGuildCreateTimeout();
+                }
+
                 if(packet.d.unavailable) {
                     /**
                      * Fired when a guild becomes unavailable
@@ -1506,11 +1514,6 @@ class Shard extends EventEmitter {
                      * @prop {Guild} guild The guild
                      */
                     this.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
-
-                    if(!this.ready) {
-                        this.#awaitedGuildIDs.delete(packet.d.id);
-                        this.restartGuildCreateTimeout();
-                    }
                 } else {
                     /**
                      * Fired when a guild is deleted. This happens when:
@@ -1523,6 +1526,8 @@ class Shard extends EventEmitter {
                     this.emit("guildDelete", guild || {
                         id: packet.d.id
                     });
+
+                    this.client.unavailableGuilds.remove(packet.d);
                 }
                 break;
             }

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -160,26 +160,32 @@ class ShardManager extends Collection {
             return;
         }
 
+        let nextTry = Infinity;
+
         // loop over the connectQueue
-        for(const shard of this.connectQueue) {
-            // find the bucket for our shard
-            const rateLimitKey = (shard.id % this.options.maxConcurrency) || 0;
-            const lastConnect = this.buckets.get(rateLimitKey) || 0;
+        for(const shard of [...this.connectQueue]) {
+            // We are only rate-limiting shards that can't be resumed
+            if(!shard.sessionID) {
+                // find the bucket for our shard
+                const rateLimitKey = (shard.id % this.options.maxConcurrency) || 0;
+                const lastIdentify = this.buckets.get(rateLimitKey) || 0;
+                const wait = 5000 - (Date.now() - lastIdentify);
 
-            // has enough time passed since the last connect for this bucket (5s/bucket)?
-            // alternatively if we have a sessionID, we can skip this check
-            if(!shard.sessionID && Date.now() - lastConnect < 5000) {
-                continue;
-            }
+                // Has enough time passed since the last identify for this bucket (5s/bucket)?
+                if(wait > 0) {
+                    nextTry = Math.min(nextTry, wait);
+                    continue;
+                }
 
-            // Are there any connecting shards in the same bucket we should wait on?
-            if(this.some((s) => s.connecting && ((s.id % this.options.maxConcurrency) || 0) === rateLimitKey)) {
-                continue;
+                // Are there any connecting shards in the same bucket we should wait on?
+                if(this.some((s) => s.connecting && ((s.id % this.options.maxConcurrency) || 0) === rateLimitKey)) {
+                    nextTry = Math.min(nextTry, 250);
+                    continue;
+                }
             }
 
             // connect the shard
             shard.connect();
-            this.buckets.set(rateLimitKey, Date.now());
 
             // remove the shard from the queue
             const index = this.connectQueue.findIndex((s) => s.id === shard.id);
@@ -191,11 +197,11 @@ class ShardManager extends Collection {
             this.connectTimeout = setTimeout(() => {
                 this.connectTimeout = null;
                 this.tryConnect();
-            }, 500);
+            }, Number.isFinite(nextTry) ? Math.max(1, nextTry) : 500);
         }
     }
 
-    _readyPacketCB(shardID) {
+    _identifyPacketCB(shardID) {
         const rateLimitKey = (shardID % this.options.maxConcurrency) || 0;
         this.buckets.set(rateLimitKey, Date.now());
 

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -30,7 +30,7 @@ class ShardManager extends Collection {
             disableEvents:        {},
             firstShardID:         0,
             getAllUsers:          false,
-            guildCreateTimeout:   2000,
+            guildCreateTimeout:   500,
             intents:              Constants.Intents.allNonPrivileged,
             largeThreshold:       250,
             maxReconnectAttempts: Infinity,

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -30,7 +30,7 @@ class ShardManager extends Collection {
             disableEvents:        {},
             firstShardID:         0,
             getAllUsers:          false,
-            guildCreateTimeout:   500,
+            guildCreateTimeout:   1000,
             intents:              Constants.Intents.allNonPrivileged,
             largeThreshold:       250,
             maxReconnectAttempts: Infinity,


### PR DESCRIPTION
Some issues with the shard manager:
- The client was checking for a `shardConcurrency` option for some reason under `connect()`
- Shards wait until its ready then wait 5s before connecting another shard rather than waiting 5s after sending an identify packet
- The default create timeout being 2 seconds is, ehh, slow? There usually isnt such a large delay between these events
- Waiting for shards to be ready is bound by the client's unavailable guilds rather than it's own list of guilds to wait for

So this PR changes some things:
- Reworks the connection strategy, it will wait 5s after sending the identify packet before connecting another shard in it's bucket, the `connectTimeout` waits until the next best moment to check over shards again. Also it was just iterating the queue while it could be altered
- Shards now hold their own "awaited guilds" set for those IDs to be expected to come in before it is considered as ready
- `guildCreateTimeout`: 2 seconds -> 500 ms, this is subjective so feel free to change this if you feel that it's too small